### PR TITLE
Pin canonical MTS v0.2 contract and conformance from anum_docs

### DIFF
--- a/contracts/anum_docs-v0.2/mts-conformance-v0.2.json
+++ b/contracts/anum_docs-v0.2/mts-conformance-v0.2.json
@@ -1,0 +1,135 @@
+{
+  "schema": "mts-conformance/v0.2",
+  "contract": "mts-contract/v0.2",
+  "status": "accepted",
+  "lexing": [
+    {
+      "id": "atomic-pronouns-do-not-overload-brackets",
+      "source": "◁[]▷",
+      "tokens": ["context-start", "lbracket", "rbracket", "context-end"]
+    },
+    {
+      "id": "context-ascent-is-separate",
+      "source": "↑↑◁",
+      "tokens": ["context-up", "context-up", "context-start"]
+    }
+  ],
+  "canonicalization": [
+    {
+      "id": "context-ascent-whitespace",
+      "source": "↑ ↑  ◁",
+      "canonical": "↑↑◁"
+    },
+    {
+      "id": "canonical-equality-definition",
+      "source": "(=):{♀◁=♀▷,◁♂=▷♂}",
+      "canonical": "(=) : {♀◁ = ♀▷, ◁♂ = ▷♂}"
+    },
+    {
+      "id": "canonical-aroot-definition",
+      "source": "∞:{◁=∞,▷=∞}",
+      "canonical": "∞ : {◁ = ∞, ▷ = ∞}"
+    }
+  ],
+  "interpretation": [
+    {
+      "id": "bind-anonymous-occurrences-to-context-roles",
+      "source": "{[] = ◁, [] = ▷}",
+      "context": {"start": 10, "end": 12},
+      "symbols": {},
+      "memory": {"links": []},
+      "expected": {
+        "success": true,
+        "substitutions": [
+          {"path": [0, 0], "link": 10},
+          {"path": [1, 0], "link": 12}
+        ],
+        "aliases": [],
+        "traceKinds": ["bundle", "equality", "context", "bind", "equality", "context", "bind"]
+      }
+    },
+    {
+      "id": "aroot-full-self-cycle",
+      "source": "{◁ = ∞, ▷ = ∞}",
+      "context": {"start": 1, "end": 1},
+      "symbols": {"∞": 1},
+      "memory": {"links": []},
+      "expected": {
+        "success": true,
+        "substitutions": [],
+        "aliases": [],
+        "traceKinds": ["bundle", "equality", "context", "equality", "context"]
+      }
+    },
+    {
+      "id": "aroot-rejects-non-self-end",
+      "source": "{◁ = ∞, ▷ = ∞}",
+      "context": {"start": 1, "end": 2},
+      "symbols": {"∞": 1},
+      "memory": {"links": []},
+      "expected": {
+        "success": false,
+        "substitutions": [],
+        "aliases": [],
+        "traceKinds": ["bundle", "equality", "context", "equality", "context"]
+      }
+    },
+    {
+      "id": "decompose-existing-link-into-two-holes",
+      "source": "10 = [] ⟼ []",
+      "context": {"start": 2, "end": 3},
+      "symbols": {"10": 10},
+      "memory": {
+        "links": [
+          {"id": 10, "start": 2, "end": 3}
+        ]
+      },
+      "expected": {
+        "success": true,
+        "substitutions": [
+          {"path": [1, 0], "link": 2},
+          {"path": [1, 1], "link": 3}
+        ],
+        "aliases": [],
+        "traceKinds": ["equality", "decompose", "bind", "bind"]
+      }
+    },
+    {
+      "id": "recursive-link-pattern-decomposition",
+      "source": "20 = ([] ⟼ []) ⟼ []",
+      "context": {"start": 2, "end": 3},
+      "symbols": {"20": 20},
+      "memory": {
+        "links": [
+          {"id": 10, "start": 2, "end": 3},
+          {"id": 20, "start": 10, "end": 1}
+        ]
+      },
+      "expected": {
+        "success": true,
+        "substitutions": [
+          {"path": [1, 0, 0, 0], "link": 2},
+          {"path": [1, 0, 0, 1], "link": 3},
+          {"path": [1, 1], "link": 1}
+        ],
+        "aliases": [],
+        "traceKinds": ["equality", "decompose", "decompose", "bind", "bind", "bind"]
+      }
+    },
+    {
+      "id": "two-anonymous-occurrences-alias-locally",
+      "source": "[] = []",
+      "context": {"start": 1, "end": 1},
+      "symbols": {},
+      "memory": {"links": []},
+      "expected": {
+        "success": true,
+        "substitutions": [],
+        "aliases": [
+          {"path": [1], "targetPath": [0]}
+        ],
+        "traceKinds": ["equality", "alias"]
+      }
+    }
+  ]
+}

--- a/contracts/anum_docs-v0.2/mts-contract-v0.2.json
+++ b/contracts/anum_docs-v0.2/mts-contract-v0.2.json
@@ -1,0 +1,86 @@
+{
+  "schema": "mts-contract/v0.2",
+  "status": "accepted",
+  "conformanceCorpus": "contracts/mts-conformance-v0.2.json",
+  "layers": {
+    "formalNotation": "L2",
+    "anumSerialization": "L3",
+    "memoryExecution": "L4"
+  },
+  "formalNotation": {
+    "anonymousForm": {
+      "source": "[]",
+      "identity": "ast-occurrence-path",
+      "meaning": "anonymous-link-form"
+    },
+    "context": {
+      "atomicPronouns": true,
+      "bracketOverloading": false,
+      "roles": [
+        {"source": "◁", "role": "start"},
+        {"source": "▷", "role": "end"}
+      ],
+      "ancestor": {
+        "operator": "↑",
+        "examples": {
+          "↑◁": "parent.start",
+          "↑▷": "parent.end",
+          "↑↑◁": "grandparent.start"
+        }
+      },
+      "genericPathLanguage": false,
+      "materializedLinkRequired": false
+    },
+    "operations": {
+      "parse": {"effect": "none"},
+      "interpret": {
+        "effect": "none",
+        "returns": [
+          "success",
+          "localSubstitutions",
+          "localAliases",
+          "resolutionTrace"
+        ]
+      }
+    },
+    "patternMatching": {
+      "linkForm": "decompose-existing-link",
+      "roundGrouping": "transparent",
+      "materializes": false
+    },
+    "equality": {
+      "execution": "local-unification",
+      "globalRewrite": false,
+      "definition": "(=) : {♀◁ = ♀▷, ◁♂ = ▷♂}"
+    },
+    "aroot": {
+      "definition": "∞ : {◁ = ∞, ▷ = ∞}"
+    }
+  },
+  "anum": {
+    "operations": ["serialize", "deserialize"],
+    "alphabet": ["[", "]", "1", "0"]
+  },
+  "memory": {
+    "readOperations": [
+      "find",
+      "poles",
+      "findLink",
+      "findStartProjection",
+      "findEndProjection"
+    ],
+    "effectOperations": ["realize", "delete"],
+    "interpretMayMaterialize": false
+  },
+  "rootProgram": "tests/mtc_formulas.mtc",
+  "integration": {
+    "displayLabelIsIdentity": false,
+    "requiredRuntimeIdentities": [
+      "LinkRef",
+      "HoleId",
+      "ContextFrameId",
+      "JudgmentId",
+      "ProofStepId"
+    ]
+  }
+}

--- a/contracts/anum_docs-v0.2/provenance.json
+++ b/contracts/anum_docs-v0.2/provenance.json
@@ -1,0 +1,12 @@
+{
+  "sourceRepository": "netkeep80/anum_docs",
+  "sourceCommit": "294aa5e3d141e16fa93f88c0c18c4b78f8ae168c",
+  "contract": {
+    "path": "contracts/mts-contract-v0.2.json",
+    "gitBlobSha": "fb414a1541f3430fa9292c0fdfd89ca07d5db8ea"
+  },
+  "conformance": {
+    "path": "contracts/mts-conformance-v0.2.json",
+    "gitBlobSha": "96303366a8808d9e67ee548b445fcdbf2233f336"
+  }
+}

--- a/src/core/mtsContract.ts
+++ b/src/core/mtsContract.ts
@@ -1,0 +1,257 @@
+export interface MtsContextRole {
+  source: string
+  role: 'start' | 'end'
+}
+
+export interface MtsContractV02 {
+  schema: 'mts-contract/v0.2'
+  status: 'accepted'
+  conformanceCorpus: 'contracts/mts-conformance-v0.2.json'
+  formalNotation: {
+    anonymousForm: {
+      source: '[]'
+      identity: 'ast-occurrence-path'
+      meaning: 'anonymous-link-form'
+    }
+    context: {
+      atomicPronouns: true
+      bracketOverloading: false
+      roles: [MtsContextRole, MtsContextRole]
+      ancestor: {
+        operator: '↑'
+        examples: Record<string, string>
+      }
+      genericPathLanguage: false
+      materializedLinkRequired: false
+    }
+    operations: {
+      parse: { effect: 'none' }
+      interpret: {
+        effect: 'none'
+        returns: string[]
+      }
+    }
+    patternMatching: {
+      linkForm: 'decompose-existing-link'
+      roundGrouping: 'transparent'
+      materializes: false
+    }
+    equality: {
+      execution: 'local-unification'
+      globalRewrite: false
+      definition: string
+    }
+    aroot: {
+      definition: string
+    }
+  }
+  anum: {
+    operations: ['serialize', 'deserialize']
+    alphabet: ['[', ']', '1', '0']
+  }
+  memory: {
+    readOperations: string[]
+    effectOperations: ['realize', 'delete']
+    interpretMayMaterialize: false
+  }
+  integration: {
+    displayLabelIsIdentity: false
+    requiredRuntimeIdentities: string[]
+  }
+}
+
+export interface MtsLexingCase {
+  id: string
+  source: string
+  tokens: string[]
+}
+
+export interface MtsCanonicalizationCase {
+  id: string
+  source: string
+  canonical: string
+}
+
+export interface MtsInterpretationCase {
+  id: string
+  source: string
+  context: {
+    start: number
+    end: number
+    parent?: MtsInterpretationCase['context']
+  }
+  symbols: Record<string, number>
+  memory: {
+    links: Array<{ id: number; start: number; end: number }>
+  }
+  expected: {
+    success: boolean
+    substitutions: Array<{ path: number[]; link: number }>
+    aliases: Array<{ path: number[]; targetPath: number[] }>
+    traceKinds: string[]
+  }
+}
+
+export interface MtsConformanceV02 {
+  schema: 'mts-conformance/v0.2'
+  contract: 'mts-contract/v0.2'
+  status: 'accepted'
+  lexing: MtsLexingCase[]
+  canonicalization: MtsCanonicalizationCase[]
+  interpretation: MtsInterpretationCase[]
+}
+
+export interface MtsContractBundleV02 {
+  contract: MtsContractV02
+  conformance: MtsConformanceV02
+}
+
+function record(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new TypeError(`${name} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+function array(value: unknown, name: string): unknown[] {
+  if (!Array.isArray(value)) throw new TypeError(`${name} must be an array`)
+  return value
+}
+
+function exact<T>(actual: unknown, expected: T, name: string): asserts actual is T {
+  if (actual !== expected) {
+    throw new TypeError(`${name} must be ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+  }
+}
+
+function string(value: unknown, name: string): string {
+  if (typeof value !== 'string') throw new TypeError(`${name} must be a string`)
+  return value
+}
+
+function validateContextRole(value: unknown, index: number): MtsContextRole {
+  const role = record(value, `formalNotation.context.roles[${index}]`)
+  const source = string(role.source, `context role ${index} source`)
+  if ([...source].length !== 1) {
+    throw new TypeError(`context role ${index} must be exactly one Unicode code point`)
+  }
+  if (source.includes('[') || source.includes(']')) {
+    throw new TypeError(`context role ${index} must not overload square brackets`)
+  }
+  if (role.role !== 'start' && role.role !== 'end') {
+    throw new TypeError(`context role ${index} must be start or end`)
+  }
+  return { source, role: role.role }
+}
+
+export function validateMtsContractV02(value: unknown): MtsContractV02 {
+  const root = record(value, 'contract')
+  exact(root.schema, 'mts-contract/v0.2', 'contract.schema')
+  exact(root.status, 'accepted', 'contract.status')
+  exact(
+    root.conformanceCorpus,
+    'contracts/mts-conformance-v0.2.json',
+    'contract.conformanceCorpus'
+  )
+
+  const formalNotation = record(root.formalNotation, 'formalNotation')
+  const anonymousForm = record(formalNotation.anonymousForm, 'formalNotation.anonymousForm')
+  exact(anonymousForm.source, '[]', 'anonymousForm.source')
+  exact(anonymousForm.identity, 'ast-occurrence-path', 'anonymousForm.identity')
+  exact(anonymousForm.meaning, 'anonymous-link-form', 'anonymousForm.meaning')
+
+  const context = record(formalNotation.context, 'formalNotation.context')
+  exact(context.atomicPronouns, true, 'context.atomicPronouns')
+  exact(context.bracketOverloading, false, 'context.bracketOverloading')
+  exact(context.genericPathLanguage, false, 'context.genericPathLanguage')
+  exact(context.materializedLinkRequired, false, 'context.materializedLinkRequired')
+
+  const roles = array(context.roles, 'context.roles').map(validateContextRole)
+  if (roles.length !== 2 || roles[0].role !== 'start' || roles[1].role !== 'end') {
+    throw new TypeError('context.roles must contain exactly ordered start/end roles')
+  }
+  if (roles[0].source === roles[1].source) {
+    throw new TypeError('context pronouns must be distinct')
+  }
+
+  const ancestor = record(context.ancestor, 'context.ancestor')
+  exact(ancestor.operator, '↑', 'context.ancestor.operator')
+
+  const operations = record(formalNotation.operations, 'formalNotation.operations')
+  const parse = record(operations.parse, 'formalNotation.operations.parse')
+  const interpret = record(operations.interpret, 'formalNotation.operations.interpret')
+  exact(parse.effect, 'none', 'parse.effect')
+  exact(interpret.effect, 'none', 'interpret.effect')
+
+  const patternMatching = record(formalNotation.patternMatching, 'formalNotation.patternMatching')
+  exact(patternMatching.linkForm, 'decompose-existing-link', 'patternMatching.linkForm')
+  exact(patternMatching.roundGrouping, 'transparent', 'patternMatching.roundGrouping')
+  exact(patternMatching.materializes, false, 'patternMatching.materializes')
+
+  const equality = record(formalNotation.equality, 'formalNotation.equality')
+  exact(equality.execution, 'local-unification', 'equality.execution')
+  exact(equality.globalRewrite, false, 'equality.globalRewrite')
+  string(equality.definition, 'equality.definition')
+
+  const aroot = record(formalNotation.aroot, 'formalNotation.aroot')
+  string(aroot.definition, 'aroot.definition')
+
+  const anum = record(root.anum, 'anum')
+  const alphabet = array(anum.alphabet, 'anum.alphabet')
+  if (JSON.stringify(alphabet) !== JSON.stringify(['[', ']', '1', '0'])) {
+    throw new TypeError('anum.alphabet must be exactly [ ] 1 0')
+  }
+
+  const memory = record(root.memory, 'memory')
+  exact(memory.interpretMayMaterialize, false, 'memory.interpretMayMaterialize')
+
+  const integration = record(root.integration, 'integration')
+  exact(integration.displayLabelIsIdentity, false, 'integration.displayLabelIsIdentity')
+
+  return value as MtsContractV02
+}
+
+export function validateMtsConformanceV02(
+  value: unknown,
+  contract: MtsContractV02
+): MtsConformanceV02 {
+  const root = record(value, 'conformance')
+  exact(root.schema, 'mts-conformance/v0.2', 'conformance.schema')
+  exact(root.contract, contract.schema, 'conformance.contract')
+  exact(root.status, 'accepted', 'conformance.status')
+
+  for (const [index, item] of array(root.lexing, 'conformance.lexing').entries()) {
+    const caseValue = record(item, `lexing[${index}]`)
+    string(caseValue.id, `lexing[${index}].id`)
+    string(caseValue.source, `lexing[${index}].source`)
+    array(caseValue.tokens, `lexing[${index}].tokens`)
+  }
+
+  for (const [index, item] of array(root.canonicalization, 'conformance.canonicalization').entries()) {
+    const caseValue = record(item, `canonicalization[${index}]`)
+    string(caseValue.id, `canonicalization[${index}].id`)
+    string(caseValue.source, `canonicalization[${index}].source`)
+    string(caseValue.canonical, `canonicalization[${index}].canonical`)
+  }
+
+  for (const [index, item] of array(root.interpretation, 'conformance.interpretation').entries()) {
+    const caseValue = record(item, `interpretation[${index}]`)
+    string(caseValue.id, `interpretation[${index}].id`)
+    string(caseValue.source, `interpretation[${index}].source`)
+    record(caseValue.context, `interpretation[${index}].context`)
+    record(caseValue.symbols, `interpretation[${index}].symbols`)
+    record(caseValue.memory, `interpretation[${index}].memory`)
+    record(caseValue.expected, `interpretation[${index}].expected`)
+  }
+
+  return value as MtsConformanceV02
+}
+
+export function validateMtsContractBundleV02(
+  contractValue: unknown,
+  conformanceValue: unknown
+): MtsContractBundleV02 {
+  const contract = validateMtsContractV02(contractValue)
+  const conformance = validateMtsConformanceV02(conformanceValue, contract)
+  return { contract, conformance }
+}

--- a/tests/unit/mtsContract.test.ts
+++ b/tests/unit/mtsContract.test.ts
@@ -1,22 +1,26 @@
 import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import { validateMtsContractBundleV02 } from '../../src/core/mtsContract'
 
-const contractUrl = new URL('../../contracts/anum_docs-v0.2/mts-contract-v0.2.json', import.meta.url)
-const conformanceUrl = new URL(
-  '../../contracts/anum_docs-v0.2/mts-conformance-v0.2.json',
-  import.meta.url
+const contractPath = resolve(
+  process.cwd(),
+  'contracts/anum_docs-v0.2/mts-contract-v0.2.json'
 )
-const provenanceUrl = new URL('../../contracts/anum_docs-v0.2/provenance.json', import.meta.url)
+const conformancePath = resolve(
+  process.cwd(),
+  'contracts/anum_docs-v0.2/mts-conformance-v0.2.json'
+)
+const provenancePath = resolve(process.cwd(), 'contracts/anum_docs-v0.2/provenance.json')
 
-function readJson(url: URL): unknown {
-  return JSON.parse(readFileSync(url, 'utf8')) as unknown
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8')) as unknown
 }
 
-function gitBlobSha(url: URL): string {
-  const content = readFileSync(url)
+function gitBlobSha(path: string): string {
+  const content = readFileSync(path)
   return createHash('sha1')
     .update(`blob ${content.byteLength}\0`)
     .update(content)
@@ -31,12 +35,15 @@ interface Provenance {
 }
 
 function readProvenance(): Provenance {
-  return readJson(provenanceUrl) as Provenance
+  return readJson(provenancePath) as Provenance
 }
 
 describe('pinned anum_docs MTS v0.2 contract', () => {
   it('loads as one validated contract + conformance bundle', () => {
-    const bundle = validateMtsContractBundleV02(readJson(contractUrl), readJson(conformanceUrl))
+    const bundle = validateMtsContractBundleV02(
+      readJson(contractPath),
+      readJson(conformancePath)
+    )
 
     expect(bundle.contract.schema).toBe('mts-contract/v0.2')
     expect(bundle.conformance.schema).toBe('mts-conformance/v0.2')
@@ -48,14 +55,17 @@ describe('pinned anum_docs MTS v0.2 contract', () => {
 
     expect(provenance.sourceRepository).toBe('netkeep80/anum_docs')
     expect(provenance.sourceCommit).toBe('294aa5e3d141e16fa93f88c0c18c4b78f8ae168c')
-    expect(gitBlobSha(contractUrl)).toBe(provenance.contract.gitBlobSha)
-    expect(gitBlobSha(conformanceUrl)).toBe(provenance.conformance.gitBlobSha)
+    expect(gitBlobSha(contractPath)).toBe(provenance.contract.gitBlobSha)
+    expect(gitBlobSha(conformancePath)).toBe(provenance.conformance.gitBlobSha)
     expect(provenance.contract.gitBlobSha).toBe('fb414a1541f3430fa9292c0fdfd89ca07d5db8ea')
     expect(provenance.conformance.gitBlobSha).toBe('96303366a8808d9e67ee548b445fcdbf2233f336')
   })
 
   it('treats the two context pronouns as atomic non-bracket code points', () => {
-    const { contract } = validateMtsContractBundleV02(readJson(contractUrl), readJson(conformanceUrl))
+    const { contract } = validateMtsContractBundleV02(
+      readJson(contractPath),
+      readJson(conformancePath)
+    )
     const context = contract.formalNotation.context
 
     expect(context.atomicPronouns).toBe(true)
@@ -70,7 +80,10 @@ describe('pinned anum_docs MTS v0.2 contract', () => {
   })
 
   it('forbids display labels from becoming semantic identity', () => {
-    const { contract } = validateMtsContractBundleV02(readJson(contractUrl), readJson(conformanceUrl))
+    const { contract } = validateMtsContractBundleV02(
+      readJson(contractPath),
+      readJson(conformancePath)
+    )
 
     expect(contract.integration.displayLabelIsIdentity).toBe(false)
     expect(contract.formalNotation.anonymousForm.identity).toBe('ast-occurrence-path')
@@ -79,7 +92,10 @@ describe('pinned anum_docs MTS v0.2 contract', () => {
   })
 
   it('keeps interpretation read-only and realization explicit', () => {
-    const { contract } = validateMtsContractBundleV02(readJson(contractUrl), readJson(conformanceUrl))
+    const { contract } = validateMtsContractBundleV02(
+      readJson(contractPath),
+      readJson(conformancePath)
+    )
 
     expect(contract.formalNotation.operations.interpret.effect).toBe('none')
     expect(contract.memory.interpretMayMaterialize).toBe(false)
@@ -89,8 +105,8 @@ describe('pinned anum_docs MTS v0.2 contract', () => {
 
   it('contains executable vectors for lexing, canonicalization and interpretation', () => {
     const { conformance } = validateMtsContractBundleV02(
-      readJson(contractUrl),
-      readJson(conformanceUrl)
+      readJson(contractPath),
+      readJson(conformancePath)
     )
 
     expect(conformance.lexing.length).toBeGreaterThan(0)

--- a/tests/unit/mtsContract.test.ts
+++ b/tests/unit/mtsContract.test.ts
@@ -1,0 +1,109 @@
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+import { validateMtsContractBundleV02 } from '../../src/core/mtsContract'
+
+const contractUrl = new URL('../../contracts/anum_docs-v0.2/mts-contract-v0.2.json', import.meta.url)
+const conformanceUrl = new URL(
+  '../../contracts/anum_docs-v0.2/mts-conformance-v0.2.json',
+  import.meta.url
+)
+const provenanceUrl = new URL('../../contracts/anum_docs-v0.2/provenance.json', import.meta.url)
+
+function readJson(url: URL): unknown {
+  return JSON.parse(readFileSync(url, 'utf8')) as unknown
+}
+
+function gitBlobSha(url: URL): string {
+  const content = readFileSync(url)
+  return createHash('sha1')
+    .update(`blob ${content.byteLength}\0`)
+    .update(content)
+    .digest('hex')
+}
+
+interface Provenance {
+  sourceRepository: string
+  sourceCommit: string
+  contract: { path: string; gitBlobSha: string }
+  conformance: { path: string; gitBlobSha: string }
+}
+
+function readProvenance(): Provenance {
+  return readJson(provenanceUrl) as Provenance
+}
+
+describe('pinned anum_docs MTS v0.2 contract', () => {
+  it('loads as one validated contract + conformance bundle', () => {
+    const bundle = validateMtsContractBundleV02(readJson(contractUrl), readJson(conformanceUrl))
+
+    expect(bundle.contract.schema).toBe('mts-contract/v0.2')
+    expect(bundle.conformance.schema).toBe('mts-conformance/v0.2')
+    expect(bundle.conformance.contract).toBe(bundle.contract.schema)
+  })
+
+  it('pins the exact upstream Git blobs rather than a manually edited fork', () => {
+    const provenance = readProvenance()
+
+    expect(provenance.sourceRepository).toBe('netkeep80/anum_docs')
+    expect(provenance.sourceCommit).toBe('294aa5e3d141e16fa93f88c0c18c4b78f8ae168c')
+    expect(gitBlobSha(contractUrl)).toBe(provenance.contract.gitBlobSha)
+    expect(gitBlobSha(conformanceUrl)).toBe(provenance.conformance.gitBlobSha)
+    expect(provenance.contract.gitBlobSha).toBe('fb414a1541f3430fa9292c0fdfd89ca07d5db8ea')
+    expect(provenance.conformance.gitBlobSha).toBe('96303366a8808d9e67ee548b445fcdbf2233f336')
+  })
+
+  it('treats the two context pronouns as atomic non-bracket code points', () => {
+    const { contract } = validateMtsContractBundleV02(readJson(contractUrl), readJson(conformanceUrl))
+    const context = contract.formalNotation.context
+
+    expect(context.atomicPronouns).toBe(true)
+    expect(context.bracketOverloading).toBe(false)
+    expect(context.roles).toEqual([
+      { source: '◁', role: 'start' },
+      { source: '▷', role: 'end' },
+    ])
+    expect(context.ancestor.operator).toBe('↑')
+    expect(context.roles.every(role => [...role.source].length === 1)).toBe(true)
+    expect(context.roles.some(role => /[\[\]]/.test(role.source))).toBe(false)
+  })
+
+  it('forbids display labels from becoming semantic identity', () => {
+    const { contract } = validateMtsContractBundleV02(readJson(contractUrl), readJson(conformanceUrl))
+
+    expect(contract.integration.displayLabelIsIdentity).toBe(false)
+    expect(contract.formalNotation.anonymousForm.identity).toBe('ast-occurrence-path')
+    expect(contract.integration.requiredRuntimeIdentities).toContain('HoleId')
+    expect(contract.integration.requiredRuntimeIdentities).toContain('LinkRef')
+  })
+
+  it('keeps interpretation read-only and realization explicit', () => {
+    const { contract } = validateMtsContractBundleV02(readJson(contractUrl), readJson(conformanceUrl))
+
+    expect(contract.formalNotation.operations.interpret.effect).toBe('none')
+    expect(contract.memory.interpretMayMaterialize).toBe(false)
+    expect(contract.memory.effectOperations).toEqual(['realize', 'delete'])
+    expect(contract.memory.readOperations).toContain('poles')
+  })
+
+  it('contains executable vectors for lexing, canonicalization and interpretation', () => {
+    const { conformance } = validateMtsContractBundleV02(
+      readJson(contractUrl),
+      readJson(conformanceUrl)
+    )
+
+    expect(conformance.lexing.length).toBeGreaterThan(0)
+    expect(conformance.canonicalization.length).toBeGreaterThan(0)
+    expect(conformance.interpretation.length).toBeGreaterThan(0)
+
+    const bracketCase = conformance.lexing.find(
+      item => item.id === 'atomic-pronouns-do-not-overload-brackets'
+    )
+    expect(bracketCase).toEqual({
+      id: 'atomic-pronouns-do-not-overload-brackets',
+      source: '◁[]▷',
+      tokens: ['context-start', 'lbracket', 'rbracket', 'context-end'],
+    })
+  })
+})


### PR DESCRIPTION
Refs #107. Depends on the accepted `anum_docs` v0.2 contract/conformance pair merged in `anum_docs#86`.

## Goal

`aprover` must stop learning MTS semantics from duplicated prose or handwritten assumptions. This PR establishes the first explicit upstream boundary:

```text
anum_docs
  mts-contract/v0.2
  mts-conformance/v0.2
        │
        ▼
aprover pinned consumer
```

## Pinned upstream artifacts

Vendored byte-for-byte for browser/offline/GitHub Pages builds:

```text
contracts/anum_docs-v0.2/mts-contract-v0.2.json
contracts/anum_docs-v0.2/mts-conformance-v0.2.json
```

`provenance.json` pins:

```text
sourceRepository = netkeep80/anum_docs
sourceCommit     = 294aa5e3d141e16fa93f88c0c18c4b78f8ae168c
Git blob SHA for each artifact
```

This is intentional vendoring, not a semantic fork.

## Tamper detection

Unit tests calculate the real Git blob SHA:

```text
sha1("blob " + byteLength + NUL + bytes)
```

for both local files and compare it to upstream provenance.

So a developer cannot silently edit the local MTS rules in `aprover`: any byte-level change fails CI unless the upstream pin is deliberately updated.

## Typed consumer boundary

Added `src/core/mtsContract.ts`:

- typed `MtsContractV02` / `MtsConformanceV02` interfaces;
- runtime bundle validation;
- exact schema/version checks;
- exactly two ordered context roles;
- one-code-point pronoun requirement;
- square-bracket exclusion from pronouns;
- `↑` context ascent;
- occurrence-local `[]` identity;
- `displayLabelIsIdentity=false`;
- `interpretMayMaterialize=false`;
- structural `LinkForm` pattern contract.

## What is tested now

TypeScript already verifies immutable upstream invariants and corpus availability:

```text
◁ / ▷ are atomic
[ ] are not context syntax
↑ is separate ascent
HoleId uses AST occurrence path
labels are not identity
interpret is read-only
conformance has lexing/canonicalization/interpretation vectors
```

## What this PR deliberately does NOT do

- does not pretend the old aprover parser already conforms;
- does not add an alternate v0.2 parser beside the old parser;
- does not rewrite prover semantics yet;
- does not weaken old tests to hide incompatibility.

Next migration PR will move the existing lexer/parser onto this pinned contract and execute the lexing/canonicalization subset of the same corpus. Once consumers move, obsolete v0.1 grammar behavior is deleted rather than retained as a compatibility language.