### PR TITLE
feat: адаптивная разметка страницы с перетаскиваемыми сплиттерами

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -4,3 +4,4 @@
 # Timestamp: 2026-02-13T19:06:21.093Z
 # This file was created with --gitkeep-file flag
 # It will be removed when the task is complete
+# Updated: 2026-03-18T15:07:44.804Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -4,4 +4,3 @@
 # Timestamp: 2026-02-13T19:06:21.093Z
 # This file was created with --gitkeep-file flag
 # It will be removed when the task is complete
-# Updated: 2026-03-18T15:07:44.804Z

--- a/src/App.vue
+++ b/src/App.vue
@@ -33,6 +33,7 @@ import {
 import InteractiveProver from './components/InteractiveProver.vue'
 import ProofExport from './components/ProofExport.vue'
 import LinkGraphViewer from './components/LinkGraphViewer.vue'
+import SplitPane from './components/SplitPane.vue'
 import type { ASTNode } from './core/ast'
 import type { ProverState, ProofStep } from './core/prover'
 
@@ -98,6 +99,13 @@ const interactiveGoals = ref<ASTNode[]>([])
 
 // Application version from package.json (injected by Vite at build time)
 const appVersion = __APP_VERSION__
+
+const splitPaneRef = ref<InstanceType<typeof SplitPane> | null>(null)
+
+const handleSplitResize = () => {
+  // Dispatch a resize event so components like Cytoscape can update
+  window.dispatchEvent(new Event('resize'))
+}
 
 const toggleAST = () => {
   showAST.value = !showAST.value
@@ -634,43 +642,160 @@ onUnmounted(() => {
       </div>
     </div>
 
-    <main
-      class="app-main"
-      :class="{
-        'with-ast': showAST,
-        'with-graph': showGraph,
-        'with-ast-and-graph': showAST && showGraph,
-      }"
-    >
-      <div class="panel editor-panel">
-        <Editor
-          v-model="input"
-          :highlighted-loc="highlightedLoc"
-          :error-loc="errorLocation"
-          :file-name="currentFileName || undefined"
-          :is-drag-over="isDragOver"
-          @file-drop="handleFileDrop"
-          @cursor-position="handleCursorPosition"
-        />
-      </div>
+    <main class="app-main">
+      <!-- Layout: Editor + AST + Graph + Results (all panels visible) -->
+      <SplitPane
+        v-if="showAST && showGraph"
+        key="ast-graph"
+        ref="splitPaneRef"
+        direction="horizontal"
+        :min-size="150"
+        :initial-sizes="[25, 25, 25, 25]"
+        @resize="handleSplitResize"
+      >
+        <template #pane-0>
+          <div class="panel editor-panel">
+            <Editor
+              v-model="input"
+              :highlighted-loc="highlightedLoc"
+              :error-loc="errorLocation"
+              :file-name="currentFileName || undefined"
+              :is-drag-over="isDragOver"
+              @file-drop="handleFileDrop"
+              @cursor-position="handleCursorPosition"
+            />
+          </div>
+        </template>
+        <template #pane-1>
+          <div class="panel ast-panel">
+            <ASTViewer
+              :ast="ast"
+              :error="error"
+              :highlighted-node-loc="highlightedNodeLoc"
+              @node-hover="handleNodeHover"
+            />
+          </div>
+        </template>
+        <template #pane-2>
+          <div class="panel graph-panel">
+            <LinkGraphViewer :ast="ast" />
+          </div>
+        </template>
+        <template #pane-3>
+          <div class="panel results-panel">
+            <ErrorPanel :error="error" />
+            <ProverPanel :results="results" :has-error="!!error" />
+          </div>
+        </template>
+      </SplitPane>
 
-      <div v-if="showAST" class="panel ast-panel">
-        <ASTViewer
-          :ast="ast"
-          :error="error"
-          :highlighted-node-loc="highlightedNodeLoc"
-          @node-hover="handleNodeHover"
-        />
-      </div>
+      <!-- Layout: Editor + AST + Results -->
+      <SplitPane
+        v-else-if="showAST"
+        key="ast-only"
+        ref="splitPaneRef"
+        direction="horizontal"
+        :min-size="150"
+        :initial-sizes="[35, 30, 35]"
+        @resize="handleSplitResize"
+      >
+        <template #pane-0>
+          <div class="panel editor-panel">
+            <Editor
+              v-model="input"
+              :highlighted-loc="highlightedLoc"
+              :error-loc="errorLocation"
+              :file-name="currentFileName || undefined"
+              :is-drag-over="isDragOver"
+              @file-drop="handleFileDrop"
+              @cursor-position="handleCursorPosition"
+            />
+          </div>
+        </template>
+        <template #pane-1>
+          <div class="panel ast-panel">
+            <ASTViewer
+              :ast="ast"
+              :error="error"
+              :highlighted-node-loc="highlightedNodeLoc"
+              @node-hover="handleNodeHover"
+            />
+          </div>
+        </template>
+        <template #pane-2>
+          <div class="panel results-panel">
+            <ErrorPanel :error="error" />
+            <ProverPanel :results="results" :has-error="!!error" />
+          </div>
+        </template>
+      </SplitPane>
 
-      <div v-if="showGraph" class="panel graph-panel">
-        <LinkGraphViewer :ast="ast" />
-      </div>
+      <!-- Layout: Editor + Graph + Results -->
+      <SplitPane
+        v-else-if="showGraph"
+        key="graph-only"
+        ref="splitPaneRef"
+        direction="horizontal"
+        :min-size="150"
+        :initial-sizes="[35, 30, 35]"
+        @resize="handleSplitResize"
+      >
+        <template #pane-0>
+          <div class="panel editor-panel">
+            <Editor
+              v-model="input"
+              :highlighted-loc="highlightedLoc"
+              :error-loc="errorLocation"
+              :file-name="currentFileName || undefined"
+              :is-drag-over="isDragOver"
+              @file-drop="handleFileDrop"
+              @cursor-position="handleCursorPosition"
+            />
+          </div>
+        </template>
+        <template #pane-1>
+          <div class="panel graph-panel">
+            <LinkGraphViewer :ast="ast" />
+          </div>
+        </template>
+        <template #pane-2>
+          <div class="panel results-panel">
+            <ErrorPanel :error="error" />
+            <ProverPanel :results="results" :has-error="!!error" />
+          </div>
+        </template>
+      </SplitPane>
 
-      <div class="panel results-panel">
-        <ErrorPanel :error="error" />
-        <ProverPanel :results="results" :has-error="!!error" />
-      </div>
+      <!-- Layout: Editor + Results (no optional panels) -->
+      <SplitPane
+        v-else
+        key="basic"
+        ref="splitPaneRef"
+        direction="horizontal"
+        :min-size="150"
+        :initial-sizes="[50, 50]"
+        @resize="handleSplitResize"
+      >
+        <template #pane-0>
+          <div class="panel editor-panel">
+            <Editor
+              v-model="input"
+              :highlighted-loc="highlightedLoc"
+              :error-loc="errorLocation"
+              :file-name="currentFileName || undefined"
+              :is-drag-over="isDragOver"
+              @file-drop="handleFileDrop"
+              @cursor-position="handleCursorPosition"
+            />
+          </div>
+        </template>
+        <template #pane-1>
+          <div class="panel results-panel">
+            <ErrorPanel :error="error" />
+            <ProverPanel :results="results" :has-error="!!error" />
+          </div>
+        </template>
+      </SplitPane>
     </main>
 
     <footer class="app-footer">
@@ -713,10 +838,10 @@ body {
 .app-container {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  max-width: 1800px;
-  margin: 0 auto;
+  height: 100vh;
+  width: 100%;
   padding: 0.5rem;
+  overflow: hidden;
 }
 
 .app-header {
@@ -978,73 +1103,14 @@ body {
 }
 
 .app-main {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.5rem;
+  display: flex;
+  gap: 0;
   flex: 1;
   min-height: 0;
-}
-
-.app-main.with-ast {
-  grid-template-columns: 1fr 1fr 1fr;
-}
-
-.app-main.with-graph {
-  grid-template-columns: 1fr 1fr 1fr;
-}
-
-.app-main.with-ast-and-graph {
-  grid-template-columns: 1fr 1fr 1fr 1fr;
-}
-
-@media (max-width: 1200px) {
-  .app-main.with-ast {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .app-main.with-ast .ast-panel {
-    grid-column: span 2;
-    max-height: 300px;
-  }
-
-  .app-main.with-graph {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .app-main.with-graph .graph-panel {
-    grid-column: span 2;
-    max-height: 400px;
-  }
-
-  .app-main.with-ast-and-graph {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .app-main.with-ast-and-graph .ast-panel,
-  .app-main.with-ast-and-graph .graph-panel {
-    max-height: 300px;
-  }
+  overflow: hidden;
 }
 
 @media (max-width: 768px) {
-  .app-main,
-  .app-main.with-ast,
-  .app-main.with-graph,
-  .app-main.with-ast-and-graph {
-    grid-template-columns: 1fr;
-  }
-
-  .app-main.with-ast .ast-panel,
-  .app-main.with-graph .graph-panel,
-  .app-main.with-ast-and-graph .ast-panel,
-  .app-main.with-ast-and-graph .graph-panel {
-    grid-column: span 1;
-  }
-
-  .panel {
-    max-height: 400px;
-  }
-
   .app-header {
     flex-wrap: wrap;
     gap: 0.5rem;
@@ -1064,7 +1130,9 @@ body {
   display: flex;
   flex-direction: column;
   border: 1px solid var(--border-color);
-  min-height: 400px;
+  min-width: 0;
+  width: 100%;
+  height: 100%;
 }
 
 .app-footer {

--- a/src/components/LinkGraphViewer.vue
+++ b/src/components/LinkGraphViewer.vue
@@ -349,11 +349,31 @@ watch(
 // Watch layout changes
 watch(selectedLayout, handleLayoutChange)
 
+// ResizeObserver to re-fit graph when container size changes
+const resizeObserver = ref<ResizeObserver | null>(null)
+
 onMounted(() => {
-  nextTick(() => renderGraph())
+  nextTick(() => {
+    renderGraph()
+
+    // Watch for container resize and re-fit graph
+    if (containerRef.value) {
+      resizeObserver.value = new ResizeObserver(() => {
+        if (cyInstance.value) {
+          cyInstance.value.resize()
+          cyInstance.value.fit(undefined, 30)
+        }
+      })
+      resizeObserver.value.observe(containerRef.value)
+    }
+  })
 })
 
 onUnmounted(() => {
+  if (resizeObserver.value) {
+    resizeObserver.value.disconnect()
+    resizeObserver.value = null
+  }
   if (cyInstance.value) {
     cyInstance.value.destroy()
     cyInstance.value = null

--- a/src/components/SplitPane.vue
+++ b/src/components/SplitPane.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, watch, nextTick } from 'vue'
+import { ref, onMounted, onUnmounted, useSlots } from 'vue'
 
 const props = withDefaults(
   defineProps<{
@@ -21,31 +21,34 @@ const emit = defineEmits<{
   (e: 'resize'): void
 }>()
 
+const slots = useSlots()
 const containerRef = ref<HTMLElement | null>(null)
-const sizes = ref<number[]>([])
 const dragging = ref<number | null>(null)
 const startPos = ref(0)
 const startSizes = ref<number[]>([])
 
-function initSizes(slotCount: number) {
-  if (props.initialSizes && props.initialSizes.length === slotCount) {
-    sizes.value = [...props.initialSizes]
-  } else {
-    const equalSize = 100 / slotCount
-    sizes.value = Array(slotCount).fill(equalSize)
-  }
-}
-
 function getPaneCount(): number {
-  if (!containerRef.value) return 0
   let count = 0
-  const children = containerRef.value.children
-  for (let i = 0; i < children.length; i++) {
-    if (children[i].classList.contains('split-pane')) {
-      count++
-    }
+  while (slots[`pane-${count}`]) {
+    count++
   }
   return count
+}
+
+const paneCount = getPaneCount()
+
+function computeInitialSizes(count: number): number[] {
+  if (props.initialSizes && props.initialSizes.length === count) {
+    return [...props.initialSizes]
+  }
+  const equalSize = 100 / count
+  return Array(count).fill(equalSize)
+}
+
+const sizes = ref<number[]>(computeInitialSizes(paneCount))
+
+function initSizes(slotCount: number) {
+  sizes.value = computeInitialSizes(slotCount)
 }
 
 function onMouseDown(index: number, e: MouseEvent) {
@@ -150,25 +153,12 @@ function onTouchEnd() {
   document.removeEventListener('touchend', onTouchEnd)
 }
 
-watch(
-  () => sizes.value.length,
-  () => {
-    nextTick(() => {
-      const count = getPaneCount()
-      if (count > 0 && count !== sizes.value.length) {
-        initSizes(count)
-      }
-    })
-  }
-)
-
 onMounted(() => {
-  nextTick(() => {
-    const count = getPaneCount()
-    if (count > 0) {
-      initSizes(count)
-    }
-  })
+  // Re-check pane count in case slots changed
+  const count = getPaneCount()
+  if (count > 0 && count !== sizes.value.length) {
+    initSizes(count)
+  }
 })
 
 onUnmounted(() => {

--- a/src/components/SplitPane.vue
+++ b/src/components/SplitPane.vue
@@ -1,0 +1,280 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted, watch, nextTick } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    /** Direction of the split */
+    direction?: 'horizontal' | 'vertical'
+    /** Minimum size of each pane in pixels */
+    minSize?: number
+    /** Initial sizes as percentages (must sum to 100 per pair) */
+    initialSizes?: number[]
+  }>(),
+  {
+    direction: 'horizontal',
+    minSize: 100,
+    initialSizes: () => [],
+  }
+)
+
+const emit = defineEmits<{
+  (e: 'resize'): void
+}>()
+
+const containerRef = ref<HTMLElement | null>(null)
+const sizes = ref<number[]>([])
+const dragging = ref<number | null>(null)
+const startPos = ref(0)
+const startSizes = ref<number[]>([])
+
+function initSizes(slotCount: number) {
+  if (props.initialSizes && props.initialSizes.length === slotCount) {
+    sizes.value = [...props.initialSizes]
+  } else {
+    const equalSize = 100 / slotCount
+    sizes.value = Array(slotCount).fill(equalSize)
+  }
+}
+
+function getPaneCount(): number {
+  if (!containerRef.value) return 0
+  let count = 0
+  const children = containerRef.value.children
+  for (let i = 0; i < children.length; i++) {
+    if (children[i].classList.contains('split-pane')) {
+      count++
+    }
+  }
+  return count
+}
+
+function onMouseDown(index: number, e: MouseEvent) {
+  e.preventDefault()
+  dragging.value = index
+  startPos.value = props.direction === 'horizontal' ? e.clientX : e.clientY
+  startSizes.value = [...sizes.value]
+  document.addEventListener('mousemove', onMouseMove)
+  document.addEventListener('mouseup', onMouseUp)
+  document.body.style.cursor = props.direction === 'horizontal' ? 'col-resize' : 'row-resize'
+  document.body.style.userSelect = 'none'
+}
+
+function onMouseMove(e: MouseEvent) {
+  if (dragging.value === null || !containerRef.value) return
+
+  const idx = dragging.value
+  const containerRect = containerRef.value.getBoundingClientRect()
+  const containerSize =
+    props.direction === 'horizontal' ? containerRect.width : containerRect.height
+  const currentPos = props.direction === 'horizontal' ? e.clientX : e.clientY
+  const diff = currentPos - startPos.value
+  const diffPercent = (diff / containerSize) * 100
+
+  const newSizes = [...startSizes.value]
+  const minPercent = (props.minSize / containerSize) * 100
+
+  let newLeft = newSizes[idx] + diffPercent
+  let newRight = newSizes[idx + 1] - diffPercent
+
+  if (newLeft < minPercent) {
+    newLeft = minPercent
+    newRight = startSizes.value[idx] + startSizes.value[idx + 1] - minPercent
+  }
+  if (newRight < minPercent) {
+    newRight = minPercent
+    newLeft = startSizes.value[idx] + startSizes.value[idx + 1] - minPercent
+  }
+
+  newSizes[idx] = newLeft
+  newSizes[idx + 1] = newRight
+  sizes.value = newSizes
+  emit('resize')
+}
+
+function onMouseUp() {
+  dragging.value = null
+  document.removeEventListener('mousemove', onMouseMove)
+  document.removeEventListener('mouseup', onMouseUp)
+  document.body.style.cursor = ''
+  document.body.style.userSelect = ''
+}
+
+function onTouchStart(index: number, e: TouchEvent) {
+  if (e.touches.length !== 1) return
+  e.preventDefault()
+  dragging.value = index
+  const touch = e.touches[0]
+  startPos.value = props.direction === 'horizontal' ? touch.clientX : touch.clientY
+  startSizes.value = [...sizes.value]
+  document.addEventListener('touchmove', onTouchMove, { passive: false })
+  document.addEventListener('touchend', onTouchEnd)
+}
+
+function onTouchMove(e: TouchEvent) {
+  if (dragging.value === null || !containerRef.value || e.touches.length !== 1) return
+  e.preventDefault()
+
+  const idx = dragging.value
+  const containerRect = containerRef.value.getBoundingClientRect()
+  const containerSize =
+    props.direction === 'horizontal' ? containerRect.width : containerRect.height
+  const touch = e.touches[0]
+  const currentPos = props.direction === 'horizontal' ? touch.clientX : touch.clientY
+  const diff = currentPos - startPos.value
+  const diffPercent = (diff / containerSize) * 100
+
+  const newSizes = [...startSizes.value]
+  const minPercent = (props.minSize / containerSize) * 100
+
+  let newLeft = newSizes[idx] + diffPercent
+  let newRight = newSizes[idx + 1] - diffPercent
+
+  if (newLeft < minPercent) {
+    newLeft = minPercent
+    newRight = startSizes.value[idx] + startSizes.value[idx + 1] - minPercent
+  }
+  if (newRight < minPercent) {
+    newRight = minPercent
+    newLeft = startSizes.value[idx] + startSizes.value[idx + 1] - minPercent
+  }
+
+  newSizes[idx] = newLeft
+  newSizes[idx + 1] = newRight
+  sizes.value = newSizes
+  emit('resize')
+}
+
+function onTouchEnd() {
+  dragging.value = null
+  document.removeEventListener('touchmove', onTouchMove)
+  document.removeEventListener('touchend', onTouchEnd)
+}
+
+watch(
+  () => sizes.value.length,
+  () => {
+    nextTick(() => {
+      const count = getPaneCount()
+      if (count > 0 && count !== sizes.value.length) {
+        initSizes(count)
+      }
+    })
+  }
+)
+
+onMounted(() => {
+  nextTick(() => {
+    const count = getPaneCount()
+    if (count > 0) {
+      initSizes(count)
+    }
+  })
+})
+
+onUnmounted(() => {
+  document.removeEventListener('mousemove', onMouseMove)
+  document.removeEventListener('mouseup', onMouseUp)
+  document.removeEventListener('touchmove', onTouchMove)
+  document.removeEventListener('touchend', onTouchEnd)
+})
+
+defineExpose({ sizes, initSizes })
+</script>
+
+<template>
+  <div
+    ref="containerRef"
+    class="split-container"
+    :class="[direction, { dragging: dragging !== null }]"
+  >
+    <template v-for="(size, index) in sizes" :key="'pane-' + index">
+      <div
+        class="split-pane"
+        :style="{
+          [direction === 'horizontal' ? 'width' : 'height']: size + '%',
+        }"
+      >
+        <slot :name="'pane-' + index" :size="size" :index="index" />
+      </div>
+      <div
+        v-if="index < sizes.length - 1"
+        class="split-gutter"
+        :class="direction"
+        @mousedown="onMouseDown(index, $event)"
+        @touchstart="onTouchStart(index, $event)"
+      >
+        <div class="gutter-handle" />
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.split-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.split-container.horizontal {
+  flex-direction: row;
+}
+
+.split-container.vertical {
+  flex-direction: column;
+}
+
+.split-pane {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+.split-gutter {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  transition: background-color 0.15s;
+}
+
+.split-gutter.horizontal {
+  width: 6px;
+  cursor: col-resize;
+}
+
+.split-gutter.vertical {
+  height: 6px;
+  cursor: row-resize;
+}
+
+.split-gutter:hover,
+.split-container.dragging .split-gutter {
+  background-color: rgba(102, 126, 234, 0.3);
+}
+
+.gutter-handle {
+  border-radius: 2px;
+  background-color: #475569;
+  transition: background-color 0.15s;
+}
+
+.split-gutter.horizontal .gutter-handle {
+  width: 2px;
+  height: 32px;
+}
+
+.split-gutter.vertical .gutter-handle {
+  width: 32px;
+  height: 2px;
+}
+
+.split-gutter:hover .gutter-handle,
+.split-container.dragging .gutter-handle {
+  background-color: #667eea;
+}
+</style>

--- a/src/style.css
+++ b/src/style.css
@@ -25,7 +25,6 @@ a:hover {
 body {
   margin: 0;
   display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
@@ -59,10 +58,8 @@ button:focus-visible {
 }
 
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  width: 100%;
+  min-height: 100vh;
 }
 
 @media (prefers-color-scheme: light) {


### PR DESCRIPTION
## Summary

Fixes #104 — Адаптивная разметка страницы

### Проблемы и решения

1. **Панели не занимали всё пространство страницы**
   - Убрано ограничение `max-width: 1800px` на контейнере приложения
   - Убрано `max-width: 1280px` и центрирование на `#app`
   - Контейнер теперь занимает `100vh` по высоте и `100%` по ширине

2. **Адаптивная разметка**
   - Заменена статическая CSS Grid разметка на динамическую flex-разметку
   - Панели автоматически перераспределяют пространство при включении/выключении AST и графа
   - 4 варианта компоновки: Editor+Results, Editor+AST+Results, Editor+Graph+Results, Editor+AST+Graph+Results

3. **Сплиттеры для ресайза**
   - Добавлен новый компонент `SplitPane.vue` — перетаскиваемые разделители панелей
   - Поддержка мыши и тач-устройств
   - Визуальная обратная связь при наведении и перетаскивании
   - Минимальный размер панели 150px

4. **Граф обрезал половину содержимого**
   - Добавлен `ResizeObserver` на контейнер графа
   - При изменении размера панели граф автоматически вызывает `resize()` + `fit()` через Cytoscape API

### Тестирование
- Все 520 unit-тестов проходят
- TypeScript type-check проходит без ошибок
- ESLint: 0 ошибок (только pre-existing warnings)
- Vite build проходит успешно

## Test plan
- [ ] Открыть приложение — панели должны занимать всю страницу
- [ ] Перетащить сплиттер между панелями — размер должен меняться
- [ ] Включить/выключить AST и Graph — панели должны перераспределяться
- [ ] Включить Graph — граф не должен обрезаться
- [ ] Проверить на мобильном/тач-устройстве

🤖 Generated with [Claude Code](https://claude.com/claude-code)