### PR TITLE
Сделать визуальный граф occurrence-safe: label больше не identity

### DIFF
--- a/src/core/linkGraph.ts
+++ b/src/core/linkGraph.ts
@@ -1,15 +1,10 @@
 /**
- * Link graph projection module for МТС (Meta-Theory of Links)
+ * Occurrence-preserving link graph projection for МТС.
  *
- * Projects link formulas (association networks) into directed graphs:
- * 1. The center of a link is a graph node
- * 2. The start of a link is an edge with a cross (+)
- * 3. The end of a link is an edge with an arrow (->)
- * 4. Self-closing links loop back to the central node
- *
- * Visual representation of a link `a -> b`:
- *   a *+--*-->* b
- * Where the middle * is the center node of the link `ab`.
+ * IMPORTANT: display labels are presentation only. Two AST occurrences with the
+ * same label remain two graph nodes unless a future canonical runtime explicitly
+ * supplies the same LinkRef/OccurrenceId. This is required for anonymous forms
+ * and contextual interpretation in anum_docs v0.2.
  */
 
 import type { ASTNode } from './ast'
@@ -33,88 +28,88 @@ import {
 import { astToString } from './ast'
 import { escapeLabel } from './utils'
 
-/**
- * Node type in the link graph
- */
 export type LinkGraphNodeType =
-  | 'link-center' // Center of a link (connection node)
-  | 'atom' // Atomic element (identifier, number, infinity, etc.)
-  | 'operator' // Binary operator (=, !=, :)
-  | 'unary' // Unary operator (!, ♂, ♀)
-  | 'set' // Set expression
-  | 'power' // Power expression
+  | 'link-center'
+  | 'atom'
+  | 'operator'
+  | 'unary'
+  | 'set'
+  | 'power'
 
-/**
- * A node in the link graph
- */
 export interface LinkGraphNode {
-  /** Unique node identifier */
+  /** Unique graph-occurrence identifier. Never derived from the display label. */
   id: string
-  /** Display label */
   label: string
-  /** Node type for styling */
   nodeType: LinkGraphNodeType
-  /** Original AST node reference */
   astNode?: ASTNode
 }
 
-/**
- * Edge type in the link graph
- */
 export type LinkGraphEdgeType =
-  | 'link-start' // Start of link: edge with cross (+)
-  | 'link-end' // End of link: edge with arrow (->)
-  | 'self-start' // Self-closing start (♂x loops back)
-  | 'self-end' // Self-closing end (x♀ loops back)
-  | 'relation' // Structural relation (=, !=, :)
-  | 'member' // Set membership
+  | 'link-start'
+  | 'link-end'
+  | 'self-start'
+  | 'self-end'
+  | 'relation'
+  | 'member'
 
-/**
- * An edge in the link graph
- */
 export interface LinkGraphEdge {
-  /** Unique edge identifier */
   id: string
-  /** Source node ID */
   source: string
-  /** Target node ID */
   target: string
-  /** Edge type for styling */
   edgeType: LinkGraphEdgeType
-  /** Display label */
   label?: string
 }
 
-/**
- * Complete link graph representation
- */
 export interface LinkGraph {
-  /** All nodes */
   nodes: LinkGraphNode[]
-  /** All edges */
   edges: LinkGraphEdge[]
 }
 
-/**
- * Internal state for graph construction
- */
 interface GraphBuilderState {
   nodes: Map<string, LinkGraphNode>
   edges: LinkGraphEdge[]
   nodeCounter: number
+  edgeCounter: number
 }
 
-/**
- * Generate a unique node ID
- */
 function nextNodeId(state: GraphBuilderState, prefix: string): string {
-  state.nodeCounter++
+  state.nodeCounter += 1
   return `${prefix}_${state.nodeCounter}`
 }
 
-/**
- * Get a short label for an AST node (for display in graph)
- */
+function nextEdgeId(state: GraphBuilderState): string {
+  state.edgeCounter += 1
+  return `edge_${state.edgeCounter}`
+}
+
+function createNode(
+  state: GraphBuilderState,
+  prefix: string,
+  label: string,
+  nodeType: LinkGraphNodeType,
+  astNode: ASTNode
+): string {
+  const id = nextNodeId(state, prefix)
+  state.nodes.set(id, { id, label, nodeType, astNode })
+  return id
+}
+
+function addEdge(
+  state: GraphBuilderState,
+  source: string,
+  target: string,
+  edgeType: LinkGraphEdgeType,
+  label?: string
+): void {
+  state.edges.push({
+    id: nextEdgeId(state),
+    source,
+    target,
+    edgeType,
+    ...(label === undefined ? {} : { label }),
+  })
+}
+
 function getNodeLabel(node: ASTNode): string {
   if (isIdentExpr(node)) return node.name
   if (isInfinityExpr(node)) return '∞'
@@ -126,346 +121,148 @@ function getNodeLabel(node: ASTNode): string {
 }
 
 /**
- * Project an AST node into the link graph.
- * Returns the ID of the node representing this expression in the graph.
+ * Project one AST occurrence. Every recursive call creates graph identity for
+ * that occurrence; equal labels are intentionally NOT interned.
  */
 function projectNode(node: ASTNode, state: GraphBuilderState): string {
-  // Link expression: a -> b
-  // This is the core projection:
-  //   - Create a center node for the link
-  //   - Project left and right sub-expressions
-  //   - Add edge from left to center (link-start, with +)
-  //   - Add edge from center to right (link-end, with ->)
   if (isLinkExpr(node)) {
-    const centerId = nextNodeId(state, 'link')
+    const centerId = createNode(state, 'link', '', 'link-center', node)
     const leftId = projectNode(node.left, state)
     const rightId = projectNode(node.right, state)
 
-    state.nodes.set(centerId, {
-      id: centerId,
-      label: '',
-      nodeType: 'link-center',
-      astNode: node,
-    })
-
-    state.edges.push({
-      id: `e_${leftId}_${centerId}`,
-      source: leftId,
-      target: centerId,
-      edgeType: 'link-start',
-      label: '+',
-    })
-
-    state.edges.push({
-      id: `e_${centerId}_${rightId}`,
-      source: centerId,
-      target: rightId,
-      edgeType: 'link-end',
-    })
-
+    addEdge(state, leftId, centerId, 'link-start', '+')
+    addEdge(state, centerId, rightId, 'link-end')
     return centerId
   }
 
-  // Male self-closing: ♂x
-  // ♂x : (♂x -> x) — start self-closes to x
-  // The center node IS ♂x, with a self-loop for the start
   if (isMaleExpr(node)) {
-    const centerId = nextNodeId(state, 'male')
+    const centerId = createNode(
+      state,
+      'male',
+      `♂${getNodeLabel(node.operand)}`,
+      'unary',
+      node
+    )
     const operandId = projectNode(node.operand, state)
 
-    state.nodes.set(centerId, {
-      id: centerId,
-      label: `♂${getNodeLabel(node.operand)}`,
-      nodeType: 'unary',
-      astNode: node,
-    })
-
-    // Self-closing start: loop from center back to center
-    state.edges.push({
-      id: `e_${centerId}_self_start`,
-      source: centerId,
-      target: centerId,
-      edgeType: 'self-start',
-      label: '+',
-    })
-
-    // End goes to the operand
-    state.edges.push({
-      id: `e_${centerId}_${operandId}`,
-      source: centerId,
-      target: operandId,
-      edgeType: 'link-end',
-    })
-
+    addEdge(state, centerId, centerId, 'self-start', '+')
+    addEdge(state, centerId, operandId, 'link-end')
     return centerId
   }
 
-  // Female self-closing: x♀
-  // x♀ : (x -> x♀) — end self-closes to x
   if (isFemaleExpr(node)) {
-    const centerId = nextNodeId(state, 'female')
+    const centerId = createNode(
+      state,
+      'female',
+      `${getNodeLabel(node.operand)}♀`,
+      'unary',
+      node
+    )
     const operandId = projectNode(node.operand, state)
 
-    state.nodes.set(centerId, {
-      id: centerId,
-      label: `${getNodeLabel(node.operand)}♀`,
-      nodeType: 'unary',
-      astNode: node,
-    })
-
-    // Start from the operand
-    state.edges.push({
-      id: `e_${operandId}_${centerId}`,
-      source: operandId,
-      target: centerId,
-      edgeType: 'link-start',
-      label: '+',
-    })
-
-    // Self-closing end: loop from center back to center
-    state.edges.push({
-      id: `e_${centerId}_self_end`,
-      source: centerId,
-      target: centerId,
-      edgeType: 'self-end',
-    })
-
+    addEdge(state, operandId, centerId, 'link-start', '+')
+    addEdge(state, centerId, centerId, 'self-end')
     return centerId
   }
 
-  // Not expression: !x
   if (isNotExpr(node)) {
-    const centerId = nextNodeId(state, 'not')
+    const centerId = createNode(
+      state,
+      'not',
+      `!${getNodeLabel(node.operand)}`,
+      'unary',
+      node
+    )
     const operandId = projectNode(node.operand, state)
-
-    state.nodes.set(centerId, {
-      id: centerId,
-      label: `!${getNodeLabel(node.operand)}`,
-      nodeType: 'unary',
-      astNode: node,
-    })
-
-    state.edges.push({
-      id: `e_${operandId}_${centerId}_inv`,
-      source: operandId,
-      target: centerId,
-      edgeType: 'relation',
-      label: '!',
-    })
-
+    addEdge(state, operandId, centerId, 'relation', '!')
     return centerId
   }
 
-  // Definition: s : F
   if (isDefExpr(node)) {
-    const centerId = nextNodeId(state, 'def')
+    const centerId = createNode(state, 'def', ':', 'operator', node)
     const nameId = projectNode(node.name, state)
     const formId = projectNode(node.form, state)
 
-    state.nodes.set(centerId, {
-      id: centerId,
-      label: ':',
-      nodeType: 'operator',
-      astNode: node,
-    })
-
-    state.edges.push({
-      id: `e_${nameId}_${centerId}`,
-      source: nameId,
-      target: centerId,
-      edgeType: 'relation',
-      label: 'имя',
-    })
-
-    state.edges.push({
-      id: `e_${centerId}_${formId}`,
-      source: centerId,
-      target: formId,
-      edgeType: 'relation',
-      label: 'форма',
-    })
-
+    addEdge(state, nameId, centerId, 'relation', 'имя')
+    addEdge(state, centerId, formId, 'relation', 'форма')
     return centerId
   }
 
-  // Equality: A = B
   if (isEqExpr(node)) {
-    const centerId = nextNodeId(state, 'eq')
+    const centerId = createNode(state, 'eq', '=', 'operator', node)
     const leftId = projectNode(node.left, state)
     const rightId = projectNode(node.right, state)
 
-    state.nodes.set(centerId, {
-      id: centerId,
-      label: '=',
-      nodeType: 'operator',
-      astNode: node,
-    })
-
-    state.edges.push({
-      id: `e_${leftId}_${centerId}`,
-      source: leftId,
-      target: centerId,
-      edgeType: 'relation',
-    })
-
-    state.edges.push({
-      id: `e_${centerId}_${rightId}`,
-      source: centerId,
-      target: rightId,
-      edgeType: 'relation',
-    })
-
+    addEdge(state, leftId, centerId, 'relation')
+    addEdge(state, centerId, rightId, 'relation')
     return centerId
   }
 
-  // Inequality: A != B
   if (isNeqExpr(node)) {
-    const centerId = nextNodeId(state, 'neq')
+    const centerId = createNode(state, 'neq', '!=', 'operator', node)
     const leftId = projectNode(node.left, state)
     const rightId = projectNode(node.right, state)
 
-    state.nodes.set(centerId, {
-      id: centerId,
-      label: '!=',
-      nodeType: 'operator',
-      astNode: node,
-    })
-
-    state.edges.push({
-      id: `e_${leftId}_${centerId}`,
-      source: leftId,
-      target: centerId,
-      edgeType: 'relation',
-    })
-
-    state.edges.push({
-      id: `e_${centerId}_${rightId}`,
-      source: centerId,
-      target: rightId,
-      edgeType: 'relation',
-    })
-
+    addEdge(state, leftId, centerId, 'relation')
+    addEdge(state, centerId, rightId, 'relation')
     return centerId
   }
 
-  // Power expression: a^n — expand as repeated links
   if (isPowerExpr(node)) {
-    const centerId = nextNodeId(state, 'pow')
+    const centerId = createNode(
+      state,
+      'pow',
+      `^${node.exponent}`,
+      'power',
+      node
+    )
     const baseId = projectNode(node.base, state)
-
-    state.nodes.set(centerId, {
-      id: centerId,
-      label: `^${node.exponent}`,
-      nodeType: 'power',
-      astNode: node,
-    })
-
-    state.edges.push({
-      id: `e_${baseId}_${centerId}`,
-      source: baseId,
-      target: centerId,
-      edgeType: 'relation',
-      label: `^${node.exponent}`,
-    })
-
+    addEdge(state, baseId, centerId, 'relation', `^${node.exponent}`)
     return centerId
   }
 
-  // Set expression: {A, B, C}
   if (isSetExpr(node)) {
-    const centerId = nextNodeId(state, 'set')
-
-    state.nodes.set(centerId, {
-      id: centerId,
-      label: '{…}',
-      nodeType: 'set',
-      astNode: node,
-    })
-
+    const centerId = createNode(state, 'set', '{…}', 'set', node)
     for (const element of node.elements) {
       const elementId = projectNode(element, state)
-      state.edges.push({
-        id: `e_${centerId}_${elementId}_member`,
-        source: centerId,
-        target: elementId,
-        edgeType: 'member',
-      })
+      addEdge(state, centerId, elementId, 'member')
     }
-
     return centerId
   }
 
-  // Atomic expressions: identifiers, numbers, infinity, literals, brackets
-  const label = getNodeLabel(node)
-
-  // Reuse existing atom nodes with the same label
-  for (const [existingId, existingNode] of state.nodes) {
-    if (existingNode.nodeType === 'atom' && existingNode.label === label) {
-      return existingId
-    }
-  }
-
-  const atomId = nextNodeId(state, 'atom')
-  state.nodes.set(atomId, {
-    id: atomId,
-    label,
-    nodeType: 'atom',
-    astNode: node,
-  })
-
-  return atomId
+  // Atomic AST nodes are occurrences, not interned symbols. A future runtime
+  // adapter may explicitly merge graph nodes by canonical LinkRef, but display
+  // text alone is never sufficient identity.
+  return createNode(state, 'atom', getNodeLabel(node), 'atom', node)
 }
 
-/**
- * Project an AST node (typically a statement expression) into a link graph.
- *
- * @param node - The AST node to project
- * @returns The link graph representation
- */
+function newState(): GraphBuilderState {
+  return {
+    nodes: new Map(),
+    edges: [],
+    nodeCounter: 0,
+    edgeCounter: 0,
+  }
+}
+
 export function projectToGraph(node: ASTNode): LinkGraph {
-  const state: GraphBuilderState = {
-    nodes: new Map(),
-    edges: [],
-    nodeCounter: 0,
-  }
-
+  const state = newState()
   projectNode(node, state)
-
   return {
     nodes: Array.from(state.nodes.values()),
     edges: state.edges,
   }
 }
 
-/**
- * Project multiple statements into a single combined graph.
- *
- * @param nodes - Array of AST nodes to project
- * @returns The combined link graph
- */
 export function projectStatementsToGraph(nodes: ASTNode[]): LinkGraph {
-  const state: GraphBuilderState = {
-    nodes: new Map(),
-    edges: [],
-    nodeCounter: 0,
-  }
-
-  for (const node of nodes) {
-    projectNode(node, state)
-  }
-
+  const state = newState()
+  for (const node of nodes) projectNode(node, state)
   return {
     nodes: Array.from(state.nodes.values()),
     edges: state.edges,
   }
 }
 
-/**
- * Convert a LinkGraph to Cytoscape.js elements format.
- *
- * @param graph - The link graph
- * @returns Array of Cytoscape element definitions
- */
 export function toCytoscapeElements(
   graph: LinkGraph
 ): Array<{ group: 'nodes' | 'edges'; data: Record<string, string | undefined> }> {
@@ -501,13 +298,6 @@ export function toCytoscapeElements(
   return elements
 }
 
-/**
- * Convert a LinkGraph to DOT format for Graphviz rendering.
- *
- * @param graph - The link graph
- * @param title - Optional graph title
- * @returns DOT format string
- */
 export function linkGraphToDOT(graph: LinkGraph, title?: string): string {
   const lines: string[] = []
   const graphLabel = title ? `  label="${escapeLabel(title)}";` : ''
@@ -519,9 +309,9 @@ export function linkGraphToDOT(graph: LinkGraph, title?: string): string {
   if (graphLabel) lines.push(graphLabel)
   lines.push('')
 
-  // Node styles by type
   const nodeStyles: Record<LinkGraphNodeType, string> = {
-    'link-center': 'shape=circle, style=filled, fillcolor="#e3f2fd", width=0.3, fixedsize=true',
+    'link-center':
+      'shape=circle, style=filled, fillcolor="#e3f2fd", width=0.3, fixedsize=true',
     atom: 'shape=box, style="filled,rounded", fillcolor="#c8e6c9"',
     operator: 'shape=diamond, style=filled, fillcolor="#fff3e0"',
     unary: 'shape=ellipse, style=filled, fillcolor="#f3e5f5"',
@@ -531,25 +321,36 @@ export function linkGraphToDOT(graph: LinkGraph, title?: string): string {
 
   for (const node of graph.nodes) {
     const style = nodeStyles[node.nodeType]
-    const label = node.label ? `label="${escapeLabel(node.label)}"` : 'label=""'
+    const label = node.label
+      ? `label="${escapeLabel(node.label)}"`
+      : 'label=""'
     lines.push(`  ${node.id} [${label}, ${style}];`)
   }
 
   lines.push('')
 
-  // Edge styles by type
   for (const edge of graph.edges) {
     const attrs: string[] = []
 
     switch (edge.edgeType) {
       case 'link-start':
-        attrs.push('arrowhead=none', 'arrowtail=odot', 'dir=both', 'color="#1565c0"')
+        attrs.push(
+          'arrowhead=none',
+          'arrowtail=odot',
+          'dir=both',
+          'color="#1565c0"'
+        )
         break
       case 'link-end':
         attrs.push('arrowhead=vee', 'color="#1565c0"')
         break
       case 'self-start':
-        attrs.push('arrowhead=none', 'arrowtail=odot', 'dir=both', 'color="#7b1fa2"')
+        attrs.push(
+          'arrowhead=none',
+          'arrowtail=odot',
+          'dir=both',
+          'color="#7b1fa2"'
+        )
         break
       case 'self-end':
         attrs.push('arrowhead=vee', 'color="#7b1fa2"')
@@ -562,14 +363,10 @@ export function linkGraphToDOT(graph: LinkGraph, title?: string): string {
         break
     }
 
-    if (edge.label) {
-      attrs.push(`label="${escapeLabel(edge.label)}"`)
-    }
-
+    if (edge.label) attrs.push(`label="${escapeLabel(edge.label)}"`)
     lines.push(`  ${edge.source} -> ${edge.target} [${attrs.join(', ')}];`)
   }
 
   lines.push('}')
-
   return lines.join('\n')
 }

--- a/tests/unit/linkGraph.test.ts
+++ b/tests/unit/linkGraph.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for Link Graph projection module
+ * Tests for occurrence-preserving Link Graph projection.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -14,308 +14,185 @@ import { normalize } from '../../src/core/normalizer'
 
 describe('LinkGraph', () => {
   describe('projectToGraph', () => {
-    it('should project a simple link a -> b', () => {
-      const expr = normalize(parseExpr('a -> b'))
-      const graph = projectToGraph(expr)
+    it('projects a simple link a -> b', () => {
+      const graph = projectToGraph(normalize(parseExpr('a -> b')))
 
-      // Should have: atom 'a', link-center, atom 'b'
       expect(graph.nodes.length).toBe(3)
       expect(graph.edges.length).toBe(2)
 
       const atoms = graph.nodes.filter(n => n.nodeType === 'atom')
       const centers = graph.nodes.filter(n => n.nodeType === 'link-center')
-
-      expect(atoms.length).toBe(2)
-      expect(centers.length).toBe(1)
       expect(atoms.map(a => a.label).sort()).toEqual(['a', 'b'])
+      expect(centers.length).toBe(1)
 
-      // Check edge types
-      const startEdges = graph.edges.filter(e => e.edgeType === 'link-start')
-      const endEdges = graph.edges.filter(e => e.edgeType === 'link-end')
-
-      expect(startEdges.length).toBe(1)
-      expect(endEdges.length).toBe(1)
-
-      // Start edge goes from 'a' to center
-      expect(startEdges[0].source).toBe(atoms.find(a => a.label === 'a')!.id)
-      expect(startEdges[0].target).toBe(centers[0].id)
-
-      // End edge goes from center to 'b'
-      expect(endEdges[0].source).toBe(centers[0].id)
-      expect(endEdges[0].target).toBe(atoms.find(a => a.label === 'b')!.id)
+      const start = graph.edges.find(e => e.edgeType === 'link-start')!
+      const end = graph.edges.find(e => e.edgeType === 'link-end')!
+      expect(start.source).toBe(atoms.find(a => a.label === 'a')!.id)
+      expect(start.target).toBe(centers[0].id)
+      expect(end.source).toBe(centers[0].id)
+      expect(end.target).toBe(atoms.find(a => a.label === 'b')!.id)
     })
 
-    it('should project infinity expression ∞', () => {
-      const expr = normalize(parseExpr('∞'))
-      const graph = projectToGraph(expr)
-
-      expect(graph.nodes.length).toBe(1)
+    it('projects infinity as one atom occurrence', () => {
+      const graph = projectToGraph(normalize(parseExpr('∞')))
+      expect(graph.nodes).toHaveLength(1)
       expect(graph.nodes[0].label).toBe('∞')
       expect(graph.nodes[0].nodeType).toBe('atom')
     })
 
-    it('should project chained links a -> b -> c', () => {
-      const expr = normalize(parseExpr('a -> b -> c'))
-      const graph = projectToGraph(expr)
+    it('keeps chained links left-associated', () => {
+      const graph = projectToGraph(normalize(parseExpr('a -> b -> c')))
+      expect(graph.nodes.filter(n => n.nodeType === 'link-center')).toHaveLength(2)
+      expect(graph.nodes.filter(n => n.nodeType === 'atom')).toHaveLength(3)
+    })
 
-      // Due to left-associativity: (a -> b) -> c
-      // Inner link: a +--*--> b (center1)
-      // Outer link: center1 +--*--> c (center2)
-      const centers = graph.nodes.filter(n => n.nodeType === 'link-center')
-      expect(centers.length).toBe(2)
+    it('projects male and female self-closing forms', () => {
+      const male = projectToGraph(normalize(parseExpr('♂x')))
+      const female = projectToGraph(normalize(parseExpr('x♀')))
 
+      expect(male.nodes.filter(n => n.nodeType === 'unary')).toHaveLength(1)
+      expect(male.edges.filter(e => e.edgeType === 'self-start')).toHaveLength(1)
+      expect(male.edges.filter(e => e.edgeType === 'link-end')).toHaveLength(1)
+
+      expect(female.nodes.filter(n => n.nodeType === 'unary')).toHaveLength(1)
+      expect(female.edges.filter(e => e.edgeType === 'link-start')).toHaveLength(1)
+      expect(female.edges.filter(e => e.edgeType === 'self-end')).toHaveLength(1)
+    })
+
+    it('projects equality and definition as structural operators', () => {
+      const equality = projectToGraph(normalize(parseExpr('a = b')))
+      const definition = projectToGraph(normalize(parseExpr('s : s -> s')))
+
+      expect(
+        equality.nodes.filter(n => n.nodeType === 'operator').map(n => n.label)
+      ).toEqual(['='])
+      expect(equality.edges.filter(e => e.edgeType === 'relation')).toHaveLength(2)
+
+      expect(
+        definition.nodes.filter(n => n.nodeType === 'operator').map(n => n.label)
+      ).toEqual([':'])
+    })
+
+    it('projects negation, set and power nodes', () => {
+      const negation = projectToGraph(normalize(parseExpr('!x')))
+      const set = projectToGraph(normalize(parseExpr('{a, b, c}')))
+      const power = projectToGraph(parseExpr('a^2'))
+
+      expect(negation.nodes.filter(n => n.nodeType === 'unary')).toHaveLength(1)
+      expect(set.nodes.filter(n => n.nodeType === 'set')).toHaveLength(1)
+      expect(set.edges.filter(e => e.edgeType === 'member')).toHaveLength(3)
+      expect(power.nodes.filter(n => n.nodeType === 'power')).toHaveLength(1)
+    })
+
+    it('keeps both occurrences when normalization produces a -> a', () => {
+      const graph = projectToGraph(normalize(parseExpr('a^2')))
       const atoms = graph.nodes.filter(n => n.nodeType === 'atom')
-      expect(atoms.length).toBe(3)
+
+      expect(graph.nodes.filter(n => n.nodeType === 'link-center')).toHaveLength(1)
+      expect(atoms).toHaveLength(2)
+      expect(atoms.map(a => a.label)).toEqual(['a', 'a'])
+      expect(new Set(atoms.map(a => a.id)).size).toBe(2)
     })
 
-    it('should project male self-closing ♂x', () => {
-      const expr = normalize(parseExpr('♂x'))
-      const graph = projectToGraph(expr)
-
-      // Should have: atom 'x', unary '♂x'
-      const unaryNodes = graph.nodes.filter(n => n.nodeType === 'unary')
-      expect(unaryNodes.length).toBe(1)
-      expect(unaryNodes[0].label).toBe('♂x')
-
-      // Should have self-closing start edge and link-end edge
-      const selfStartEdges = graph.edges.filter(e => e.edgeType === 'self-start')
-      const endEdges = graph.edges.filter(e => e.edgeType === 'link-end')
-
-      expect(selfStartEdges.length).toBe(1)
-      expect(endEdges.length).toBe(1)
-
-      // Self-start loops on the unary node
-      expect(selfStartEdges[0].source).toBe(unaryNodes[0].id)
-      expect(selfStartEdges[0].target).toBe(unaryNodes[0].id)
-    })
-
-    it('should project female self-closing x♀', () => {
-      const expr = normalize(parseExpr('x♀'))
-      const graph = projectToGraph(expr)
-
-      const unaryNodes = graph.nodes.filter(n => n.nodeType === 'unary')
-      expect(unaryNodes.length).toBe(1)
-      expect(unaryNodes[0].label).toBe('x♀')
-
-      // Should have link-start edge and self-closing end edge
-      const startEdges = graph.edges.filter(e => e.edgeType === 'link-start')
-      const selfEndEdges = graph.edges.filter(e => e.edgeType === 'self-end')
-
-      expect(startEdges.length).toBe(1)
-      expect(selfEndEdges.length).toBe(1)
-
-      // Self-end loops on the unary node
-      expect(selfEndEdges[0].source).toBe(unaryNodes[0].id)
-      expect(selfEndEdges[0].target).toBe(unaryNodes[0].id)
-    })
-
-    it('should project equality a = b', () => {
-      const expr = normalize(parseExpr('a = b'))
-      const graph = projectToGraph(expr)
-
-      const operators = graph.nodes.filter(n => n.nodeType === 'operator')
-      expect(operators.length).toBe(1)
-      expect(operators[0].label).toBe('=')
-
+    it('does not use display label as identity inside equality', () => {
+      const graph = projectToGraph(normalize(parseExpr('a = a')))
       const atoms = graph.nodes.filter(n => n.nodeType === 'atom')
-      expect(atoms.length).toBe(2)
 
-      // Two relation edges
-      const relations = graph.edges.filter(e => e.edgeType === 'relation')
-      expect(relations.length).toBe(2)
-    })
-
-    it('should project definition s : F', () => {
-      const expr = normalize(parseExpr('s : s -> s'))
-      const graph = projectToGraph(expr)
-
-      const operators = graph.nodes.filter(n => n.nodeType === 'operator')
-      expect(operators.length).toBe(1)
-      expect(operators[0].label).toBe(':')
-    })
-
-    it('should project negation !x', () => {
-      const expr = normalize(parseExpr('!x'))
-      const graph = projectToGraph(expr)
-
-      const unaryNodes = graph.nodes.filter(n => n.nodeType === 'unary')
-      expect(unaryNodes.length).toBe(1)
-    })
-
-    it('should project set expression {a, b, c}', () => {
-      const expr = normalize(parseExpr('{a, b, c}'))
-      const graph = projectToGraph(expr)
-
-      const setNodes = graph.nodes.filter(n => n.nodeType === 'set')
-      expect(setNodes.length).toBe(1)
-
-      const memberEdges = graph.edges.filter(e => e.edgeType === 'member')
-      expect(memberEdges.length).toBe(3)
-    })
-
-    it('should project power expression a^2 (unnormalized)', () => {
-      // Note: normalize() expands a^2 into (a -> a), so test with raw parsed AST
-      const expr = parseExpr('a^2')
-      const graph = projectToGraph(expr)
-
-      const powerNodes = graph.nodes.filter(n => n.nodeType === 'power')
-      expect(powerNodes.length).toBe(1)
-      expect(powerNodes[0].label).toBe('^2')
-    })
-
-    it('should project normalized power a^2 as link chain', () => {
-      const expr = normalize(parseExpr('a^2'))
-      const graph = projectToGraph(expr)
-
-      // a^2 normalizes to (a -> a), which is a link with shared atom
-      const centers = graph.nodes.filter(n => n.nodeType === 'link-center')
-      expect(centers.length).toBe(1)
-
-      const atoms = graph.nodes.filter(n => n.nodeType === 'atom')
-      expect(atoms.length).toBe(1) // 'a' is reused
-    })
-
-    it('should reuse atom nodes with the same label', () => {
-      const expr = normalize(parseExpr('a = a'))
-      const graph = projectToGraph(expr)
-
-      // Should have only one 'a' atom (reused), plus the '=' operator
-      const atoms = graph.nodes.filter(n => n.nodeType === 'atom')
-      expect(atoms.length).toBe(1)
+      expect(atoms).toHaveLength(2)
       expect(atoms[0].label).toBe('a')
+      expect(atoms[1].label).toBe('a')
+      expect(atoms[0].id).not.toBe(atoms[1].id)
+      expect(atoms[0].astNode).not.toBe(atoms[1].astNode)
     })
 
-    it('should project numeric constants', () => {
-      const expr = normalize(parseExpr('0'))
-      const graph = projectToGraph(expr)
+    it('gives every graph node and edge a unique runtime ID', () => {
+      const graph = projectToGraph(normalize(parseExpr('(a -> a) = (a -> a)')))
 
-      expect(graph.nodes.length).toBe(1)
+      expect(new Set(graph.nodes.map(n => n.id)).size).toBe(graph.nodes.length)
+      expect(new Set(graph.edges.map(e => e.id)).size).toBe(graph.edges.length)
+    })
+
+    it('projects numeric constants', () => {
+      const graph = projectToGraph(normalize(parseExpr('0')))
+      expect(graph.nodes).toHaveLength(1)
       expect(graph.nodes[0].label).toBe('0')
       expect(graph.nodes[0].nodeType).toBe('atom')
-    })
-
-    it('should project axiom A4: ∞ : (∞ -> ∞)', () => {
-      const expr = normalize(parseExpr('∞ : (∞ -> ∞)'))
-      const graph = projectToGraph(expr)
-
-      // Should have: atom '∞', link-center, operator ':'
-      expect(graph.nodes.length).toBeGreaterThanOrEqual(2)
-
-      const operators = graph.nodes.filter(n => n.nodeType === 'operator')
-      expect(operators.some(o => o.label === ':')).toBe(true)
     })
   })
 
   describe('projectStatementsToGraph', () => {
-    it('should project multiple statements into one graph', () => {
-      const expr1 = normalize(parseExpr('a -> b'))
-      const expr2 = normalize(parseExpr('c -> d'))
-      const graph = projectStatementsToGraph([expr1, expr2])
+    it('projects multiple statements into one graph', () => {
+      const graph = projectStatementsToGraph([
+        normalize(parseExpr('a -> b')),
+        normalize(parseExpr('c -> d')),
+      ])
 
-      const atoms = graph.nodes.filter(n => n.nodeType === 'atom')
-      expect(atoms.length).toBe(4) // a, b, c, d
-
-      const centers = graph.nodes.filter(n => n.nodeType === 'link-center')
-      expect(centers.length).toBe(2)
+      expect(graph.nodes.filter(n => n.nodeType === 'atom')).toHaveLength(4)
+      expect(graph.nodes.filter(n => n.nodeType === 'link-center')).toHaveLength(2)
     })
 
-    it('should share atom nodes across statements', () => {
-      const expr1 = normalize(parseExpr('a -> b'))
-      const expr2 = normalize(parseExpr('b -> c'))
-      const graph = projectStatementsToGraph([expr1, expr2])
-
-      // 'b' should be shared
+    it('keeps repeated labels as separate occurrences across statements', () => {
+      const graph = projectStatementsToGraph([
+        normalize(parseExpr('a -> b')),
+        normalize(parseExpr('b -> c')),
+      ])
       const atoms = graph.nodes.filter(n => n.nodeType === 'atom')
-      expect(atoms.length).toBe(3) // a, b, c (b is shared)
+      const bOccurrences = atoms.filter(n => n.label === 'b')
+
+      expect(atoms).toHaveLength(4)
+      expect(bOccurrences).toHaveLength(2)
+      expect(bOccurrences[0].id).not.toBe(bOccurrences[1].id)
     })
 
-    it('should handle empty array', () => {
+    it('handles an empty statement list', () => {
       const graph = projectStatementsToGraph([])
-      expect(graph.nodes.length).toBe(0)
-      expect(graph.edges.length).toBe(0)
+      expect(graph.nodes).toHaveLength(0)
+      expect(graph.edges).toHaveLength(0)
     })
   })
 
   describe('toCytoscapeElements', () => {
-    it('should convert graph to cytoscape format', () => {
-      const expr = normalize(parseExpr('a -> b'))
-      const graph = projectToGraph(expr)
+    it('preserves all occurrence IDs in Cytoscape data', () => {
+      const graph = projectToGraph(normalize(parseExpr('a = a')))
       const elements = toCytoscapeElements(graph)
 
       const nodeElements = elements.filter(e => e.group === 'nodes')
       const edgeElements = elements.filter(e => e.group === 'edges')
-
-      expect(nodeElements.length).toBe(graph.nodes.length)
-      expect(edgeElements.length).toBe(graph.edges.length)
-
-      // Check node data
-      for (const nodeEl of nodeElements) {
-        expect(nodeEl.data.id).toBeDefined()
-        expect(nodeEl.data.nodeType).toBeDefined()
-      }
-
-      // Check edge data
-      for (const edgeEl of edgeElements) {
-        expect(edgeEl.data.source).toBeDefined()
-        expect(edgeEl.data.target).toBeDefined()
-        expect(edgeEl.data.edgeType).toBeDefined()
-      }
+      expect(nodeElements).toHaveLength(graph.nodes.length)
+      expect(edgeElements).toHaveLength(graph.edges.length)
+      expect(new Set(nodeElements.map(e => e.data.id)).size).toBe(graph.nodes.length)
     })
 
-    it('should handle empty graph', () => {
-      const graph = projectStatementsToGraph([])
-      const elements = toCytoscapeElements(graph)
-      expect(elements.length).toBe(0)
+    it('handles an empty graph', () => {
+      expect(toCytoscapeElements(projectStatementsToGraph([]))).toHaveLength(0)
     })
   })
 
   describe('linkGraphToDOT', () => {
-    it('should generate valid DOT format', () => {
-      const expr = normalize(parseExpr('a -> b'))
-      const graph = projectToGraph(expr)
-      const dot = linkGraphToDOT(graph)
-
+    it('generates DOT with links', () => {
+      const dot = linkGraphToDOT(projectToGraph(normalize(parseExpr('a -> b'))))
       expect(dot).toContain('digraph LinkGraph')
       expect(dot).toContain('rankdir=LR')
-      expect(dot).toContain('->')
-      expect(dot).toContain('}')
-    })
-
-    it('should include title when provided', () => {
-      const expr = normalize(parseExpr('a -> b'))
-      const graph = projectToGraph(expr)
-      const dot = linkGraphToDOT(graph, 'Test Graph')
-
-      expect(dot).toContain('label="Test Graph"')
-    })
-
-    it('should handle edge types', () => {
-      const expr = normalize(parseExpr('a -> b'))
-      const graph = projectToGraph(expr)
-      const dot = linkGraphToDOT(graph)
-
-      // Link start edge should have odot arrowtail
       expect(dot).toContain('arrowtail=odot')
-      // Link end edge should have vee arrowhead
       expect(dot).toContain('arrowhead=vee')
-    })
-
-    it('should handle empty graph', () => {
-      const graph = projectStatementsToGraph([])
-      const dot = linkGraphToDOT(graph)
-
-      expect(dot).toContain('digraph LinkGraph')
       expect(dot).toContain('}')
     })
 
-    it('should escape special characters in labels', () => {
-      const expr = normalize(parseExpr('{a, b}'))
-      const graph = projectToGraph(expr)
-      const dot = linkGraphToDOT(graph)
+    it('includes an escaped title', () => {
+      const graph = projectToGraph(normalize(parseExpr('a -> b')))
+      expect(linkGraphToDOT(graph, 'Test Graph')).toContain('label="Test Graph"')
+    })
 
-      // Curly braces should be escaped
+    it('escapes special characters in labels', () => {
+      const dot = linkGraphToDOT(projectToGraph(normalize(parseExpr('{a, b}'))))
       expect(dot).not.toContain('label="{…}"')
       expect(dot).toContain('\\{')
+    })
+
+    it('handles an empty graph', () => {
+      const dot = linkGraphToDOT(projectStatementsToGraph([]))
+      expect(dot).toContain('digraph LinkGraph')
+      expect(dot).toContain('}')
     })
   })
 })


### PR DESCRIPTION
Refs #107.

Первый независимый шаг миграции visual approver на canonical contract `anum_docs`.

## Проблема

Текущий `src/core/linkGraph.ts` интернировал atom nodes по display label:

```text
same label => same graph node
```

Из-за этого `a = a` визуально имел один atom node, а одинаковый label между разными statements автоматически сливался.

Для МТС v0.2 это фундаментально неверно. В canonical `anum_docs`:

```text
[] = []
```

содержит два разных AST occurrences. Display label не является `HoleId`, `LinkRef` или другой runtime identity.

## Изменение

`linkGraph.ts` сохраняет прежний public API, но теперь:

- каждый AST occurrence получает отдельный graph node ID;
- atom nodes больше не dedup-ятся по `label`;
- edge IDs генерируются отдельным monotonic counter;
- одинаковые labels могут встречаться у нескольких nodes;
- explicit semantic merging в будущем разрешается только по canonical runtime identity (`LinkRef`/`HoleId`), а не по строке.

## Tests

Обновлены assertions:

```text
a = a        => два atom occurrences
normalize(a²)=> два `a` occurrences
b в двух statements => два occurrences
```

Добавлена проверка уникальности всех graph/edge IDs и сохранения occurrence IDs при экспорте в Cytoscape.

## Что PR НЕ делает

- не переносит пока parser/prover на `◁/▷/↑`;
- не реализует ContextFrame UI;
- не меняет semantic equality;
- не добавляет временный compatibility renderer.

Это безопасный identity refactor, необходимый независимо от следующих этапов #107.