### PR TITLE
Перевести lexer/AST/parser aprover на canonical MTS v0.2

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -38,20 +38,21 @@ import type { ASTNode } from './core/ast'
 import type { ProverState, ProofStep } from './core/prover'
 
 const input = ref(`// МТС — Ассоциативный прувер
-// Примеры аксиом и формул
+// Синтаксис примеров соответствует canonical MTS v0.2.
+// A4-A7 ниже пока демонстрируют legacy proof semantics приложения до Phase E.
 
-// А4. Смысл (акорень): ∞ : (∞ -> ∞)
+// А4. Смысл (акорень)
 ∞ = ∞ -> ∞
 
-// А5. Самозамыкание начала: ♂x : (♂x -> x)
-♂v = ♂v -> v
+// Legacy A5 semantics через canonical end projection F♂
+v♂ = v♂ -> v
 
-// А6. Самозамыкание конца: x♀ : (x -> x♀)
-r♀ = r -> r♀
+// Legacy A6 semantics через canonical start projection ♀F
+♀r = r -> ♀r
 
-// А7. Инверсия
-!♂x = x♀
-!x♀ = ♂x
+// Legacy A7 inversion semantics
+!x♂ = ♀x
+!♀x = x♂
 
 // А11. Левоассоциативность
 a -> b -> c = (a -> b) -> c

--- a/src/core/ast.ts
+++ b/src/core/ast.ts
@@ -5,47 +5,40 @@
  * is never semantic identity: repeated forms remain separate AST occurrences.
  */
 
-/** Source location for error reporting */
 export interface SourceLocation {
   start: { line: number; column: number; offset: number }
   end: { line: number; column: number; offset: number }
 }
 
-/** Base interface for all AST nodes */
 export interface ASTNode {
   type: string
   loc?: SourceLocation
 }
 
-/** Link expression: a ⟼ b */
 export interface LinkExpr extends ASTNode {
   type: 'Link'
   left: ASTNode
   right: ASTNode
 }
 
-/** Not-link expression: a !-> b (legacy sugar for !(a -> b)) */
 export interface NotLinkExpr extends ASTNode {
   type: 'NotLink'
   left: ASTNode
   right: ASTNode
 }
 
-/** Definition expression: s : F */
 export interface DefExpr extends ASTNode {
   type: 'Definition'
   name: ASTNode
   form: ASTNode
 }
 
-/** Equality expression: A = B */
 export interface EqExpr extends ASTNode {
   type: 'Equality'
   left: ASTNode
   right: ASTNode
 }
 
-/** Inequality expression: A != B */
 export interface NeqExpr extends ASTNode {
   type: 'Inequality'
   left: ASTNode
@@ -64,55 +57,61 @@ export interface FemaleExpr extends ASTNode {
   operand: ASTNode
 }
 
-/** Negation/inversion: !x or ¬x */
 export interface NotExpr extends ASTNode {
   type: 'Not'
   operand: ASTNode
 }
 
-/** Power expression retained until old prover consumers are migrated. */
+/** Power is legacy application syntax; remove after prover consumers migrate. */
 export interface PowerExpr extends ASTNode {
   type: 'Power'
   base: ASTNode
   exponent: number
 }
 
-/** Bundle expression: { A, B, C } */
+/** Bundle expression: { A, B, C }. */
 export interface SetExpr extends ASTNode {
   type: 'Set'
   elements: ASTNode[]
 }
 
-/** Infinity/akorень: ∞ */
 export interface InfinityExpr extends ASTNode {
   type: 'Infinity'
 }
 
-/** Numeric constants: 0, 1 */
 export interface NumExpr extends ASTNode {
   type: 'Num'
   value: 0 | 1
 }
 
-/** Identifier/symbol. */
 export interface IdentExpr extends ASTNode {
   type: 'Identifier'
   name: string
 }
 
-/** Abit literal: '...' */
 export interface AbitLitExpr extends ASTNode {
   type: 'AbitLit'
   value: string
 }
 
-/** String literal: "..." */
 export interface StringLitExpr extends ASTNode {
   type: 'StringLit'
   value: string
 }
 
-/** Literal square-boundary glyph, e.g. `([)` or `(])`. */
+/** Literal operator/boundary glyph inside a formal container, e.g. (=), (⟼), ([). */
+export interface LiteralExpr extends ASTNode {
+  type: 'Literal'
+  value: string
+}
+
+/** Explicit round formal form. Parentheses are not discarded by the parser. */
+export interface RoundExpr extends ASTNode {
+  type: 'Round'
+  content: ASTNode | null
+}
+
+/** Literal square-boundary glyph, retained for old application consumers. */
 export interface BracketExpr extends ASTNode {
   type: 'Bracket'
   side: 'left' | 'right'
@@ -132,92 +131,78 @@ export interface ContextPronounExpr extends ASTNode {
   up: number
 }
 
-/** Statement wrapper used by the application file parser. */
 export interface Statement extends ASTNode {
   type: 'Statement'
   expr: ASTNode
 }
 
-/** File: sequence of statements */
 export interface File extends ASTNode {
   type: 'File'
   statements: Statement[]
 }
 
-/** Type guards */
 export function isLinkExpr(node: ASTNode): node is LinkExpr {
   return node.type === 'Link'
 }
-
 export function isNotLinkExpr(node: ASTNode): node is NotLinkExpr {
   return node.type === 'NotLink'
 }
-
 export function isDefExpr(node: ASTNode): node is DefExpr {
   return node.type === 'Definition'
 }
-
 export function isEqExpr(node: ASTNode): node is EqExpr {
   return node.type === 'Equality'
 }
-
 export function isNeqExpr(node: ASTNode): node is NeqExpr {
   return node.type === 'Inequality'
 }
-
 export function isMaleExpr(node: ASTNode): node is MaleExpr {
   return node.type === 'Male'
 }
-
 export function isFemaleExpr(node: ASTNode): node is FemaleExpr {
   return node.type === 'Female'
 }
-
 export function isNotExpr(node: ASTNode): node is NotExpr {
   return node.type === 'Not'
 }
-
 export function isPowerExpr(node: ASTNode): node is PowerExpr {
   return node.type === 'Power'
 }
-
 export function isSetExpr(node: ASTNode): node is SetExpr {
   return node.type === 'Set'
 }
-
 export function isInfinityExpr(node: ASTNode): node is InfinityExpr {
   return node.type === 'Infinity'
 }
-
 export function isNumExpr(node: ASTNode): node is NumExpr {
   return node.type === 'Num'
 }
-
 export function isIdentExpr(node: ASTNode): node is IdentExpr {
   return node.type === 'Identifier'
 }
-
 export function isAbitLitExpr(node: ASTNode): node is AbitLitExpr {
   return node.type === 'AbitLit'
 }
-
 export function isStringLitExpr(node: ASTNode): node is StringLitExpr {
   return node.type === 'StringLit'
 }
-
+export function isLiteralExpr(node: ASTNode): node is LiteralExpr {
+  return node.type === 'Literal'
+}
+export function isRoundExpr(node: ASTNode): node is RoundExpr {
+  return node.type === 'Round'
+}
 export function isBracketExpr(node: ASTNode): node is BracketExpr {
   return node.type === 'Bracket'
 }
-
 export function isSquareExpr(node: ASTNode): node is SquareExpr {
   return node.type === 'Square'
 }
-
 export function isContextPronounExpr(node: ASTNode): node is ContextPronounExpr {
   return node.type === 'ContextPronoun'
 }
 
-/** Pretty print AST node for debugging. */
+/** Human-readable structural printer; it preserves explicit containers. */
 export function astToString(node: ASTNode): string {
   switch (node.type) {
     case 'Link':
@@ -250,6 +235,12 @@ export function astToString(node: ASTNode): string {
       return `'${(node as AbitLitExpr).value}'`
     case 'StringLit':
       return `"${(node as StringLitExpr).value}"`
+    case 'Literal':
+      return (node as LiteralExpr).value
+    case 'Round': {
+      const content = (node as RoundExpr).content
+      return `(${content === null ? '' : astToString(content)})`
+    }
     case 'Bracket':
       return (node as BracketExpr).side === 'left' ? '[' : ']'
     case 'Square': {

--- a/src/core/ast.ts
+++ b/src/core/ast.ts
@@ -1,6 +1,8 @@
 /**
- * AST types for МТС (Meta-Theory of Links) formal notation
- * Based on EBNF from "МТС — Чистовик v0.1.md"
+ * AST types for the МТС formal notation consumed from anum_docs.
+ *
+ * This module is shared by parser, prover and visual projection. Display text
+ * is never semantic identity: repeated forms remain separate AST occurrences.
  */
 
 /** Source location for error reporting */
@@ -15,14 +17,14 @@ export interface ASTNode {
   loc?: SourceLocation
 }
 
-/** Link expression: a -> b */
+/** Link expression: a ⟼ b */
 export interface LinkExpr extends ASTNode {
   type: 'Link'
   left: ASTNode
   right: ASTNode
 }
 
-/** Not-link expression: a !-> b (sugar for !(a -> b)) */
+/** Not-link expression: a !-> b (legacy sugar for !(a -> b)) */
 export interface NotLinkExpr extends ASTNode {
   type: 'NotLink'
   left: ASTNode
@@ -50,13 +52,13 @@ export interface NeqExpr extends ASTNode {
   right: ASTNode
 }
 
-/** Male/self-closing start: ♂x */
+/** Glyph ♂ node. Canonical v0.2 uses it as postfix end projection F♂. */
 export interface MaleExpr extends ASTNode {
   type: 'Male'
   operand: ASTNode
 }
 
-/** Female/self-closing end: x♀ */
+/** Glyph ♀ node. Canonical v0.2 uses it as prefix start projection ♀F. */
 export interface FemaleExpr extends ASTNode {
   type: 'Female'
   operand: ASTNode
@@ -68,14 +70,14 @@ export interface NotExpr extends ASTNode {
   operand: ASTNode
 }
 
-/** Power expression: a^n */
+/** Power expression retained until old prover consumers are migrated. */
 export interface PowerExpr extends ASTNode {
   type: 'Power'
   base: ASTNode
   exponent: number
 }
 
-/** Set/package expression: { A, B, C } */
+/** Bundle expression: { A, B, C } */
 export interface SetExpr extends ASTNode {
   type: 'Set'
   elements: ASTNode[]
@@ -92,31 +94,45 @@ export interface NumExpr extends ASTNode {
   value: 0 | 1
 }
 
-/** Identifier: variable names */
+/** Identifier/symbol. */
 export interface IdentExpr extends ASTNode {
   type: 'Identifier'
   name: string
 }
 
-/** Abit literal: '...' (sequence of [, 0, 1, ] characters for quaternary abits) */
+/** Abit literal: '...' */
 export interface AbitLitExpr extends ASTNode {
   type: 'AbitLit'
   value: string
 }
 
-/** String literal: "..." (multi-character string, used for string anumbers) */
+/** String literal: "..." */
 export interface StringLitExpr extends ASTNode {
   type: 'StringLit'
   value: string
 }
 
-/** Bracket constants: [ and ] (abits) */
+/** Literal square-boundary glyph, e.g. `([)` or `(])`. */
 export interface BracketExpr extends ASTNode {
   type: 'Bracket'
   side: 'left' | 'right'
 }
 
-/** Statement: expression followed by dot */
+/** Canonical L2 square form: [], [1], [0], [...]. */
+export interface SquareExpr extends ASTNode {
+  type: 'Square'
+  content: ASTNode | null
+}
+
+/** One of exactly two atomic current/ancestor context pronouns. */
+export interface ContextPronounExpr extends ASTNode {
+  type: 'ContextPronoun'
+  pole: 'start' | 'end'
+  /** 0=current context, 1=parent, 2=grandparent, ... */
+  up: number
+}
+
+/** Statement wrapper used by the application file parser. */
 export interface Statement extends ASTNode {
   type: 'Statement'
   expr: ASTNode
@@ -193,11 +209,19 @@ export function isBracketExpr(node: ASTNode): node is BracketExpr {
   return node.type === 'Bracket'
 }
 
-/** Pretty print AST node for debugging */
+export function isSquareExpr(node: ASTNode): node is SquareExpr {
+  return node.type === 'Square'
+}
+
+export function isContextPronounExpr(node: ASTNode): node is ContextPronounExpr {
+  return node.type === 'ContextPronoun'
+}
+
+/** Pretty print AST node for debugging. */
 export function astToString(node: ASTNode): string {
   switch (node.type) {
     case 'Link':
-      return `(${astToString((node as LinkExpr).left)} -> ${astToString((node as LinkExpr).right)})`
+      return `(${astToString((node as LinkExpr).left)} ⟼ ${astToString((node as LinkExpr).right)})`
     case 'NotLink':
       return `(${astToString((node as NotLinkExpr).left)} !-> ${astToString((node as NotLinkExpr).right)})`
     case 'Definition':
@@ -207,11 +231,11 @@ export function astToString(node: ASTNode): string {
     case 'Inequality':
       return `(${astToString((node as NeqExpr).left)} != ${astToString((node as NeqExpr).right)})`
     case 'Male':
-      return `♂${astToString((node as MaleExpr).operand)}`
+      return `${astToString((node as MaleExpr).operand)}♂`
     case 'Female':
-      return `${astToString((node as FemaleExpr).operand)}♀`
+      return `♀${astToString((node as FemaleExpr).operand)}`
     case 'Not':
-      return `!${astToString((node as NotExpr).operand)}`
+      return `¬${astToString((node as NotExpr).operand)}`
     case 'Power':
       return `${astToString((node as PowerExpr).base)}^${(node as PowerExpr).exponent}`
     case 'Set':
@@ -228,6 +252,14 @@ export function astToString(node: ASTNode): string {
       return `"${(node as StringLitExpr).value}"`
     case 'Bracket':
       return (node as BracketExpr).side === 'left' ? '[' : ']'
+    case 'Square': {
+      const content = (node as SquareExpr).content
+      return `[${content === null ? '' : astToString(content)}]`
+    }
+    case 'ContextPronoun': {
+      const pronoun = node as ContextPronounExpr
+      return `${'↑'.repeat(pronoun.up)}${pronoun.pole === 'start' ? '◁' : '▷'}`
+    }
     case 'Statement':
       return `${astToString((node as Statement).expr)}.`
     case 'File':

--- a/src/core/lexer.ts
+++ b/src/core/lexer.ts
@@ -1,22 +1,28 @@
 /**
- * Lexer for МТС (Meta-Theory of Links) formal notation
- * Based on EBNF from "МТС — Чистовик v0.1.md"
+ * Lexer for the canonical МТС formal notation consumed from anum_docs.
+ *
+ * The lexer stays deliberately context-free: square brackets are always
+ * emitted as square-bracket tokens and never acquire special meaning from a
+ * neighbouring pronoun. This is required by mts-contract/v0.2.
  */
 
 import type { SourceLocation } from './ast'
 
 /** Token types */
 export type TokenType =
-  | 'ARROW' // ->
+  | 'ARROW' // ⟼ | ->
   | 'NOT_ARROW' // !->
   | 'DEFINE' // :
   | 'EQUAL' // =
   | 'NOT_EQUAL' // != | ≠ | ¬=
-  | 'MALE' // ♂
-  | 'FEMALE' // ♀
+  | 'MALE' // ♂ (legacy name; parser semantics is migrated separately)
+  | 'FEMALE' // ♀ (legacy name; parser semantics is migrated separately)
   | 'NOT' // ! | ¬
   | 'POWER' // ^
   | 'INFINITY' // ∞
+  | 'CONTEXT_START' // ◁
+  | 'CONTEXT_END' // ▷
+  | 'CONTEXT_UP' // ↑
   | 'ZERO' // 0
   | 'ONE' // 1
   | 'LPAREN' // (
@@ -38,6 +44,32 @@ export interface Token {
   type: TokenType
   value: string
   loc: SourceLocation
+}
+
+/** Names used by the upstream mts-conformance/v0.2 lexing vectors. */
+export type MtsConformanceToken =
+  | 'context-start'
+  | 'context-end'
+  | 'context-up'
+  | 'lbracket'
+  | 'rbracket'
+
+/** Map lexical primitives that are explicitly named by the upstream corpus. */
+export function toMtsConformanceToken(token: Token): MtsConformanceToken | null {
+  switch (token.type) {
+    case 'CONTEXT_START':
+      return 'context-start'
+    case 'CONTEXT_END':
+      return 'context-end'
+    case 'CONTEXT_UP':
+      return 'context-up'
+    case 'LBRACKET':
+      return 'lbracket'
+    case 'RBRACKET':
+      return 'rbracket'
+    default:
+      return null
+  }
 }
 
 /** Lexer error */
@@ -64,17 +96,14 @@ export class Lexer {
     this.input = input
   }
 
-  /** Get current character */
   private current(): string {
     return this.input[this.pos] || ''
   }
 
-  /** Peek ahead n characters */
   private peek(n: number = 1): string {
     return this.input[this.pos + n] || ''
   }
 
-  /** Advance position by n characters */
   private advance(n: number = 1): void {
     for (let i = 0; i < n; i++) {
       if (this.current() === '\n') {
@@ -87,20 +116,16 @@ export class Lexer {
     }
   }
 
-  /** Check if at end of input */
   private isEOF(): boolean {
     return this.pos >= this.input.length
   }
 
-  /** Skip whitespace and comments */
   private skipWhitespaceAndComments(): void {
     while (!this.isEOF()) {
-      // Skip whitespace
       if (/\s/.test(this.current())) {
         this.advance()
         continue
       }
-      // Skip line comments: // ...
       if (this.current() === '/' && this.peek() === '/') {
         while (!this.isEOF() && this.current() !== '\n') {
           this.advance()
@@ -111,7 +136,6 @@ export class Lexer {
     }
   }
 
-  /** Create source location */
   private makeLoc(startLine: number, startColumn: number, startOffset: number): SourceLocation {
     return {
       start: { line: startLine, column: startColumn, offset: startOffset },
@@ -119,22 +143,18 @@ export class Lexer {
     }
   }
 
-  /** Check if character is start of identifier */
   private isIdStart(c: string): boolean {
     return /[a-zA-Zа-яА-ЯёЁ_]/.test(c)
   }
 
-  /** Check if character can continue identifier */
   private isIdContinue(c: string): boolean {
     return /[a-zA-Zа-яА-ЯёЁ0-9_]/.test(c)
   }
 
-  /** Check if character is digit */
   private isDigit(c: string): boolean {
     return /[0-9]/.test(c)
   }
 
-  /** Read identifier */
   private readIdentifier(): string {
     let result = ''
     while (!this.isEOF() && this.isIdContinue(this.current())) {
@@ -144,7 +164,6 @@ export class Lexer {
     return result
   }
 
-  /** Read natural number */
   private readNumber(): string {
     let result = ''
     while (!this.isEOF() && this.isDigit(this.current())) {
@@ -154,14 +173,12 @@ export class Lexer {
     return result
   }
 
-  /** Check if character is valid abit character: [, 0, 1, ] */
   private isAbitChar(c: string): boolean {
     return c === '[' || c === '0' || c === '1' || c === ']'
   }
 
-  /** Read abit literal (sequence of [, 0, 1, ] characters in single quotes) */
   private readAbitLit(): string {
-    this.advance() // skip opening '
+    this.advance()
     let result = ''
     while (!this.isEOF() && this.current() !== "'") {
       const c = this.current()
@@ -182,16 +199,14 @@ export class Lexer {
     if (result.length === 0) {
       throw new LexerError('Empty abit literal', this.line, this.column, this.pos)
     }
-    this.advance() // skip closing '
+    this.advance()
     return result
   }
 
-  /** Read string literal (multiple characters in double quotes) */
   private readStringLit(): string {
-    this.advance() // skip opening "
+    this.advance()
     let result = ''
     while (!this.isEOF() && this.current() !== '"') {
-      // Handle escape sequences
       if (this.current() === '\\') {
         this.advance()
         if (this.isEOF()) {
@@ -215,7 +230,6 @@ export class Lexer {
             result += '"'
             break
           default:
-            // For unknown escape sequences, just include the character as-is
             result += escaped
         }
       } else {
@@ -226,11 +240,10 @@ export class Lexer {
     if (this.isEOF()) {
       throw new LexerError('Unterminated string literal', this.line, this.column, this.pos)
     }
-    this.advance() // skip closing "
+    this.advance()
     return result
   }
 
-  /** Get next token */
   nextToken(): Token {
     this.skipWhitespaceAndComments()
 
@@ -247,7 +260,6 @@ export class Lexer {
     const startOffset = this.pos
     const c = this.current()
 
-    // Multi-character tokens: check !-> before ! and !=
     if (c === '!' && this.peek() === '-' && this.peek(2) === '>') {
       this.advance(3)
       return {
@@ -280,8 +292,31 @@ export class Lexer {
       }
     }
 
-    // Single character tokens
     switch (c) {
+      case '⟼':
+        this.advance()
+        return { type: 'ARROW', value: '⟼', loc: this.makeLoc(startLine, startColumn, startOffset) }
+      case '◁':
+        this.advance()
+        return {
+          type: 'CONTEXT_START',
+          value: '◁',
+          loc: this.makeLoc(startLine, startColumn, startOffset),
+        }
+      case '▷':
+        this.advance()
+        return {
+          type: 'CONTEXT_END',
+          value: '▷',
+          loc: this.makeLoc(startLine, startColumn, startOffset),
+        }
+      case '↑':
+        this.advance()
+        return {
+          type: 'CONTEXT_UP',
+          value: '↑',
+          loc: this.makeLoc(startLine, startColumn, startOffset),
+        }
       case ':':
         this.advance()
         return {
@@ -373,23 +408,24 @@ export class Lexer {
       case '.':
         this.advance()
         return { type: 'DOT', value: '.', loc: this.makeLoc(startLine, startColumn, startOffset) }
-      case "'":
+      case "'": {
         const abit = this.readAbitLit()
         return {
           type: 'ABIT_LIT',
           value: abit,
           loc: this.makeLoc(startLine, startColumn, startOffset),
         }
-      case '"':
+      }
+      case '"': {
         const str = this.readStringLit()
         return {
           type: 'STRING_LIT',
           value: str,
           loc: this.makeLoc(startLine, startColumn, startOffset),
         }
+      }
     }
 
-    // Numbers: 0 and 1 are special constants, larger numbers are NAT
     if (this.isDigit(c)) {
       const num = this.readNumber()
       if (num === '0') {
@@ -401,7 +437,6 @@ export class Lexer {
       return { type: 'NAT', value: num, loc: this.makeLoc(startLine, startColumn, startOffset) }
     }
 
-    // Identifiers
     if (this.isIdStart(c)) {
       const id = this.readIdentifier()
       return { type: 'ID', value: id, loc: this.makeLoc(startLine, startColumn, startOffset) }
@@ -410,7 +445,6 @@ export class Lexer {
     throw new LexerError(`Unexpected character: ${c}`, this.line, this.column, this.pos)
   }
 
-  /** Tokenize entire input */
   tokenize(): Token[] {
     const tokens: Token[] = []
     while (true) {
@@ -422,7 +456,6 @@ export class Lexer {
   }
 }
 
-/** Convenience function to tokenize a string */
 export function tokenize(input: string): Token[] {
   return new Lexer(input).tokenize()
 }

--- a/src/core/lexer.ts
+++ b/src/core/lexer.ts
@@ -8,45 +8,42 @@
 
 import type { SourceLocation } from './ast'
 
-/** Token types */
 export type TokenType =
-  | 'ARROW' // ⟼ | ->
-  | 'NOT_ARROW' // !->
-  | 'DEFINE' // :
-  | 'EQUAL' // =
-  | 'NOT_EQUAL' // != | ≠ | ¬=
-  | 'MALE' // ♂ (legacy name; parser semantics is migrated separately)
-  | 'FEMALE' // ♀ (legacy name; parser semantics is migrated separately)
-  | 'NOT' // ! | ¬
-  | 'POWER' // ^
-  | 'INFINITY' // ∞
-  | 'CONTEXT_START' // ◁
-  | 'CONTEXT_END' // ▷
-  | 'CONTEXT_UP' // ↑
-  | 'ZERO' // 0
-  | 'ONE' // 1
-  | 'LPAREN' // (
-  | 'RPAREN' // )
-  | 'LBRACE' // {
-  | 'RBRACE' // }
-  | 'LBRACKET' // [
-  | 'RBRACKET' // ]
-  | 'COMMA' // ,
-  | 'DOT' // .
-  | 'ABIT_LIT' // '...' (abit sequence: only [, 0, 1, ] characters)
-  | 'STRING_LIT' // "..." (string for string anumbers - UTF-8)
-  | 'ID' // identifier
-  | 'NAT' // natural number
+  | 'ARROW'
+  | 'NOT_ARROW'
+  | 'DEFINE'
+  | 'EQUAL'
+  | 'NOT_EQUAL'
+  | 'MALE'
+  | 'FEMALE'
+  | 'NOT'
+  | 'POWER'
+  | 'INFINITY'
+  | 'CONTEXT_START'
+  | 'CONTEXT_END'
+  | 'CONTEXT_UP'
+  | 'ZERO'
+  | 'ONE'
+  | 'LPAREN'
+  | 'RPAREN'
+  | 'LBRACE'
+  | 'RBRACE'
+  | 'LBRACKET'
+  | 'RBRACKET'
+  | 'COMMA'
+  | 'DOT'
+  | 'ABIT_LIT'
+  | 'STRING_LIT'
+  | 'ID'
+  | 'NAT'
   | 'EOF'
 
-/** Token structure */
 export interface Token {
   type: TokenType
   value: string
   loc: SourceLocation
 }
 
-/** Names used by the upstream mts-conformance/v0.2 lexing vectors. */
 export type MtsConformanceToken =
   | 'context-start'
   | 'context-end'
@@ -54,7 +51,6 @@ export type MtsConformanceToken =
   | 'lbracket'
   | 'rbracket'
 
-/** Map lexical primitives that are explicitly named by the upstream corpus. */
 export function toMtsConformanceToken(token: Token): MtsConformanceToken | null {
   switch (token.type) {
     case 'CONTEXT_START':
@@ -72,7 +68,6 @@ export function toMtsConformanceToken(token: Token): MtsConformanceToken | null 
   }
 }
 
-/** Lexer error */
 export class LexerError extends Error {
   constructor(
     message: string,
@@ -85,7 +80,6 @@ export class LexerError extends Error {
   }
 }
 
-/** Lexer class */
 export class Lexer {
   private input: string
   private pos: number = 0
@@ -127,9 +121,7 @@ export class Lexer {
         continue
       }
       if (this.current() === '/' && this.peek() === '/') {
-        while (!this.isEOF() && this.current() !== '\n') {
-          this.advance()
-        }
+        while (!this.isEOF() && this.current() !== '\n') this.advance()
         continue
       }
       break
@@ -193,12 +185,8 @@ export class Lexer {
       result += c
       this.advance()
     }
-    if (this.isEOF()) {
-      throw new LexerError('Unterminated abit literal', this.line, this.column, this.pos)
-    }
-    if (result.length === 0) {
-      throw new LexerError('Empty abit literal', this.line, this.column, this.pos)
-    }
+    if (this.isEOF()) throw new LexerError('Unterminated abit literal', this.line, this.column, this.pos)
+    if (result.length === 0) throw new LexerError('Empty abit literal', this.line, this.column, this.pos)
     this.advance()
     return result
   }
@@ -209,50 +197,30 @@ export class Lexer {
     while (!this.isEOF() && this.current() !== '"') {
       if (this.current() === '\\') {
         this.advance()
-        if (this.isEOF()) {
-          throw new LexerError('Unterminated string literal', this.line, this.column, this.pos)
-        }
+        if (this.isEOF()) throw new LexerError('Unterminated string literal', this.line, this.column, this.pos)
         const escaped = this.current()
         switch (escaped) {
-          case 'n':
-            result += '\n'
-            break
-          case 't':
-            result += '\t'
-            break
-          case 'r':
-            result += '\r'
-            break
-          case '\\':
-            result += '\\'
-            break
-          case '"':
-            result += '"'
-            break
-          default:
-            result += escaped
+          case 'n': result += '\n'; break
+          case 't': result += '\t'; break
+          case 'r': result += '\r'; break
+          case '\\': result += '\\'; break
+          case '"': result += '"'; break
+          default: result += escaped
         }
       } else {
         result += this.current()
       }
       this.advance()
     }
-    if (this.isEOF()) {
-      throw new LexerError('Unterminated string literal', this.line, this.column, this.pos)
-    }
+    if (this.isEOF()) throw new LexerError('Unterminated string literal', this.line, this.column, this.pos)
     this.advance()
     return result
   }
 
   nextToken(): Token {
     this.skipWhitespaceAndComments()
-
     if (this.isEOF()) {
-      return {
-        type: 'EOF',
-        value: '',
-        loc: this.makeLoc(this.line, this.column, this.pos),
-      }
+      return { type: 'EOF', value: '', loc: this.makeLoc(this.line, this.column, this.pos) }
     }
 
     const startLine = this.line
@@ -262,178 +230,46 @@ export class Lexer {
 
     if (c === '!' && this.peek() === '-' && this.peek(2) === '>') {
       this.advance(3)
-      return {
-        type: 'NOT_ARROW',
-        value: '!->',
-        loc: this.makeLoc(startLine, startColumn, startOffset),
-      }
+      return { type: 'NOT_ARROW', value: '!->', loc: this.makeLoc(startLine, startColumn, startOffset) }
     }
-
     if (c === '!' && this.peek() === '=') {
       this.advance(2)
-      return {
-        type: 'NOT_EQUAL',
-        value: '!=',
-        loc: this.makeLoc(startLine, startColumn, startOffset),
-      }
+      return { type: 'NOT_EQUAL', value: '!=', loc: this.makeLoc(startLine, startColumn, startOffset) }
     }
-
     if (c === '-' && this.peek() === '>') {
       this.advance(2)
       return { type: 'ARROW', value: '->', loc: this.makeLoc(startLine, startColumn, startOffset) }
     }
-
     if (c === '¬' && this.peek() === '=') {
       this.advance(2)
-      return {
-        type: 'NOT_EQUAL',
-        value: '¬=',
-        loc: this.makeLoc(startLine, startColumn, startOffset),
-      }
+      return { type: 'NOT_EQUAL', value: '¬=', loc: this.makeLoc(startLine, startColumn, startOffset) }
     }
 
-    switch (c) {
-      case '⟼':
-        this.advance()
-        return { type: 'ARROW', value: '⟼', loc: this.makeLoc(startLine, startColumn, startOffset) }
-      case '◁':
-        this.advance()
-        return {
-          type: 'CONTEXT_START',
-          value: '◁',
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      case '▷':
-        this.advance()
-        return {
-          type: 'CONTEXT_END',
-          value: '▷',
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      case '↑':
-        this.advance()
-        return {
-          type: 'CONTEXT_UP',
-          value: '↑',
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      case ':':
-        this.advance()
-        return {
-          type: 'DEFINE',
-          value: ':',
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      case '=':
-        this.advance()
-        return { type: 'EQUAL', value: '=', loc: this.makeLoc(startLine, startColumn, startOffset) }
-      case '≠':
-        this.advance()
-        return {
-          type: 'NOT_EQUAL',
-          value: '≠',
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      case '♂':
-        this.advance()
-        return { type: 'MALE', value: '♂', loc: this.makeLoc(startLine, startColumn, startOffset) }
-      case '♀':
-        this.advance()
-        return {
-          type: 'FEMALE',
-          value: '♀',
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      case '!':
-        this.advance()
-        return { type: 'NOT', value: '!', loc: this.makeLoc(startLine, startColumn, startOffset) }
-      case '¬':
-        this.advance()
-        return { type: 'NOT', value: '¬', loc: this.makeLoc(startLine, startColumn, startOffset) }
-      case '^':
-        this.advance()
-        return { type: 'POWER', value: '^', loc: this.makeLoc(startLine, startColumn, startOffset) }
-      case '∞':
-        this.advance()
-        return {
-          type: 'INFINITY',
-          value: '∞',
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      case '(':
-        this.advance()
-        return {
-          type: 'LPAREN',
-          value: '(',
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      case ')':
-        this.advance()
-        return {
-          type: 'RPAREN',
-          value: ')',
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      case '{':
-        this.advance()
-        return {
-          type: 'LBRACE',
-          value: '{',
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      case '}':
-        this.advance()
-        return {
-          type: 'RBRACE',
-          value: '}',
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      case '[':
-        this.advance()
-        return {
-          type: 'LBRACKET',
-          value: '[',
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      case ']':
-        this.advance()
-        return {
-          type: 'RBRACKET',
-          value: ']',
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      case ',':
-        this.advance()
-        return { type: 'COMMA', value: ',', loc: this.makeLoc(startLine, startColumn, startOffset) }
-      case '.':
-        this.advance()
-        return { type: 'DOT', value: '.', loc: this.makeLoc(startLine, startColumn, startOffset) }
-      case "'": {
-        const abit = this.readAbitLit()
-        return {
-          type: 'ABIT_LIT',
-          value: abit,
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      }
-      case '"': {
-        const str = this.readStringLit()
-        return {
-          type: 'STRING_LIT',
-          value: str,
-          loc: this.makeLoc(startLine, startColumn, startOffset),
-        }
-      }
+    const single: Partial<Record<string, TokenType>> = {
+      '⟼': 'ARROW', '↛': 'NOT_ARROW', '◁': 'CONTEXT_START', '▷': 'CONTEXT_END', '↑': 'CONTEXT_UP',
+      ':': 'DEFINE', '=': 'EQUAL', '≠': 'NOT_EQUAL', '♂': 'MALE', '♀': 'FEMALE', '!': 'NOT', '¬': 'NOT',
+      '^': 'POWER', '∞': 'INFINITY', '(': 'LPAREN', ')': 'RPAREN', '{': 'LBRACE', '}': 'RBRACE',
+      '[': 'LBRACKET', ']': 'RBRACKET', ',': 'COMMA', '.': 'DOT'
+    }
+    const tokenType = single[c]
+    if (tokenType) {
+      this.advance()
+      return { type: tokenType, value: c, loc: this.makeLoc(startLine, startColumn, startOffset) }
+    }
+
+    if (c === "'") {
+      const value = this.readAbitLit()
+      return { type: 'ABIT_LIT', value, loc: this.makeLoc(startLine, startColumn, startOffset) }
+    }
+    if (c === '"') {
+      const value = this.readStringLit()
+      return { type: 'STRING_LIT', value, loc: this.makeLoc(startLine, startColumn, startOffset) }
     }
 
     if (this.isDigit(c)) {
       const num = this.readNumber()
-      if (num === '0') {
-        return { type: 'ZERO', value: '0', loc: this.makeLoc(startLine, startColumn, startOffset) }
-      }
-      if (num === '1') {
-        return { type: 'ONE', value: '1', loc: this.makeLoc(startLine, startColumn, startOffset) }
-      }
+      if (num === '0') return { type: 'ZERO', value: '0', loc: this.makeLoc(startLine, startColumn, startOffset) }
+      if (num === '1') return { type: 'ONE', value: '1', loc: this.makeLoc(startLine, startColumn, startOffset) }
       return { type: 'NAT', value: num, loc: this.makeLoc(startLine, startColumn, startOffset) }
     }
 

--- a/src/core/linkGraph.ts
+++ b/src/core/linkGraph.ts
@@ -139,7 +139,7 @@ function projectNode(node: ASTNode, state: GraphBuilderState): string {
     const centerId = createNode(
       state,
       'male',
-      `♂${getNodeLabel(node.operand)}`,
+      astToString(node),
       'unary',
       node
     )
@@ -154,7 +154,7 @@ function projectNode(node: ASTNode, state: GraphBuilderState): string {
     const centerId = createNode(
       state,
       'female',
-      `${getNodeLabel(node.operand)}♀`,
+      astToString(node),
       'unary',
       node
     )

--- a/src/core/mtsSource.ts
+++ b/src/core/mtsSource.ts
@@ -1,0 +1,164 @@
+import type {
+  ASTNode,
+  LinkExpr,
+  NotLinkExpr,
+  DefExpr,
+  EqExpr,
+  NeqExpr,
+  MaleExpr,
+  FemaleExpr,
+  NotExpr,
+  PowerExpr,
+  SetExpr,
+  NumExpr,
+  IdentExpr,
+  AbitLitExpr,
+  StringLitExpr,
+  LiteralExpr,
+  RoundExpr,
+  BracketExpr,
+  SquareExpr,
+  ContextPronounExpr,
+} from './ast'
+
+const PRECEDENCE = {
+  definition: 1,
+  equality: 2,
+  link: 3,
+  prefix: 4,
+  postfix: 5,
+  atom: 6,
+} as const
+
+function render(node: ASTNode, parentPrecedence = 0, rightOfLeftAssociative = false): string {
+  let text: string
+  let precedence: number
+
+  switch (node.type) {
+    case 'Definition': {
+      const definition = node as DefExpr
+      text = `${render(definition.name, PRECEDENCE.definition)} : ${render(definition.form, PRECEDENCE.definition)}`
+      precedence = PRECEDENCE.definition
+      break
+    }
+    case 'Equality': {
+      const equality = node as EqExpr
+      text = `${render(equality.left, PRECEDENCE.equality)} = ${render(equality.right, PRECEDENCE.equality)}`
+      precedence = PRECEDENCE.equality
+      break
+    }
+    case 'Inequality': {
+      const inequality = node as NeqExpr
+      text = `${render(inequality.left, PRECEDENCE.equality)} != ${render(inequality.right, PRECEDENCE.equality)}`
+      precedence = PRECEDENCE.equality
+      break
+    }
+    case 'Link': {
+      const link = node as LinkExpr
+      text = `${render(link.left, PRECEDENCE.link)} ⟼ ${render(link.right, PRECEDENCE.link, true)}`
+      precedence = PRECEDENCE.link
+      break
+    }
+    case 'NotLink': {
+      const link = node as NotLinkExpr
+      text = `${render(link.left, PRECEDENCE.link)} ↛ ${render(link.right, PRECEDENCE.link, true)}`
+      precedence = PRECEDENCE.link
+      break
+    }
+    case 'Not': {
+      const expression = node as NotExpr
+      text = `¬${render(expression.operand, PRECEDENCE.prefix)}`
+      precedence = PRECEDENCE.prefix
+      break
+    }
+    case 'Female': {
+      const expression = node as FemaleExpr
+      text = `♀${render(expression.operand, PRECEDENCE.prefix)}`
+      precedence = PRECEDENCE.prefix
+      break
+    }
+    case 'Male': {
+      const expression = node as MaleExpr
+      text = `${render(expression.operand, PRECEDENCE.postfix)}♂`
+      precedence = PRECEDENCE.postfix
+      break
+    }
+    case 'Power': {
+      const expression = node as PowerExpr
+      text = `${render(expression.base, PRECEDENCE.postfix)}^${expression.exponent}`
+      precedence = PRECEDENCE.postfix
+      break
+    }
+    case 'Set': {
+      const set = node as SetExpr
+      text = `{${set.elements.map(element => render(element)).join(', ')}}`
+      precedence = PRECEDENCE.atom
+      break
+    }
+    case 'Round': {
+      const round = node as RoundExpr
+      text = `(${round.content === null ? '' : render(round.content)})`
+      precedence = PRECEDENCE.atom
+      break
+    }
+    case 'Square': {
+      const square = node as SquareExpr
+      text = `[${square.content === null ? '' : render(square.content)}]`
+      precedence = PRECEDENCE.atom
+      break
+    }
+    case 'ContextPronoun': {
+      const pronoun = node as ContextPronounExpr
+      text = `${'↑'.repeat(pronoun.up)}${pronoun.pole === 'start' ? '◁' : '▷'}`
+      precedence = PRECEDENCE.atom
+      break
+    }
+    case 'Literal':
+      text = (node as LiteralExpr).value
+      precedence = PRECEDENCE.atom
+      break
+    case 'Infinity':
+      text = '∞'
+      precedence = PRECEDENCE.atom
+      break
+    case 'Num':
+      text = String((node as NumExpr).value)
+      precedence = PRECEDENCE.atom
+      break
+    case 'Identifier':
+      text = (node as IdentExpr).name
+      precedence = PRECEDENCE.atom
+      break
+    case 'AbitLit':
+      text = `'${(node as AbitLitExpr).value}'`
+      precedence = PRECEDENCE.atom
+      break
+    case 'StringLit':
+      text = `"${(node as StringLitExpr).value}"`
+      precedence = PRECEDENCE.atom
+      break
+    case 'Bracket':
+      text = (node as BracketExpr).side === 'left' ? '[' : ']'
+      precedence = PRECEDENCE.atom
+      break
+    default:
+      throw new Error(`Cannot format unsupported AST node type: ${node.type}`)
+  }
+
+  const needsParentheses =
+    precedence < parentPrecedence ||
+    (rightOfLeftAssociative && precedence === PRECEDENCE.link)
+
+  return needsParentheses ? `(${text})` : text
+}
+
+/**
+ * Serialize one canonical MTS v0.2 AST expression back to formal source.
+ *
+ * This is a syntax formatter only. It preserves explicit Round/Square forms,
+ * canonical projection fixity (`♀F`, `F♂`) and bundle order; it does not
+ * normalize or interpret the expression.
+ */
+export function toMtsSource(node: ASTNode): string {
+  return render(node)
+}

--- a/src/core/normalizer.ts
+++ b/src/core/normalizer.ts
@@ -1,18 +1,10 @@
 /**
- * Normalizer for МТС (Meta-Theory of Links) AST
+ * Normalizer for the МТС AST consumed from anum_docs.
  *
- * Transformations:
- * 1. Desugaring:
- *    - a !-> b → !(a -> b)
- *    - a^n → (...((a -> a) -> a) ... -> a) (n times)
- *
- * 2. Canonical form:
- *    - !!x → x (double negation elimination)
- *    - !(♂x) → x♀ (inversion duality)
- *    - !(x♀) → ♂x (inversion duality)
- *
- * 3. Well-formedness checks:
- *    - Guarded recursion: recursive mentions allowed only under ->
+ * The parser preserves explicit L2 containers for round-trip/visual identity.
+ * Semantic normalization follows the upstream interpreter boundary:
+ * parentheses are transparent grouping, while square forms, literals and
+ * context pronouns remain first-class structures.
  */
 
 import type { ASTNode, DefExpr, Statement, File } from './ast'
@@ -32,87 +24,56 @@ import {
   isIdentExpr,
   isAbitLitExpr,
   isStringLitExpr,
+  isLiteralExpr,
+  isRoundExpr,
   isBracketExpr,
+  isSquareExpr,
+  isContextPronounExpr,
 } from './ast'
 import { makeLink, makeNot, makeMale, makeFemale } from './astHelpers'
 
-/**
- * Cache for normalization results.
- * Uses canonical string representation of AST as key.
- *
- * Performance optimization for:
- * - Large expressions with repeated subexpressions
- * - Multiple verification passes over the same input
- */
 class NormalizationCache {
   private cache: Map<string, ASTNode> = new Map()
   private maxSize: number
-  private hits: number = 0
-  private misses: number = 0
-  private enabled: boolean = true
+  private hits = 0
+  private misses = 0
+  private enabled = true
 
   constructor(maxSize: number = 1000) {
     this.maxSize = maxSize
   }
 
-  /**
-   * Enable or disable caching
-   */
   setEnabled(enabled: boolean): void {
     this.enabled = enabled
   }
 
-  /**
-   * Check if caching is enabled
-   */
   isEnabled(): boolean {
     return this.enabled
   }
 
-  /**
-   * Get cached result for a canonical string key
-   */
   get(key: string): ASTNode | undefined {
     if (!this.enabled) return undefined
-
     const result = this.cache.get(key)
-    if (result) {
-      this.hits++
-    } else {
-      this.misses++
-    }
+    if (result) this.hits++
+    else this.misses++
     return result
   }
 
-  /**
-   * Store normalized result in cache
-   */
   set(key: string, value: ASTNode): void {
     if (!this.enabled) return
-
-    // Evict oldest entries if cache is full (simple LRU approximation)
     if (this.cache.size >= this.maxSize) {
       const firstKey = this.cache.keys().next().value
-      if (firstKey) {
-        this.cache.delete(firstKey)
-      }
+      if (firstKey) this.cache.delete(firstKey)
     }
-
     this.cache.set(key, value)
   }
 
-  /**
-   * Clear all cached entries
-   */
   clear(): void {
     this.cache.clear()
     this.hits = 0
     this.misses = 0
   }
 
-  /**
-   * Get cache statistics
-   */
   getStats(): { size: number; hits: number; misses: number; hitRate: number } {
     const total = this.hits + this.misses
     return {
@@ -124,34 +85,20 @@ class NormalizationCache {
   }
 }
 
-/** Global normalization cache instance */
 const normalizationCache = new NormalizationCache()
 
-/**
- * Get the global normalization cache instance
- * Useful for statistics and cache management
- */
 export function getNormalizationCache(): NormalizationCache {
   return normalizationCache
 }
 
-/**
- * Clear the normalization cache
- */
 export function clearNormalizationCache(): void {
   normalizationCache.clear()
 }
 
-/**
- * Enable or disable normalization caching
- */
 export function setNormalizationCacheEnabled(enabled: boolean): void {
   normalizationCache.setEnabled(enabled)
 }
 
-/**
- * Get normalization cache statistics
- */
 export function getNormalizationCacheStats(): {
   size: number
   hits: number
@@ -161,7 +108,6 @@ export function getNormalizationCacheStats(): {
   return normalizationCache.getStats()
 }
 
-/** Normalization error */
 export class NormalizationError extends Error {
   constructor(
     message: string,
@@ -174,15 +120,10 @@ export class NormalizationError extends Error {
   }
 }
 
-/** Normalizer options */
 export interface NormalizerOptions {
-  /** Desugar !-> to !(a -> b) */
   desugarNotLink?: boolean
-  /** Expand power operator */
   expandPower?: boolean
-  /** Apply canonical form rules */
   canonicalize?: boolean
-  /** Check guarded recursion */
   checkGuardedRecursion?: boolean
 }
 
@@ -193,25 +134,15 @@ const defaultOptions: NormalizerOptions = {
   checkGuardedRecursion: true,
 }
 
-/** Deep clone AST node */
 function cloneNode<T extends ASTNode>(node: T): T {
   return JSON.parse(JSON.stringify(node))
 }
 
-/**
- * Expand power: a^n → (...((a -> a) -> a) ... -> a)
- * a^1 = a
- * a^2 = (a -> a)
- * a^3 = ((a -> a) -> a)
- * a^n = (a^(n-1) -> a)
- */
 function expandPower(base: ASTNode, exponent: number): ASTNode {
   if (exponent < 1) {
     throw new NormalizationError('Power exponent must be >= 1', base)
   }
-  if (exponent === 1) {
-    return cloneNode(base)
-  }
+  if (exponent === 1) return cloneNode(base)
 
   let result = makeLink(cloneNode(base), cloneNode(base))
   for (let i = 3; i <= exponent; i++) {
@@ -220,57 +151,36 @@ function expandPower(base: ASTNode, exponent: number): ASTNode {
   return result
 }
 
-/**
- * Check if identifier appears in node (for guarded recursion check)
- */
 function containsIdent(node: ASTNode, name: string, guarded: boolean): boolean {
-  if (isIdentExpr(node)) {
-    if (node.name === name && !guarded) {
-      return true
-    }
-    return false
+  if (isRoundExpr(node)) {
+    return node.content === null ? false : containsIdent(node.content, name, guarded)
   }
-
+  if (isSquareExpr(node)) {
+    return node.content === null ? false : containsIdent(node.content, name, guarded)
+  }
+  if (isIdentExpr(node)) return node.name === name && !guarded
   if (isLinkExpr(node)) {
-    // Under -> the recursion becomes guarded
     return containsIdent(node.left, name, true) || containsIdent(node.right, name, true)
   }
-
   if (isNotLinkExpr(node)) {
     return containsIdent(node.left, name, guarded) || containsIdent(node.right, name, guarded)
   }
-
   if (isMaleExpr(node) || isFemaleExpr(node) || isNotExpr(node)) {
     return containsIdent(node.operand, name, guarded)
   }
-
-  if (isPowerExpr(node)) {
-    return containsIdent(node.base, name, guarded)
-  }
-
-  if (isSetExpr(node)) {
-    return node.elements.some(el => containsIdent(el, name, guarded))
-  }
-
+  if (isPowerExpr(node)) return containsIdent(node.base, name, guarded)
+  if (isSetExpr(node)) return node.elements.some(el => containsIdent(el, name, guarded))
   if (isDefExpr(node)) {
     return containsIdent(node.name, name, guarded) || containsIdent(node.form, name, guarded)
   }
-
   if (isEqExpr(node) || isNeqExpr(node)) {
     return containsIdent(node.left, name, guarded) || containsIdent(node.right, name, guarded)
   }
-
   return false
 }
 
-/**
- * Check guarded recursion in definition
- */
 function checkGuardedRecursion(def: DefExpr): void {
-  if (!isIdentExpr(def.name)) {
-    return // Only check simple identifier definitions
-  }
-
+  if (!isIdentExpr(def.name)) return
   const name = def.name.name
   if (containsIdent(def.form, name, false)) {
     throw new NormalizationError(
@@ -280,24 +190,34 @@ function checkGuardedRecursion(def: DefExpr): void {
   }
 }
 
-/**
- * Normalize a single node
- */
 function normalizeNode(node: ASTNode, options: NormalizerOptions): ASTNode {
-  // First, recursively normalize children
   let normalized: ASTNode
 
-  if (isLinkExpr(node)) {
+  if (isRoundExpr(node)) {
+    if (node.content === null) {
+      // Empty () is a genuine formal atom, not grouping that can be erased.
+      normalized = node
+    } else {
+      // Upstream mtc_interpreter._unwrap_round(): explicit parentheses are
+      // retained by parser but transparent to semantic matching.
+      normalized = normalizeNode(node.content, options)
+    }
+  } else if (isSquareExpr(node)) {
+    normalized = {
+      ...node,
+      content: node.content === null ? null : normalizeNode(node.content, options),
+    }
+  } else if (isLinkExpr(node)) {
     normalized = {
       ...node,
       left: normalizeNode(node.left, options),
       right: normalizeNode(node.right, options),
     }
   } else if (isNotLinkExpr(node)) {
-    // Desugar: a !-> b → !(a -> b)
     if (options.desugarNotLink) {
-      const link = makeLink(normalizeNode(node.left, options), normalizeNode(node.right, options))
-      normalized = makeNot(link)
+      normalized = makeNot(
+        makeLink(normalizeNode(node.left, options), normalizeNode(node.right, options))
+      )
     } else {
       normalized = {
         ...node,
@@ -311,9 +231,7 @@ function normalizeNode(node: ASTNode, options: NormalizerOptions): ASTNode {
       name: normalizeNode(node.name, options),
       form: normalizeNode(node.form, options),
     }
-    if (options.checkGuardedRecursion) {
-      checkGuardedRecursion(normalized as DefExpr)
-    }
+    if (options.checkGuardedRecursion) checkGuardedRecursion(normalized as DefExpr)
   } else if (isEqExpr(node)) {
     normalized = {
       ...node,
@@ -326,87 +244,40 @@ function normalizeNode(node: ASTNode, options: NormalizerOptions): ASTNode {
       left: normalizeNode(node.left, options),
       right: normalizeNode(node.right, options),
     }
-  } else if (isMaleExpr(node)) {
-    normalized = {
-      ...node,
-      operand: normalizeNode(node.operand, options),
-    }
-  } else if (isFemaleExpr(node)) {
-    normalized = {
-      ...node,
-      operand: normalizeNode(node.operand, options),
-    }
-  } else if (isNotExpr(node)) {
+  } else if (isMaleExpr(node) || isFemaleExpr(node) || isNotExpr(node)) {
     normalized = {
       ...node,
       operand: normalizeNode(node.operand, options),
     }
   } else if (isPowerExpr(node)) {
-    // Expand power: a^n → (...((a -> a) -> a) ... -> a)
     if (options.expandPower) {
-      const base = normalizeNode(node.base, options)
-      normalized = expandPower(base, node.exponent)
+      normalized = expandPower(normalizeNode(node.base, options), node.exponent)
     } else {
-      normalized = {
-        ...node,
-        base: normalizeNode(node.base, options),
-      }
+      normalized = { ...node, base: normalizeNode(node.base, options) }
     }
   } else if (isSetExpr(node)) {
-    normalized = {
-      ...node,
-      elements: node.elements.map(el => normalizeNode(el, options)),
-    }
+    normalized = { ...node, elements: node.elements.map(el => normalizeNode(el, options)) }
   } else {
-    // Leaf nodes: Infinity, Num, Identifier, AbitLit, StringLit, Bracket
     normalized = node
   }
 
-  // Apply canonical form rules
-  if (options.canonicalize) {
-    normalized = canonicalize(normalized)
-  }
-
-  return normalized
+  return options.canonicalize ? canonicalize(normalized) : normalized
 }
 
-/**
- * Apply canonical form rules:
- * - !!x → x
- * - !(♂x) → x♀
- * - !(x♀) → ♂x
- */
 function canonicalize(node: ASTNode): ASTNode {
-  if (!isNotExpr(node)) {
-    return node
-  }
-
+  if (!isNotExpr(node)) return node
   const operand = node.operand
+  if (isNotExpr(operand)) return operand.operand
 
-  // !!x → x
-  if (isNotExpr(operand)) {
-    return operand.operand
-  }
-
-  // !(♂x) → x♀
-  if (isMaleExpr(operand)) {
-    return makeFemale(operand.operand)
-  }
-
-  // !(x♀) → ♂x
-  if (isFemaleExpr(operand)) {
-    return makeMale(operand.operand)
-  }
-
+  // Keep the historical duality transformation only while old prover
+  // consumers are being migrated. The glyph orientation here follows the
+  // canonical AST: Female=♀ prefix/start, Male=♂ postfix/end.
+  if (isMaleExpr(operand)) return makeFemale(operand.operand)
+  if (isFemaleExpr(operand)) return makeMale(operand.operand)
   return node
 }
 
-/**
- * Generate a cache key for an AST node with given options.
- * The key includes the options hash to differentiate different normalization modes.
- */
 function generateCacheKey(node: ASTNode, opts: NormalizerOptions): string {
-  // Create options signature (only include non-default values to save space)
   const optsSig = [
     opts.desugarNotLink ? '' : 'D0',
     opts.expandPower ? '' : 'P0',
@@ -415,46 +286,23 @@ function generateCacheKey(node: ASTNode, opts: NormalizerOptions): string {
   ]
     .filter(Boolean)
     .join('')
-
-  // Use toCanonicalString for the node structure (pre-normalization)
   const nodeKey = toCanonicalString(node)
-
   return optsSig ? `${optsSig}:${nodeKey}` : nodeKey
 }
 
-/**
- * Normalize AST
- *
- * Uses caching to improve performance for repeated normalizations
- * of the same expression. Cache is keyed by the canonical string
- * representation of the input AST and normalization options.
- */
 export function normalize(node: ASTNode, options: Partial<NormalizerOptions> = {}): ASTNode {
   const opts = { ...defaultOptions, ...options }
-
-  // Try to get from cache first
   if (normalizationCache.isEnabled()) {
     const cacheKey = generateCacheKey(node, opts)
     const cached = normalizationCache.get(cacheKey)
-    if (cached) {
-      return cached
-    }
-
-    // Normalize and cache the result
+    if (cached) return cached
     const result = normalizeNode(node, opts)
     normalizationCache.set(cacheKey, result)
     return result
   }
-
-  // Caching disabled, just normalize
   return normalizeNode(node, opts)
 }
 
-/**
- * Normalize file
- *
- * Each statement expression is normalized using the cached normalize function.
- */
 export function normalizeFile(file: File, options: Partial<NormalizerOptions> = {}): File {
   return {
     type: 'File',
@@ -470,65 +318,41 @@ export function normalizeFile(file: File, options: Partial<NormalizerOptions> = 
   }
 }
 
-/**
- * Convert AST to canonical string form (for comparison)
- */
 export function toCanonicalString(node: ASTNode): string {
-  if (isLinkExpr(node)) {
-    return `(${toCanonicalString(node.left)}->${toCanonicalString(node.right)})`
+  if (isRoundExpr(node)) {
+    return node.content === null ? '()' : `(${toCanonicalString(node.content)})`
   }
+  if (isSquareExpr(node)) {
+    return `[${node.content === null ? '' : toCanonicalString(node.content)}]`
+  }
+  if (isContextPronounExpr(node)) {
+    return `${'↑'.repeat(node.up)}${node.pole === 'start' ? '◁' : '▷'}`
+  }
+  if (isLiteralExpr(node)) return node.value
+  if (isLinkExpr(node)) return `(${toCanonicalString(node.left)}->${toCanonicalString(node.right)})`
   if (isNotLinkExpr(node)) {
     return `(${toCanonicalString(node.left)}!->${toCanonicalString(node.right)})`
   }
-  if (isDefExpr(node)) {
-    return `(${toCanonicalString(node.name)}:${toCanonicalString(node.form)})`
-  }
-  if (isEqExpr(node)) {
-    return `(${toCanonicalString(node.left)}=${toCanonicalString(node.right)})`
-  }
-  if (isNeqExpr(node)) {
-    return `(${toCanonicalString(node.left)}!=${toCanonicalString(node.right)})`
-  }
-  if (isMaleExpr(node)) {
-    return `♂${toCanonicalString(node.operand)}`
-  }
-  if (isFemaleExpr(node)) {
-    return `${toCanonicalString(node.operand)}♀`
-  }
-  if (isNotExpr(node)) {
-    return `!${toCanonicalString(node.operand)}`
-  }
-  if (isPowerExpr(node)) {
-    return `${toCanonicalString(node.base)}^${node.exponent}`
-  }
+  if (isDefExpr(node)) return `(${toCanonicalString(node.name)}:${toCanonicalString(node.form)})`
+  if (isEqExpr(node)) return `(${toCanonicalString(node.left)}=${toCanonicalString(node.right)})`
+  if (isNeqExpr(node)) return `(${toCanonicalString(node.left)}!=${toCanonicalString(node.right)})`
+  if (isMaleExpr(node)) return `${toCanonicalString(node.operand)}♂`
+  if (isFemaleExpr(node)) return `♀${toCanonicalString(node.operand)}`
+  if (isNotExpr(node)) return `¬${toCanonicalString(node.operand)}`
+  if (isPowerExpr(node)) return `${toCanonicalString(node.base)}^${node.exponent}`
   if (isSetExpr(node)) {
     const sorted = [...node.elements].map(toCanonicalString).sort()
     return `{${sorted.join(',')}}`
   }
-  if (isInfinityExpr(node)) {
-    return '∞'
-  }
-  if (isNumExpr(node)) {
-    return String(node.value)
-  }
-  if (isIdentExpr(node)) {
-    return node.name
-  }
-  if (isAbitLitExpr(node)) {
-    return `'${node.value}'`
-  }
-  if (isStringLitExpr(node)) {
-    return `"${node.value}"`
-  }
-  if (isBracketExpr(node)) {
-    return node.side === 'left' ? '[' : ']'
-  }
+  if (isInfinityExpr(node)) return '∞'
+  if (isNumExpr(node)) return String(node.value)
+  if (isIdentExpr(node)) return node.name
+  if (isAbitLitExpr(node)) return `'${node.value}'`
+  if (isStringLitExpr(node)) return `"${node.value}"`
+  if (isBracketExpr(node)) return node.side === 'left' ? '[' : ']'
   return `<unknown:${node.type}>`
 }
 
-/**
- * Check structural equality of two AST nodes
- */
 export function astEqual(a: ASTNode, b: ASTNode): boolean {
   return toCanonicalString(a) === toCanonicalString(b)
 }

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -1,10 +1,9 @@
 /**
  * Parser for the canonical МТС formal notation consumed from anum_docs.
  *
- * This is the existing aprover parser being migrated in-place. It does not
- * create a parallel v2 grammar. During this draft migration the old projection
- * fixities are still accepted for existing consumers; canonical fixities are
- * represented in the AST and will become the only path before promotion.
+ * This is the single aprover parser. Projection fixity follows МТС v0.2:
+ * `♀F` is start projection and `F♂` is end projection. The rejected legacy
+ * `♂F / F♀` grammar is intentionally not accepted.
  */
 
 import type { Token, TokenType } from './lexer'
@@ -30,7 +29,6 @@ import type {
   StringLitExpr,
   LiteralExpr,
   RoundExpr,
-  BracketExpr,
   SquareExpr,
   ContextPronounExpr,
   SourceLocation,
@@ -64,7 +62,7 @@ const ROUND_LITERALS = new Set<TokenType>([
 
 export class Parser {
   private tokens: Token[]
-  private pos: number = 0
+  private pos = 0
 
   constructor(tokens: Token[]) {
     this.tokens = tokens
@@ -74,7 +72,7 @@ export class Parser {
     return this.tokens[this.pos]
   }
 
-  private peek(n: number = 1): Token {
+  private peek(n = 1): Token {
     return this.tokens[this.pos + n] || this.tokens[this.tokens.length - 1]
   }
 
@@ -106,9 +104,7 @@ export class Parser {
   parseFile(): File {
     const statements: Statement[] = []
     const startLoc = this.current().loc
-
     while (!this.check('EOF')) statements.push(this.parseStatement())
-
     return {
       type: 'File',
       statements,
@@ -150,9 +146,7 @@ export class Parser {
   private parseStatement(): Statement {
     const expr = this.parseExpr()
     let endLoc = expr.loc!
-
     if (this.checkAny('COMMA', 'DOT')) endLoc = this.advance().loc
-
     return {
       type: 'Statement',
       expr,
@@ -229,16 +223,13 @@ export class Parser {
     return left
   }
 
-  /**
-   * Canonical prefix operators are ¬ and ♀. Prefix ♂ is temporarily accepted
-   * only until old aprover consumers/tests are migrated in this draft PR.
-   */
+  /** Canonical prefix operators: inversion `¬`/`!` and start projection `♀`. */
   private parsePref(): ASTNode {
-    const prefixes: { type: 'NOT' | 'FEMALE' | 'MALE'; loc: SourceLocation }[] = []
+    const prefixes: { type: 'NOT' | 'FEMALE'; loc: SourceLocation }[] = []
 
-    while (this.checkAny('NOT', 'FEMALE', 'MALE')) {
+    while (this.checkAny('NOT', 'FEMALE')) {
       const token = this.current()
-      prefixes.push({ type: token.type as 'NOT' | 'FEMALE' | 'MALE', loc: token.loc })
+      prefixes.push({ type: token.type as 'NOT' | 'FEMALE', loc: token.loc })
       this.advance()
     }
 
@@ -252,29 +243,23 @@ export class Parser {
           operand: node,
           loc: this.mergeLoc(prefix.loc, node.loc!),
         } as NotExpr
-      } else if (prefix.type === 'FEMALE') {
+      } else {
         node = {
           type: 'Female',
           operand: node,
           loc: this.mergeLoc(prefix.loc, node.loc!),
         } as FemaleExpr
-      } else {
-        node = {
-          type: 'Male',
-          operand: node,
-          loc: this.mergeLoc(prefix.loc, node.loc!),
-        } as MaleExpr
       }
     }
 
     return node
   }
 
-  /** Canonical postfix projection is ♂; postfix ♀ remains draft-only legacy. */
+  /** Canonical postfix operators: end projection `♂` and legacy-neutral power. */
   private parsePost(): ASTNode {
     let node = this.parseAtom()
 
-    while (this.checkAny('MALE', 'FEMALE', 'POWER')) {
+    while (this.checkAny('MALE', 'POWER')) {
       if (this.check('MALE')) {
         const loc = this.advance().loc
         node = {
@@ -282,13 +267,6 @@ export class Parser {
           operand: node,
           loc: this.mergeLoc(node.loc!, loc),
         } as MaleExpr
-      } else if (this.check('FEMALE')) {
-        const loc = this.advance().loc
-        node = {
-          type: 'Female',
-          operand: node,
-          loc: this.mergeLoc(node.loc!, loc),
-        } as FemaleExpr
       } else {
         this.advance()
         let expToken: Token
@@ -344,10 +322,6 @@ export class Parser {
     if (this.check('LBRACE')) return this.parseSet()
     if (this.check('LPAREN')) return this.parseRound()
     if (this.check('LBRACKET')) return this.parseSquare()
-    if (this.check('RBRACKET')) {
-      this.advance()
-      return { type: 'Bracket', side: 'right', loc: token.loc } as BracketExpr
-    }
 
     throw new ParseError(`Unexpected token: ${token.type}`, token)
   }
@@ -401,19 +375,20 @@ export class Parser {
     return { type: 'Round', content, loc: this.mergeLoc(opening.loc, closing.loc) }
   }
 
-  private parseSquare(): ASTNode {
+  private parseSquare(): SquareExpr {
     const opening = this.expect('LBRACKET')
-
-    // `([)` is handled by parseRound() before entering this method. Here `[` is
-    // therefore a real L2 square container, including the anonymous `[]` form.
     if (this.check('RBRACKET')) {
       const closing = this.advance()
-      return { type: 'Square', content: null, loc: this.mergeLoc(opening.loc, closing.loc) } as SquareExpr
+      return {
+        type: 'Square',
+        content: null,
+        loc: this.mergeLoc(opening.loc, closing.loc),
+      }
     }
 
     const content = this.parseExpr()
     const closing = this.expect('RBRACKET')
-    return { type: 'Square', content, loc: this.mergeLoc(opening.loc, closing.loc) } as SquareExpr
+    return { type: 'Square', content, loc: this.mergeLoc(opening.loc, closing.loc) }
   }
 
   private parseSet(): SetExpr {

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -1,24 +1,10 @@
 /**
- * Parser for МТС (Meta-Theory of Links) formal notation
- * Based on EBNF from "МТС — Чистовик v0.1.md"
+ * Parser for the canonical МТС formal notation consumed from anum_docs.
  *
- * Grammar (simplified):
- * File      ::= { Stmt }
- * Stmt      ::= Expr [ "," ]  // comma separator is optional
- * Expr      ::= DefExpr | EqExpr | NeqExpr | Term
- * DefExpr   ::= Term ":" Term
- * EqExpr    ::= Term "=" Term
- * NeqExpr   ::= Term ("!=" | "≠" | "¬=") Term
- * Term      ::= Chain
- * Chain     ::= Pref { ("->" | "!->") Pref }  // left-associative
- * Pref      ::= { "!" | "¬" | "♂" } Post
- * Post      ::= Atom { "♀" | "^" Nat }
- * Atom      ::= Const | Id | AbitLit | StringLit | Set | "(" Expr ")"
- * Set       ::= "{" Expr { "," Expr } "}"
- * Const     ::= "∞" | "0" | "1" | "[" | "]"
- * AbitLit   ::= "'" { AbitChar } "'" // sequence of [, 0, 1, ] for abit anumbers
- * StringLit ::= '"' { Utf8Char } '"' // string for string anumbers
- * AbitChar  ::= "[" | "0" | "1" | "]"
+ * This is the existing aprover parser being migrated in-place. It does not
+ * create a parallel v2 grammar. During this draft migration the old projection
+ * fixities are still accepted for existing consumers; canonical fixities are
+ * represented in the AST and will become the only path before promotion.
  */
 
 import type { Token, TokenType } from './lexer'
@@ -42,11 +28,14 @@ import type {
   IdentExpr,
   AbitLitExpr,
   StringLitExpr,
+  LiteralExpr,
+  RoundExpr,
   BracketExpr,
+  SquareExpr,
+  ContextPronounExpr,
   SourceLocation,
 } from './ast'
 
-/** Parser error */
 export class ParseError extends Error {
   constructor(
     message: string,
@@ -57,14 +46,22 @@ export class ParseError extends Error {
   }
 }
 
-/** Parse result with partial AST and optional error */
 export interface ParseResult {
   file: File | null
   error: ParseError | null
   errorLocation?: SourceLocation
 }
 
-/** Parser class */
+const ROUND_LITERALS = new Set<TokenType>([
+  'ARROW',
+  'NOT_ARROW',
+  'EQUAL',
+  'NOT_EQUAL',
+  'DEFINE',
+  'LBRACKET',
+  'RBRACKET',
+])
+
 export class Parser {
   private tokens: Token[]
   private pos: number = 0
@@ -73,36 +70,28 @@ export class Parser {
     this.tokens = tokens
   }
 
-  /** Get current token */
   private current(): Token {
     return this.tokens[this.pos]
   }
 
-  /** Peek ahead n tokens */
   private peek(n: number = 1): Token {
     return this.tokens[this.pos + n] || this.tokens[this.tokens.length - 1]
   }
 
-  /** Advance to next token */
   private advance(): Token {
     const token = this.current()
-    if (this.pos < this.tokens.length - 1) {
-      this.pos++
-    }
+    if (this.pos < this.tokens.length - 1) this.pos++
     return token
   }
 
-  /** Check if current token matches type */
   private check(type: TokenType): boolean {
     return this.current().type === type
   }
 
-  /** Check if current token matches any of types */
   private checkAny(...types: TokenType[]): boolean {
     return types.includes(this.current().type)
   }
 
-  /** Expect current token to be of type, throw if not */
   private expect(type: TokenType): Token {
     if (!this.check(type)) {
       throw new ParseError(`Expected ${type}, got ${this.current().type}`, this.current())
@@ -110,19 +99,15 @@ export class Parser {
     return this.advance()
   }
 
-  /** Merge source locations */
   private mergeLoc(start: SourceLocation, end: SourceLocation): SourceLocation {
     return { start: start.start, end: end.end }
   }
 
-  /** Parse file */
   parseFile(): File {
     const statements: Statement[] = []
     const startLoc = this.current().loc
 
-    while (!this.check('EOF')) {
-      statements.push(this.parseStatement())
-    }
+    while (!this.check('EOF')) statements.push(this.parseStatement())
 
     return {
       type: 'File',
@@ -131,7 +116,6 @@ export class Parser {
     }
   }
 
-  /** Parse file with error recovery - returns partial AST on error */
   parseFileWithRecovery(): ParseResult {
     const statements: Statement[] = []
     const startLoc = this.current().loc
@@ -145,7 +129,6 @@ export class Parser {
         if (e instanceof ParseError) {
           error = e
           errorLocation = e.token.loc
-          // Stop parsing on first error
           break
         }
         throw e
@@ -161,44 +144,25 @@ export class Parser {
           }
         : null
 
-    return {
-      file,
-      error,
-      errorLocation,
-    }
+    return { file, error, errorLocation }
   }
 
-  /** Parse statement: Expr ["," | newline]
-   * Commas and newlines are optional separators between statements.
-   * They are consumed if present but not required.
-   * Periods (.) are NOT supported as separators.
-   */
   private parseStatement(): Statement {
     const expr = this.parseExpr()
+    let endLoc = expr.loc!
 
-    // Optional separator: consume comma if present
-    // Newlines are already consumed by whitespace skipping in lexer
-    if (this.check('COMMA')) {
-      const separator = this.advance()
-      return {
-        type: 'Statement',
-        expr,
-        loc: this.mergeLoc(expr.loc!, separator.loc),
-      }
-    }
+    if (this.checkAny('COMMA', 'DOT')) endLoc = this.advance().loc
 
     return {
       type: 'Statement',
       expr,
-      loc: expr.loc!,
+      loc: this.mergeLoc(expr.loc!, endLoc),
     }
   }
 
-  /** Parse expression: DefExpr | EqExpr | NeqExpr | Term */
   private parseExpr(): ASTNode {
     const left = this.parseTerm()
 
-    // Check for definition, equality, or inequality
     if (this.check('DEFINE')) {
       this.advance()
       const right = this.parseTerm()
@@ -235,12 +199,10 @@ export class Parser {
     return left
   }
 
-  /** Parse term: Chain */
   private parseTerm(): ASTNode {
     return this.parseChain()
   }
 
-  /** Parse chain: Pref { ("->" | "!->") Pref } (left-associative) */
   private parseChain(): ASTNode {
     let left = this.parsePref()
 
@@ -249,42 +211,39 @@ export class Parser {
       this.advance()
       const right = this.parsePref()
 
-      if (isNotArrow) {
-        left = {
-          type: 'NotLink',
-          left,
-          right,
-          loc: this.mergeLoc(left.loc!, right.loc!),
-        } as NotLinkExpr
-      } else {
-        left = {
-          type: 'Link',
-          left,
-          right,
-          loc: this.mergeLoc(left.loc!, right.loc!),
-        } as LinkExpr
-      }
+      left = isNotArrow
+        ? ({
+            type: 'NotLink',
+            left,
+            right,
+            loc: this.mergeLoc(left.loc!, right.loc!),
+          } as NotLinkExpr)
+        : ({
+            type: 'Link',
+            left,
+            right,
+            loc: this.mergeLoc(left.loc!, right.loc!),
+          } as LinkExpr)
     }
 
     return left
   }
 
-  /** Parse prefix: { "!" | "¬" | "♂" } Post (right-associative for ♂) */
+  /**
+   * Canonical prefix operators are ¬ and ♀. Prefix ♂ is temporarily accepted
+   * only until old aprover consumers/tests are migrated in this draft PR.
+   */
   private parsePref(): ASTNode {
-    const prefixes: { type: 'NOT' | 'MALE'; loc: SourceLocation }[] = []
+    const prefixes: { type: 'NOT' | 'FEMALE' | 'MALE'; loc: SourceLocation }[] = []
 
-    // Collect all prefix operators
-    while (this.checkAny('NOT', 'MALE')) {
-      prefixes.push({
-        type: this.check('NOT') ? 'NOT' : 'MALE',
-        loc: this.current().loc,
-      })
+    while (this.checkAny('NOT', 'FEMALE', 'MALE')) {
+      const token = this.current()
+      prefixes.push({ type: token.type as 'NOT' | 'FEMALE' | 'MALE', loc: token.loc })
       this.advance()
     }
 
     let node = this.parsePost()
 
-    // Apply prefixes in reverse order (right-to-left for ♂)
     for (let i = prefixes.length - 1; i >= 0; i--) {
       const prefix = prefixes[i]
       if (prefix.type === 'NOT') {
@@ -293,6 +252,12 @@ export class Parser {
           operand: node,
           loc: this.mergeLoc(prefix.loc, node.loc!),
         } as NotExpr
+      } else if (prefix.type === 'FEMALE') {
+        node = {
+          type: 'Female',
+          operand: node,
+          loc: this.mergeLoc(prefix.loc, node.loc!),
+        } as FemaleExpr
       } else {
         node = {
           type: 'Male',
@@ -305,37 +270,35 @@ export class Parser {
     return node
   }
 
-  /** Parse postfix: Atom { "♀" | "^" Nat } (left-associative for ♀) */
+  /** Canonical postfix projection is ♂; postfix ♀ remains draft-only legacy. */
   private parsePost(): ASTNode {
     let node = this.parseAtom()
 
-    while (this.checkAny('FEMALE', 'POWER')) {
-      if (this.check('FEMALE')) {
-        const femLoc = this.current().loc
-        this.advance()
+    while (this.checkAny('MALE', 'FEMALE', 'POWER')) {
+      if (this.check('MALE')) {
+        const loc = this.advance().loc
+        node = {
+          type: 'Male',
+          operand: node,
+          loc: this.mergeLoc(node.loc!, loc),
+        } as MaleExpr
+      } else if (this.check('FEMALE')) {
+        const loc = this.advance().loc
         node = {
           type: 'Female',
           operand: node,
-          loc: this.mergeLoc(node.loc!, femLoc),
+          loc: this.mergeLoc(node.loc!, loc),
         } as FemaleExpr
-      } else if (this.check('POWER')) {
+      } else {
         this.advance()
-        // Accept NAT, ONE, or ZERO as exponent
         let expToken: Token
-        if (this.check('NAT')) {
-          expToken = this.advance()
-        } else if (this.check('ONE')) {
-          expToken = this.advance()
-        } else if (this.check('ZERO')) {
-          expToken = this.advance()
-        } else {
-          throw new ParseError('Expected number after ^', this.current())
-        }
-        const exponent = parseInt(expToken.value, 10)
+        if (this.checkAny('NAT', 'ONE', 'ZERO')) expToken = this.advance()
+        else throw new ParseError('Expected number after ^', this.current())
+
         node = {
           type: 'Power',
           base: node,
-          exponent,
+          exponent: parseInt(expToken.value, 10),
           loc: this.mergeLoc(node.loc!, expToken.loc),
         } as PowerExpr
       }
@@ -344,78 +307,115 @@ export class Parser {
     return node
   }
 
-  /** Parse atom: Const | Id | AbitLit | StringLit | Set | "(" Expr ")" */
   private parseAtom(): ASTNode {
     const token = this.current()
 
-    // Constants
     if (this.check('INFINITY')) {
       this.advance()
       return { type: 'Infinity', loc: token.loc } as InfinityExpr
     }
-
     if (this.check('ZERO')) {
       this.advance()
       return { type: 'Num', value: 0, loc: token.loc } as NumExpr
     }
-
     if (this.check('ONE')) {
       this.advance()
       return { type: 'Num', value: 1, loc: token.loc } as NumExpr
     }
-
-    if (this.check('LBRACKET')) {
-      this.advance()
-      return { type: 'Bracket', side: 'left', loc: token.loc } as BracketExpr
+    if (this.checkAny('CONTEXT_START', 'CONTEXT_END', 'CONTEXT_UP')) {
+      return this.parseContextPronoun()
     }
-
+    if (this.check('ID')) {
+      this.advance()
+      return { type: 'Identifier', name: token.value, loc: token.loc } as IdentExpr
+    }
+    if (this.check('NAT')) {
+      this.advance()
+      return { type: 'Identifier', name: token.value, loc: token.loc } as IdentExpr
+    }
+    if (this.check('ABIT_LIT')) {
+      this.advance()
+      return { type: 'AbitLit', value: token.value, loc: token.loc } as AbitLitExpr
+    }
+    if (this.check('STRING_LIT')) {
+      this.advance()
+      return { type: 'StringLit', value: token.value, loc: token.loc } as StringLitExpr
+    }
+    if (this.check('LBRACE')) return this.parseSet()
+    if (this.check('LPAREN')) return this.parseRound()
+    if (this.check('LBRACKET')) return this.parseSquare()
     if (this.check('RBRACKET')) {
       this.advance()
       return { type: 'Bracket', side: 'right', loc: token.loc } as BracketExpr
     }
 
-    // Identifier
-    if (this.check('ID')) {
-      this.advance()
-      return { type: 'Identifier', name: token.value, loc: token.loc } as IdentExpr
-    }
-
-    // Natural number (used as identifier in some contexts)
-    if (this.check('NAT')) {
-      this.advance()
-      return { type: 'Identifier', name: token.value, loc: token.loc } as IdentExpr
-    }
-
-    // Abit literal (sequence of [, 0, 1, ] in single quotes - for abit anumbers)
-    if (this.check('ABIT_LIT')) {
-      this.advance()
-      return { type: 'AbitLit', value: token.value, loc: token.loc } as AbitLitExpr
-    }
-
-    // String literal (multiple characters in double quotes - for string anumbers)
-    if (this.check('STRING_LIT')) {
-      this.advance()
-      return { type: 'StringLit', value: token.value, loc: token.loc } as StringLitExpr
-    }
-
-    // Set: "{" Expr { "," Expr } "}"
-    if (this.check('LBRACE')) {
-      return this.parseSet()
-    }
-
-    // Parenthesized expression
-    if (this.check('LPAREN')) {
-      const lparen = this.advance()
-      const expr = this.parseExpr()
-      const rparen = this.expect('RPAREN')
-      expr.loc = this.mergeLoc(lparen.loc, rparen.loc)
-      return expr
-    }
-
     throw new ParseError(`Unexpected token: ${token.type}`, token)
   }
 
-  /** Parse set: "{" Expr { "," Expr } "}" */
+  private parseContextPronoun(): ContextPronounExpr {
+    const first = this.current()
+    let up = 0
+    while (this.check('CONTEXT_UP')) {
+      this.advance()
+      up++
+    }
+
+    const pole = this.current()
+    if (!this.checkAny('CONTEXT_START', 'CONTEXT_END')) {
+      throw new ParseError('Expected ◁ or ▷ after ↑', first)
+    }
+    this.advance()
+
+    return {
+      type: 'ContextPronoun',
+      pole: pole.type === 'CONTEXT_START' ? 'start' : 'end',
+      up,
+      loc: this.mergeLoc(first.loc, pole.loc),
+    } as ContextPronounExpr
+  }
+
+  private parseRound(): RoundExpr {
+    const opening = this.expect('LPAREN')
+    if (this.check('RPAREN')) {
+      const closing = this.advance()
+      return { type: 'Round', content: null, loc: this.mergeLoc(opening.loc, closing.loc) }
+    }
+
+    if (ROUND_LITERALS.has(this.current().type) && this.peek().type === 'RPAREN') {
+      const literalToken = this.advance()
+      const closing = this.expect('RPAREN')
+      const literal: LiteralExpr = {
+        type: 'Literal',
+        value: literalToken.value,
+        loc: literalToken.loc,
+      }
+      return {
+        type: 'Round',
+        content: literal,
+        loc: this.mergeLoc(opening.loc, closing.loc),
+      }
+    }
+
+    const content = this.parseExpr()
+    const closing = this.expect('RPAREN')
+    return { type: 'Round', content, loc: this.mergeLoc(opening.loc, closing.loc) }
+  }
+
+  private parseSquare(): ASTNode {
+    const opening = this.expect('LBRACKET')
+
+    // `([)` is handled by parseRound() before entering this method. Here `[` is
+    // therefore a real L2 square container, including the anonymous `[]` form.
+    if (this.check('RBRACKET')) {
+      const closing = this.advance()
+      return { type: 'Square', content: null, loc: this.mergeLoc(opening.loc, closing.loc) } as SquareExpr
+    }
+
+    const content = this.parseExpr()
+    const closing = this.expect('RBRACKET')
+    return { type: 'Square', content, loc: this.mergeLoc(opening.loc, closing.loc) } as SquareExpr
+  }
+
   private parseSet(): SetExpr {
     const lbrace = this.expect('LBRACE')
     const elements: ASTNode[] = []
@@ -429,7 +429,6 @@ export class Parser {
     }
 
     const rbrace = this.expect('RBRACE')
-
     return {
       type: 'Set',
       elements,
@@ -438,28 +437,20 @@ export class Parser {
   }
 }
 
-/** Convenience function to parse a string */
 export function parse(input: string): File {
   const lexer = new Lexer(input)
-  const tokens = lexer.tokenize()
-  const parser = new Parser(tokens)
-  return parser.parseFile()
+  return new Parser(lexer.tokenize()).parseFile()
 }
 
-/** Convenience function to parse with error recovery */
 export function parseWithRecovery(input: string): ParseResult {
   const lexer = new Lexer(input)
-  const tokens = lexer.tokenize()
-  const parser = new Parser(tokens)
-  return parser.parseFileWithRecovery()
+  return new Parser(lexer.tokenize()).parseFileWithRecovery()
 }
 
-/** Parse single expression */
 export function parseExpr(input: string): ASTNode {
   const lexer = new Lexer(input)
   const tokens = lexer.tokenize()
-  const parser = new Parser(tokens)
-  const file = parser.parseFile()
+  const file = new Parser(tokens).parseFile()
   if (file.statements.length !== 1) {
     throw new ParseError('Expected single expression', tokens[0])
   }

--- a/src/core/proofExport.ts
+++ b/src/core/proofExport.ts
@@ -11,6 +11,7 @@
 import type { ASTNode } from './ast'
 import {
   isLinkExpr,
+  isNotLinkExpr,
   isDefExpr,
   isEqExpr,
   isNeqExpr,
@@ -23,7 +24,11 @@ import {
   isIdentExpr,
   isAbitLitExpr,
   isStringLitExpr,
+  isLiteralExpr,
+  isRoundExpr,
   isBracketExpr,
+  isSquareExpr,
+  isContextPronounExpr,
   isPowerExpr,
 } from './ast'
 import type { ProofResult, ProverState, AxiomId } from './prover'
@@ -173,11 +178,15 @@ export interface ProverStateExport {
 }
 
 /**
- * Convert AST node to LaTeX notation
+ * Convert AST node to LaTeX notation while preserving canonical MTS v0.2
+ * structure and projection fixity.
  */
 export function astToLaTeX(node: ASTNode): string {
   if (isLinkExpr(node)) {
     return `(${astToLaTeX(node.left)} \\to ${astToLaTeX(node.right)})`
+  }
+  if (isNotLinkExpr(node)) {
+    return `(${astToLaTeX(node.left)} \\nrightarrow ${astToLaTeX(node.right)})`
   }
   if (isDefExpr(node)) {
     return `${astToLaTeX(node.name)} : ${astToLaTeX(node.form)}`
@@ -189,10 +198,10 @@ export function astToLaTeX(node: ASTNode): string {
     return `${astToLaTeX(node.left)} \\neq ${astToLaTeX(node.right)}`
   }
   if (isMaleExpr(node)) {
-    return `\\male{${astToLaTeX(node.operand)}}`
+    return `${astToLaTeX(node.operand)}\\male{}`
   }
   if (isFemaleExpr(node)) {
-    return `${astToLaTeX(node.operand)}\\female`
+    return `\\female{}${astToLaTeX(node.operand)}`
   }
   if (isNotExpr(node)) {
     return `\\lnot ${astToLaTeX(node.operand)}`
@@ -218,8 +227,21 @@ export function astToLaTeX(node: ASTNode): string {
   if (isStringLitExpr(node)) {
     return `\\text{"${node.value}"}`
   }
+  if (isLiteralExpr(node)) {
+    return stringToLaTeX(node.value)
+  }
+  if (isRoundExpr(node)) {
+    return `(${node.content === null ? '' : astToLaTeX(node.content)})`
+  }
   if (isBracketExpr(node)) {
     return node.side === 'left' ? '[' : ']'
+  }
+  if (isSquareExpr(node)) {
+    return `[${node.content === null ? '' : astToLaTeX(node.content)}]`
+  }
+  if (isContextPronounExpr(node)) {
+    const glyph = `${'↑'.repeat(node.up)}${node.pole === 'start' ? '◁' : '▷'}`
+    return `\\text{${glyph}}`
   }
   return `\\text{<unknown>}`
 }
@@ -230,6 +252,8 @@ export function astToLaTeX(node: ASTNode): string {
 export function stringToLaTeX(str: string): string {
   return str
     .replace(/∞/g, '\\infty')
+    .replace(/⟼/g, '\\to')
+    .replace(/↛/g, '\\nrightarrow')
     .replace(/→/g, '\\to')
     .replace(/->/g, '\\to')
     .replace(/♂/g, '\\male{}')
@@ -269,7 +293,7 @@ export function exportToLaTeX(
     }
     lines.push('')
     lines.push('% Custom commands for МТС notation')
-    lines.push('\\newcommand{\\male}[1]{\\text{♂}#1}')
+    lines.push('\\newcommand{\\male}{\\text{♂}}')
     lines.push('\\newcommand{\\female}{\\text{♀}}')
     lines.push('')
     lines.push('\\begin{document}')

--- a/src/core/prover.ts
+++ b/src/core/prover.ts
@@ -258,15 +258,16 @@ export function createProverState(): ProverState {
   // !∞ = ∞
   addAxiomEq(state, '!∞', '∞')
 
-  // А8. Единица смысла: 1 : (♂∞ -> ∞♀)
-  state.definitions.set('1', parseAndNormalize('♂∞ -> ∞♀'))
+  // Legacy prover semantics still lives here until Phase E; only its parser-facing
+  // spellings are canonicalized now so it consumes the single v0.2 projection grammar.
+  state.definitions.set('1', parseAndNormalize('♀∞ -> ∞♂'))
 
   // А9. Нуль смысла: 0 : !1
   state.definitions.set('0', parseAndNormalize('!1'))
 
   // А10. Абиты
-  state.definitions.set('[', parseAndNormalize('♂∞'))
-  state.definitions.set(']', parseAndNormalize('∞♀'))
+  state.definitions.set('[', parseAndNormalize('♀∞'))
+  state.definitions.set(']', parseAndNormalize('∞♂'))
 
   // А11. Левоассоциативность: (a -> b -> c) = ((a -> b) -> c)
   // This is built into the parser
@@ -517,7 +518,6 @@ export function expandDefinitions(node: ASTNode, state: ProverState): ASTNode {
     }
     return node
   }
-
   if (isLinkExpr(node)) {
     return {
       ...node,

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -31,22 +31,17 @@ test.describe('aprover Web Interface', () => {
   })
 
   test('should verify default formulas successfully', async ({ page }) => {
-    // The default formulas should be verified and shown in results
     const results = page.locator('.result-item')
     await expect(results.first()).toBeVisible()
 
-    // All default formulas should pass
     const successItems = page.locator('.result-item.success')
     await expect(successItems.first()).toBeVisible()
   })
 
   test('should update results when editor content changes', async ({ page }) => {
     const editor = page.locator('.code-input')
-
-    // Clear editor and enter a simple valid formula
     await editor.fill('∞ = ∞')
 
-    // Wait for results to update
     await expect(page.locator('.result-item')).toHaveCount(1)
     await expect(page.locator('.result-item.success')).toBeVisible()
   })
@@ -62,9 +57,8 @@ test.describe('aprover Web Interface', () => {
 
   test('should show failure indicator for invalid equality', async ({ page }) => {
     const editor = page.locator('.code-input')
-    // Using different structures that cannot be unified:
-    // ♂∞ (male of infinity) cannot equal ∞♀ (female of infinity)
-    await editor.fill('♂∞ = ∞♀')
+    // Canonical end/start projections are structurally different.
+    await editor.fill('∞♂ = ♀∞')
 
     const resultItem = page.locator('.result-item')
     await expect(resultItem).toHaveClass(/failure/)
@@ -86,23 +80,23 @@ test.describe('aprover Web Interface', () => {
     await expect(page.locator('.result-status')).toHaveText('✓')
   })
 
-  test('should verify male self-closing axiom (А5)', async ({ page }) => {
+  test('should verify legacy A5 semantics through canonical end projection', async ({ page }) => {
     const editor = page.locator('.code-input')
-    await editor.fill('♂v = ♂v -> v')
+    await editor.fill('v♂ = v♂ -> v')
 
     await expect(page.locator('.result-item.success')).toBeVisible()
   })
 
-  test('should verify female self-closing axiom (А6)', async ({ page }) => {
+  test('should verify legacy A6 semantics through canonical start projection', async ({ page }) => {
     const editor = page.locator('.code-input')
-    await editor.fill('r♀ = r -> r♀')
+    await editor.fill('♀r = r -> ♀r')
 
     await expect(page.locator('.result-item.success')).toBeVisible()
   })
 
-  test('should verify inversion axiom (А7)', async ({ page }) => {
+  test('should verify legacy A7 inversion semantics with canonical projections', async ({ page }) => {
     const editor = page.locator('.code-input')
-    await editor.fill('!♂x = x♀')
+    await editor.fill('!x♂ = ♀x')
 
     await expect(page.locator('.result-item.success')).toBeVisible()
   })
@@ -118,21 +112,20 @@ test.describe('aprover Web Interface', () => {
     const editor = page.locator('.code-input')
     await editor.fill(`
 ∞ = ∞ -> ∞
-♂v = ♂v -> v
-r♀ = r -> r♀
+v♂ = v♂ -> v
+♀r = r -> ♀r
 `)
 
     const results = page.locator('.result-item')
     await expect(results).toHaveCount(3)
 
-    // All formulas should be successful
     const successItems = page.locator('.result-item.success')
     await expect(successItems).toHaveCount(3)
   })
 
   test('should verify inequality', async ({ page }) => {
     const editor = page.locator('.code-input')
-    await editor.fill('♂∞ != ∞♀')
+    await editor.fill('∞♂ != ♀∞')
 
     await expect(page.locator('.result-item.success')).toBeVisible()
   })
@@ -154,45 +147,34 @@ r♀ = r -> r♀
   })
 
   test('should have AST viewer panel', async ({ page }) => {
-    // AST viewer should be visible by default
     await expect(page.locator('.ast-panel')).toBeVisible()
     await expect(page.locator('.ast-viewer')).toBeVisible()
   })
 
   test('should toggle AST viewer visibility', async ({ page }) => {
-    // Initially visible
     await expect(page.locator('.ast-panel')).toBeVisible()
 
-    // Click AST toggle button (contains 'AST' text) to hide
     const astToggle = page.locator('.toggle-btn').filter({ hasText: /AST/ })
     await astToggle.click()
     await expect(page.locator('.ast-panel')).not.toBeVisible()
 
-    // Click toggle button to show again
     await astToggle.click()
     await expect(page.locator('.ast-panel')).toBeVisible()
   })
 
   test('should have AST expand/collapse controls', async ({ page }) => {
-    // AST viewer should have expand/collapse buttons
     await expect(page.locator('.ast-controls')).toBeVisible()
     await expect(page.locator('.ast-btn').first()).toBeVisible()
     await expect(page.locator('.ast-btn').nth(1)).toBeVisible()
   })
 
   test('should collapse all AST nodes', async ({ page }) => {
-    // Enter a formula to generate AST
     const editor = page.locator('.code-input')
     await editor.fill('a -> b')
 
-    // Wait for AST to render
     await expect(page.locator('.tree-root')).toBeVisible()
-
-    // Click collapse all button
     await page.locator('.ast-btn').nth(1).click()
 
-    // After collapse, the Statement level should show collapsed indicator
-    // (Statement is a child of File, and collapse all keeps only File expanded)
     const statementToggle = page
       .locator('.tree-node-content')
       .filter({ hasText: 'Statement' })
@@ -202,112 +184,80 @@ r♀ = r -> r♀
   })
 
   test('should expand all AST nodes after collapse', async ({ page }) => {
-    // Enter a formula to generate AST
     const editor = page.locator('.code-input')
     await editor.fill('a -> b')
 
-    // Wait for AST to render
     await expect(page.locator('.tree-root')).toBeVisible()
-
-    // Collapse all first
     await page.locator('.ast-btn').nth(1).click()
-
-    // Now expand all
     await page.locator('.ast-btn').first().click()
 
-    // Tree children should be visible again
     const treeChildren = page.locator('.tree-children')
     await expect(treeChildren.first()).toBeVisible()
   })
 
   test('should display node location in AST tree', async ({ page }) => {
-    // Enter a simple formula
     const editor = page.locator('.code-input')
     await editor.fill('a = a')
 
-    // Wait for AST to render
     await expect(page.locator('.tree-root')).toBeVisible()
-
-    // Check that location info is displayed (format: [line:column])
     await expect(page.locator('.tree-loc').first()).toBeVisible()
     await expect(page.locator('.tree-loc').first()).toContainText('[')
   })
 
   test('should highlight source code when hovering AST node', async ({ page }) => {
-    // Enter a simple formula
     const editor = page.locator('.code-input')
     await editor.fill('a = a')
 
-    // Wait for AST to render
     await expect(page.locator('.tree-root')).toBeVisible()
 
-    // Find a tree node (e.g., the Identifier node)
     const treeNodes = page.locator('.tree-node-content')
     const identifierNode = treeNodes.filter({ hasText: 'Identifier' }).first()
-
-    // Hover over the node
     await identifierNode.hover()
 
-    // Check that the highlight appears in the editor
     await expect(page.locator('.ast-highlight')).toBeVisible()
   })
 
   test('should remove highlight when mouse leaves AST node', async ({ page }) => {
-    // Enter a simple formula
     const editor = page.locator('.code-input')
     await editor.fill('a = a')
 
-    // Wait for AST to render
     await expect(page.locator('.tree-root')).toBeVisible()
 
-    // Find a tree node
     const treeNodes = page.locator('.tree-node-content')
     const identifierNode = treeNodes.filter({ hasText: 'Identifier' }).first()
 
-    // Hover over the node
     await identifierNode.hover()
     await expect(page.locator('.ast-highlight')).toBeVisible()
 
-    // Move mouse away (hover over header)
     await page.locator('.app-header').hover()
-
-    // Highlight should disappear
     await expect(page.locator('.ast-highlight')).not.toBeVisible()
   })
 
   test('should toggle individual AST nodes', async ({ page }) => {
-    // Enter a formula with nested structure
     const editor = page.locator('.code-input')
     await editor.fill('a -> b')
 
-    // Wait for AST to render with children visible
     await expect(page.locator('.tree-root')).toBeVisible()
     const treeChildren = page.locator('.tree-children')
     await expect(treeChildren.first()).toBeVisible()
 
-    // First collapse all to get to a known state
     await page.locator('.ast-btn').nth(1).click()
 
-    // Now expand Statement node by clicking on it
     const statementNode = page
       .locator('.tree-node-content')
       .filter({ hasText: 'Statement' })
       .first()
     await statementNode.click()
 
-    // After clicking collapsed node, it should expand (show ▼)
     const toggleIndicator = statementNode.locator('.tree-toggle')
     await expect(toggleIndicator).toHaveText('▼')
 
-    // Click again to collapse
     await statementNode.click()
     await expect(toggleIndicator).toHaveText('▶')
   })
 
-  // Phase 3.1: File Operations Tests
   test.describe('File Operations', () => {
     test('should have toolbar with file operation buttons', async ({ page }) => {
-      // Check for New button
       await expect(
         page
           .locator('.toolbar-btn')
@@ -316,7 +266,6 @@ r♀ = r -> r♀
           .first()
       ).toBeVisible()
 
-      // Check for Open button
       await expect(
         page
           .locator('.toolbar-btn')
@@ -325,7 +274,6 @@ r♀ = r -> r♀
           .first()
       ).toBeVisible()
 
-      // Check for Save button
       await expect(
         page
           .locator('.toolbar-btn')
@@ -350,20 +298,13 @@ r♀ = r -> r♀
         .or(page.locator('.toolbar-btn[title*="Недавние"]'))
         .first()
 
-      // Initially dropdown should not be visible
       await expect(page.locator('.recent-files-dropdown')).not.toBeVisible()
-
-      // Click to open dropdown
       await recentBtn.click()
       await expect(page.locator('.recent-files-dropdown')).toBeVisible()
-
-      // Click again to close (or click outside)
       await recentBtn.click()
-      // May still be visible depending on toggle logic, let's check for consistency
     })
 
     test('should show empty recent files message', async ({ page }) => {
-      // Clear localStorage first
       await page.evaluate(() => localStorage.clear())
       await page.reload()
 
@@ -400,11 +341,8 @@ r♀ = r -> r♀
 
     test('should disable export buttons when no results', async ({ page }) => {
       const editor = page.locator('.code-input')
-      // Clear editor with invalid content that produces no valid results
       await editor.fill('')
 
-      // Export buttons should be disabled when no results
-      // Look for buttons containing "Результаты" or "JSON" text in the toolbar
       const resultsBtn = page.locator('.toolbar-btn').filter({ hasText: 'Результаты' }).first()
       const jsonBtn = page.locator('.toolbar-btn').filter({ hasText: 'JSON' }).first()
 
@@ -416,10 +354,8 @@ r♀ = r -> r♀
       const editor = page.locator('.code-input')
       await editor.fill('a = a')
 
-      // Wait for verification to complete
       await expect(page.locator('.result-item')).toBeVisible()
 
-      // Export buttons should be enabled
       const resultsBtn = page.locator('.toolbar-btn').filter({ hasText: 'Результаты' }).first()
       const jsonBtn = page.locator('.toolbar-btn').filter({ hasText: 'JSON' }).first()
 
@@ -428,23 +364,18 @@ r♀ = r -> r♀
     })
 
     test('should display file name in editor header', async ({ page }) => {
-      // Default file name should be shown
       await expect(page.locator('.file-name')).toBeVisible()
       await expect(page.locator('.file-name')).toContainText('.mtl')
     })
 
     test('should clear editor on New file button', async ({ page }) => {
       const editor = page.locator('.code-input')
-
-      // Enter some content first
       await editor.fill('custom content here')
       await expect(editor).toHaveValue('custom content here')
 
-      // Click New button
       const newBtn = page.locator('.toolbar-btn[title*="Новый"]').first()
       await newBtn.click()
 
-      // Editor should be cleared to default template
       const value = await editor.inputValue()
       expect(value).toContain('МТС')
     })
@@ -452,7 +383,6 @@ r♀ = r -> r♀
     test('should show drag-and-drop overlay on drag over', async ({ page }) => {
       const editor = page.locator('.editor-container')
 
-      // Simulate drag enter using page.evaluate to access browser context
       await editor.evaluate(el => {
         const event = new DragEvent('dragenter', {
           bubbles: true,
@@ -461,7 +391,6 @@ r♀ = r -> r♀
         el.dispatchEvent(event)
       })
 
-      // Drop overlay should appear
       await expect(page.locator('.drop-overlay')).toBeVisible()
       await expect(page.locator('.drop-message')).toContainText('Отпустите файл')
     })
@@ -490,16 +419,12 @@ r♀ = r -> r♀
     })
   })
 
-  // Phase 2.4: Enhanced Prover Tests
   test.describe('Enhanced Prover Features', () => {
     test('should display applied axioms badges', async ({ page }) => {
       const editor = page.locator('.code-input')
       await editor.fill('∞ = ∞ -> ∞')
 
-      // Wait for results
       await expect(page.locator('.result-item.success')).toBeVisible()
-
-      // Check for applied axioms section
       await expect(page.locator('.applied-axioms')).toBeVisible()
       await expect(page.locator('.axiom-badge')).toBeVisible()
     })
@@ -510,18 +435,15 @@ r♀ = r -> r♀
 
       await expect(page.locator('.result-item.success')).toBeVisible()
 
-      // Should have A4 axiom badge for infinity
       const axiomBadge = page.locator('.axiom-badge')
       await expect(axiomBadge.filter({ hasText: 'A4' })).toBeVisible()
     })
 
     test('should show expand toggle for results with details', async ({ page }) => {
       const editor = page.locator('.code-input')
-      await editor.fill('♂v = ♂v -> v')
+      await editor.fill('v♂ = v♂ -> v')
 
       await expect(page.locator('.result-item.success')).toBeVisible()
-
-      // Should have expand toggle indicator
       await expect(page.locator('.expand-toggle')).toBeVisible()
     })
 
@@ -530,11 +452,8 @@ r♀ = r -> r♀
       await editor.fill('∞ = ∞ -> ∞')
 
       await expect(page.locator('.result-item.success')).toBeVisible()
-
-      // Click on result header to expand
       await page.locator('.result-header').first().click()
 
-      // Should show proof details
       await expect(page.locator('.proof-details')).toBeVisible()
       await expect(page.locator('.proof-steps-list')).toBeVisible()
     })
@@ -544,11 +463,8 @@ r♀ = r -> r♀
       await editor.fill('a = a')
 
       await expect(page.locator('.result-item.success')).toBeVisible()
-
-      // Click to expand
       await page.locator('.result-header').first().click()
 
-      // Should have step indices
       await expect(page.locator('.step-index').first()).toBeVisible()
       await expect(page.locator('.step-index').first()).toContainText('1.')
     })
@@ -558,11 +474,8 @@ r♀ = r -> r♀
       await editor.fill('a = a')
 
       await expect(page.locator('.result-item.success')).toBeVisible()
-
-      // Click to expand
       await page.locator('.result-header').first().click()
 
-      // Should have step actions
       await expect(page.locator('.step-action').first()).toBeVisible()
     })
 
@@ -571,66 +484,53 @@ r♀ = r -> r♀
       await editor.fill('a = a')
 
       await expect(page.locator('.result-item.success')).toBeVisible()
-
-      // Click to expand
       await page.locator('.result-header').first().click()
       await expect(page.locator('.proof-details')).toBeVisible()
 
-      // Click to collapse
       await page.locator('.result-header').first().click()
       await expect(page.locator('.proof-details')).not.toBeVisible()
     })
 
     test('should display hints for failed verification', async ({ page }) => {
       const editor = page.locator('.code-input')
-      // This should fail: male and female are dual but not equal
-      await editor.fill('♂∞ = ∞♀')
+      await editor.fill('∞♂ = ♀∞')
 
       await expect(page.locator('.result-item.failure')).toBeVisible()
-
-      // Should show hints section
       await expect(page.locator('.hints-section')).toBeVisible()
       await expect(page.locator('.hint-item').first()).toBeVisible()
     })
 
     test('should display hint icons', async ({ page }) => {
       const editor = page.locator('.code-input')
-      await editor.fill('♂∞ = ∞♀')
+      await editor.fill('∞♂ = ♀∞')
 
       await expect(page.locator('.result-item.failure')).toBeVisible()
-
-      // Should have lightbulb icon
       await expect(page.locator('.hint-icon').first()).toBeVisible()
     })
 
     test('should display related axiom in hints when applicable', async ({ page }) => {
       const editor = page.locator('.code-input')
-      await editor.fill('♂∞ = ∞♀')
+      await editor.fill('∞♂ = ♀∞')
 
       await expect(page.locator('.result-item.failure')).toBeVisible()
 
-      // Should have axiom reference in hints
       const hintAxiom = page.locator('.hint-axiom')
       await expect(hintAxiom.first()).toBeVisible()
     })
 
-    test('should show A5 axiom for male self-closing', async ({ page }) => {
+    test('should show A5 axiom for canonical end projection', async ({ page }) => {
       const editor = page.locator('.code-input')
-      await editor.fill('♂v = ♂v -> v')
+      await editor.fill('v♂ = v♂ -> v')
 
       await expect(page.locator('.result-item.success')).toBeVisible()
-
-      // Should show A5 axiom badge
       await expect(page.locator('.axiom-badge').filter({ hasText: 'A5' })).toBeVisible()
     })
 
-    test('should show A6 axiom for female self-closing', async ({ page }) => {
+    test('should show A6 axiom for canonical start projection', async ({ page }) => {
       const editor = page.locator('.code-input')
-      await editor.fill('r♀ = r -> r♀')
+      await editor.fill('♀r = r -> ♀r')
 
       await expect(page.locator('.result-item.success')).toBeVisible()
-
-      // Should show A6 axiom badge
       await expect(page.locator('.axiom-badge').filter({ hasText: 'A6' })).toBeVisible()
     })
 
@@ -639,8 +539,6 @@ r♀ = r -> r♀
       await editor.fill('a = a')
 
       await expect(page.locator('.result-item.success')).toBeVisible()
-
-      // Should show A1 axiom badge
       await expect(page.locator('.axiom-badge').filter({ hasText: 'A1' })).toBeVisible()
     })
 
@@ -650,7 +548,6 @@ r♀ = r -> r♀
 
       await expect(page.locator('.result-item.success')).toBeVisible()
 
-      // Axiom badge should have title attribute for tooltip
       const axiomBadge = page.locator('.axiom-badge').first()
       const title = await axiomBadge.getAttribute('title')
       expect(title).toBeTruthy()
@@ -662,23 +559,18 @@ r♀ = r -> r♀
       await editor.fill('a = a')
 
       await expect(page.locator('.result-item.success')).toBeVisible()
-
-      // Should show "Применённые аксиомы:" label
       await expect(page.locator('.axioms-label')).toBeVisible()
       await expect(page.locator('.axioms-label')).toContainText('Применённые аксиомы')
     })
   })
 
-  // Phase 3.2: String Anums (.astr) Tests
   test.describe('String Anums Support', () => {
     test('should not show conversion toggle by default (mtl mode)', async ({ page }) => {
-      // By default, we're in MTL mode, so no conversion toggle
       const convToggle = page.locator('.toggle-btn').filter({ hasText: 'Conv' })
       await expect(convToggle).not.toBeVisible()
     })
 
     test('should not show file type badge in MTL mode', async ({ page }) => {
-      // MTL is the default mode, no badge should be shown
       await expect(page.locator('.file-type-badge')).not.toBeVisible()
     })
 
@@ -687,11 +579,8 @@ r♀ = r -> r♀
     })
   })
 
-  // Phase 3.3: Quaternary Anums (.anum) Tests
   test.describe('Quaternary Anums Support', () => {
     test('should have abit legend defined in conversion panel styles', async ({ page }) => {
-      // Verify that the page has the abit-legend CSS class defined
-      // (This tests that the anum panel structure is properly set up)
       const hasStyles = await page.evaluate(() => {
         const styleSheets = Array.from(document.styleSheets)
         for (const sheet of styleSheets) {
@@ -712,7 +601,6 @@ r♀ = r -> r♀
     })
   })
 
-  // Phase 3.4: Extended Resolution Algorithm Tests
   test.describe('Extended Resolution Algorithm', () => {
     test('should verify reflexivity (A1)', async ({ page }) => {
       const editor = page.locator('.code-input')
@@ -724,7 +612,6 @@ r♀ = r -> r♀
 
     test('should verify symmetry (A1) via proven equalities', async ({ page }) => {
       const editor = page.locator('.code-input')
-      // Reflexivity should work for any identifier
       await editor.fill('myVar = myVar')
 
       await expect(page.locator('.result-item.success')).toBeVisible()
@@ -739,19 +626,15 @@ r♀ = r -> r♀
     })
   })
 
-  // Phase 3.5: Performance and UX Tests
   test.describe('Performance and UX Features', () => {
     test('should handle large expressions without freezing', async ({ page }) => {
       const editor = page.locator('.code-input')
-      // Create a moderately large expression
       const largeExpr = Array.from({ length: 10 }, (_, i) => `a${i} = a${i}`).join('\n')
       await editor.fill(largeExpr)
 
-      // Should verify all without timeout
       const results = page.locator('.result-item')
       await expect(results).toHaveCount(10)
 
-      // All should be successful
       const successItems = page.locator('.result-item.success')
       await expect(successItems).toHaveCount(10)
     })
@@ -761,23 +644,16 @@ r♀ = r -> r♀
       const testContent = '// Test autosave content\na = a'
       await editor.fill(testContent)
 
-      // Manually trigger autosave by checking localStorage
-      // (actual autosave happens every 30s, but we can verify the mechanism)
-      const hasAutosaveKey = await page.evaluate(() => {
-        // Check if autosave mechanism is set up
-        return typeof Storage !== 'undefined'
-      })
+      const hasAutosaveKey = await page.evaluate(() => typeof Storage !== 'undefined')
       expect(hasAutosaveKey).toBe(true)
     })
 
     test('should support AST lazy loading for large expressions', async ({ page }) => {
       const editor = page.locator('.code-input')
-      // Create expression with nested structure
       await editor.fill('((a -> b) -> c) -> d')
 
       await expect(page.locator('.tree-root')).toBeVisible()
 
-      // AST should render without issues
       const treeNodes = page.locator('.tree-node-content')
       await expect(treeNodes.first()).toBeVisible()
     })
@@ -787,21 +663,15 @@ r♀ = r -> r♀
       await editor.fill('a -> b -> c')
 
       await expect(page.locator('.tree-root')).toBeVisible()
-
-      // Collapse all
       await page.locator('.ast-btn').nth(1).click()
 
-      // Look for child count indicators (if implemented)
-      // This tests the lazy loading infrastructure
       const toggles = page.locator('.tree-toggle')
       await expect(toggles.first()).toBeVisible()
     })
   })
 
-  // Phase 3.6: Testing and Documentation Verification
   test.describe('Documentation and Help', () => {
     test('should have correct version displayed', async ({ page }) => {
-      // Version should match package.json
       await expect(page.locator('.version')).toBeVisible()
       const version = await page.locator('.version').textContent()
       expect(version).toMatch(/^v\d+\.\d+\.\d+$/)

--- a/tests/integration/mtl_formulas.test.ts
+++ b/tests/integration/mtl_formulas.test.ts
@@ -1,267 +1,115 @@
 /**
- * Integration tests for МТС formulas
- * Tests the complete pipeline: text → AST → normalization → verification
+ * Integration tests for the aprover text → AST → normalization → verification
+ * pipeline.
  *
- * These tests verify that all formulas from tests/mtl_formulas.mtc
- * are correctly parsed, normalized, and verified.
- *
- * NOTE: Some formulas from mtl_formulas.mtc use syntax that is not yet
- * supported by the parser/prover:
- * - Multi-character identifiers as implicit links (e.g., "ab" meaning "a -> b")
- * - Implicit concatenation with parentheses (e.g., "ab(ab)")
- * - Standalone ♂♀ without operand
+ * The application does not define an independent MTS axiom system here.
+ * Normative MTS v0.2 syntax/contract lives in the pinned anum_docs artifacts;
+ * these tests only exercise application consumers of that language.
  */
 
 import { describe, it, expect } from 'vitest'
-import { parse } from '../../src/core/parser'
-import { normalize } from '../../src/core/normalizer'
+import { parse, parseExpr } from '../../src/core/parser'
+import { normalize, toCanonicalString } from '../../src/core/normalizer'
 import { createProverState, verify } from '../../src/core/prover'
 
-/**
- * Parse and verify a single formula string
- */
 function verifyFormula(formula: string): { success: boolean; message: string } {
-  const file = parse(formula)
-  const state = createProverState()
-  const stmt = file.statements[0]
-  const normalized = normalize(stmt.expr)
-  return verify(normalized, state)
+  const normalized = normalize(parseExpr(formula))
+  return verify(normalized, createProverState())
 }
 
-describe('Integration: mtl_formulas.mtc', () => {
-  describe('Male operator (♂) self-closing axiom', () => {
-    it('♂v = ♂v -> v (axiom А5)', () => {
-      const result = verifyFormula('♂v = ♂v -> v')
-      expect(result.success).toBe(true)
-    })
+describe('Integration: canonical MTS v0.2 application pipeline', () => {
+  it('keeps explicit grouping in parser and removes it only for semantic normalization', () => {
+    const parsed = parseExpr('a ⟼ (b ⟼ c)') as any
+    expect(parsed.type).toBe('Link')
+    expect(parsed.right.type).toBe('Round')
+    expect(parsed.right.content.type).toBe('Link')
 
-    it('♂♂v = ♂♂v -> ♂v', () => {
-      const result = verifyFormula('♂♂v = ♂♂v -> ♂v')
-      expect(result.success).toBe(true)
-    })
-
-    it('♂♂♂v = ♂♂♂v -> ♂♂v', () => {
-      const result = verifyFormula('♂♂♂v = ♂♂♂v -> ♂♂v')
-      expect(result.success).toBe(true)
-    })
-
-    it('♂∞ = ♂∞ -> ∞', () => {
-      const result = verifyFormula('♂∞ = ♂∞ -> ∞')
-      expect(result.success).toBe(true)
-    })
+    const normalized = normalize(parsed) as any
+    expect(normalized.type).toBe('Link')
+    expect(normalized.right.type).toBe('Link')
   })
 
-  describe('Female operator (♀) self-closing axiom', () => {
-    it('r♀ = r -> r♀ (axiom А6)', () => {
-      const result = verifyFormula('r♀ = r -> r♀')
-      expect(result.success).toBe(true)
-    })
-
-    it('r♀♀ = r♀ -> r♀♀', () => {
-      const result = verifyFormula('r♀♀ = r♀ -> r♀♀')
-      expect(result.success).toBe(true)
-    })
-
-    it('r♀♀♀ = r♀♀ -> r♀♀♀', () => {
-      const result = verifyFormula('r♀♀♀ = r♀♀ -> r♀♀♀')
-      expect(result.success).toBe(true)
-    })
-
-    it('∞♀ = ∞ -> ∞♀', () => {
-      const result = verifyFormula('∞♀ = ∞ -> ∞♀')
-      expect(result.success).toBe(true)
-    })
+  it('verifies reflexive judgments over canonical link syntax', () => {
+    expect(verifyFormula('(a ⟼ b) = (a ⟼ b)').success).toBe(true)
   })
 
-  describe('Infinity (∞) akorень axiom', () => {
-    it('∞ = ∞ -> ∞ (axiom А4)', () => {
-      const result = verifyFormula('∞ = ∞ -> ∞')
-      expect(result.success).toBe(true)
-    })
-
-    it('∞ = ∞ (reflexivity)', () => {
-      const result = verifyFormula('∞ = ∞')
-      expect(result.success).toBe(true)
-    })
-
-    it('∞ -> ∞ = ∞', () => {
-      const result = verifyFormula('∞ -> ∞ = ∞')
-      expect(result.success).toBe(true)
-    })
-
-    it('(∞ -> ∞) -> ∞ = ∞ -> ∞ -> ∞ (left associativity)', () => {
-      const result = verifyFormula('(∞ -> ∞) -> ∞ = ∞ -> ∞ -> ∞')
-      expect(result.success).toBe(true)
-    })
+  it('verifies reflexive judgments over canonical start projections', () => {
+    expect(verifyFormula('♀a = ♀a').success).toBe(true)
   })
 
-  describe('Inversion axiom (А7)', () => {
-    it('!♂x = x♀', () => {
-      const result = verifyFormula('!♂x = x♀')
-      expect(result.success).toBe(true)
-    })
-
-    it('!x♀ = ♂x', () => {
-      const result = verifyFormula('!x♀ = ♂x')
-      expect(result.success).toBe(true)
-    })
-
-    it('!♂∞ = ∞♀', () => {
-      const result = verifyFormula('!♂∞ = ∞♀')
-      expect(result.success).toBe(true)
-    })
-
-    it('!∞♀ = ♂∞', () => {
-      const result = verifyFormula('!∞♀ = ♂∞')
-      expect(result.success).toBe(true)
-    })
-
-    it('!♂♂x = ♂x♀', () => {
-      const result = verifyFormula('!♂♂x = ♂x♀')
-      expect(result.success).toBe(true)
-    })
+  it('verifies reflexive judgments over canonical end projections', () => {
+    expect(verifyFormula('a♂ = a♂').success).toBe(true)
   })
 
-  describe('Left associativity (А11)', () => {
-    it('a->b->c = (a->b)->c', () => {
-      const result = verifyFormula('a->b->c = (a->b)->c')
-      expect(result.success).toBe(true)
-    })
-
-    it('a->b->c->d = (a->b->c)->d', () => {
-      const result = verifyFormula('a->b->c->d = (a->b->c)->d')
-      expect(result.success).toBe(true)
-    })
-
-    it('(a->b)->c->d = ((a->b)->c)->d', () => {
-      const result = verifyFormula('(a->b)->c->d = ((a->b)->c)->d')
-      expect(result.success).toBe(true)
-    })
+  it('normalizes the canonical inversion glyph deterministically', () => {
+    expect(toCanonicalString(normalize(parseExpr('¬¬a')))).toBe('a')
   })
 
-  describe('Power operator expansion', () => {
-    it('a^2 = a -> a', () => {
-      const result = verifyFormula('a^2 = a -> a')
-      expect(result.success).toBe(true)
-    })
-
-    it('a^3 = (a -> a) -> a', () => {
-      const result = verifyFormula('a^3 = (a -> a) -> a')
-      expect(result.success).toBe(true)
-    })
-
-    it('a^4 = ((a -> a) -> a) -> a', () => {
-      const result = verifyFormula('a^4 = ((a -> a) -> a) -> a')
-      expect(result.success).toBe(true)
-    })
+  it('preserves empty round form as a semantic atom', () => {
+    expect(toCanonicalString(normalize(parseExpr('()')))).toBe('()')
+    expect(verifyFormula('() = ()').success).toBe(true)
   })
 
-  describe('Combined ♂∞♀ expressions', () => {
-    it('♂∞♀ = (♂∞)♀', () => {
-      const result = verifyFormula('♂∞♀ = (♂∞)♀')
-      expect(result.success).toBe(true)
-    })
+  it('preserves square forms as structures distinct from bare boundary glyphs', () => {
+    expect(toCanonicalString(normalize(parseExpr('[]')))).toBe('[]')
+    expect(toCanonicalString(normalize(parseExpr('[1]')))).toBe('[1]')
+    expect(toCanonicalString(normalize(parseExpr('[0]')))).toBe('[0]')
   })
 
-  describe('Inequality tests', () => {
-    it('♂∞♀ != ∞', () => {
-      const result = verifyFormula('♂∞♀ != ∞')
-      expect(result.success).toBe(true)
-    })
+  it('preserves context pronouns through normalization', () => {
+    expect(toCanonicalString(normalize(parseExpr('◁')))).toBe('◁')
+    expect(toCanonicalString(normalize(parseExpr('▷')))).toBe('▷')
+    expect(toCanonicalString(normalize(parseExpr('↑↑◁')))).toBe('↑↑◁')
+  })
 
-    it('♂∞ != ∞♀', () => {
-      const result = verifyFormula('♂∞ != ∞♀')
-      expect(result.success).toBe(true)
-    })
+  it('keeps literal (=) structurally distinct from equality judgment', () => {
+    const literal = parseExpr('(=)') as any
+    const judgment = parseExpr('a = b')
+    expect(literal.type).toBe('Round')
+    expect(literal.content.type).toBe('Literal')
+    expect(judgment.type).toBe('Equality')
+  })
+
+  it('parses every canonical root definition as an application input', () => {
+    const root = [
+      '∞ : {◁ = ∞, ▷ = ∞}',
+      '() : ♀() ⟼ ()♂',
+      '([) : (♀∞)',
+      '(]) : (∞♂)',
+      '(⟼) : (♀∞ ⟼ ∞♂)',
+      '(↛) : (∞♂ ⟼ ♀∞)',
+      '[1] : (⟼)',
+      '[0] : (↛)',
+      '(=) : {♀◁ = ♀▷, ◁♂ = ▷♂}',
+      '(!=) : ¬(=)',
+    ]
+
+    for (const formula of root) {
+      expect(parseExpr(formula).type).toBe('Definition')
+    }
   })
 })
 
-describe('Integration: Full pipeline test', () => {
-  it('should process multiple statements', () => {
+describe('Integration: multi-statement app input', () => {
+  it('processes several canonical judgments in one file', () => {
     const input = `
-      ∞ = ∞ -> ∞
-      ♂v = ♂v -> v
-      r♀ = r -> r♀
-      !♂x = x♀
+      ∞ = ∞
+      ♀v = ♀v
+      r♂ = r♂
+      (a ⟼ b) = (a ⟼ b)
     `
     const file = parse(input)
     expect(file.statements).toHaveLength(4)
 
     const state = createProverState()
     for (const stmt of file.statements) {
-      const normalized = normalize(stmt.expr)
-      const result = verify(normalized, state)
+      const result = verify(normalize(stmt.expr), state)
       expect(result.success).toBe(true)
     }
   })
 
-  it('should normalize and verify power expressions correctly', () => {
-    // Power expansion should work with normalizer
-    const input = 'a^5'
-    const file = parse(input)
-    const stmt = file.statements[0]
-    const normalized = normalize(stmt.expr)
-
-    // After normalization, a^5 should become ((((a -> a) -> a) -> a) -> a)
+  it('still expands application-only power sugar before verification', () => {
+    const normalized = normalize(parseExpr('a^5'))
     expect(normalized.type).toBe('Link')
-  })
-
-  it('should handle deep male nesting', () => {
-    const result = verifyFormula('♂♂♂♂v = ♂♂♂♂v -> ♂♂♂v')
-    expect(result.success).toBe(true)
-  })
-
-  it('should handle deep female nesting', () => {
-    const result = verifyFormula('r♀♀♀♀ = r♀♀♀ -> r♀♀♀♀')
-    expect(result.success).toBe(true)
-  })
-})
-
-/**
- * Future tests: formulas that require features not yet implemented
- *
- * The following tests document formulas from mtl_formulas.mtc that
- * require parser or prover features not yet implemented:
- *
- * 1. Multi-character identifiers as implicit links:
- *    - "ab = a -> b" (ab is parsed as identifier, not as a -> b)
- *    - "aa = a -> a"
- *    - "aaa = (a -> a) -> a"
- *
- * 2. Implicit concatenation with parentheses:
- *    - "ab(ab)" should be "(a -> b) -> (a -> b)"
- *    - Parser doesn't support identifier followed by parenthesized expression
- *
- * 3. Standalone ♂♀:
- *    - "♂♀ = ∞" requires ♂♀ to be parsed without operand
- *    - Parser requires operand for both ♂ and ♀
- *
- * 4. Extended ∞ equality proofs:
- *    - "∞ = ∞ -> ∞ -> ∞" (requires repeated application of ∞ axiom)
- *    - "∞ = ((∞ -> ∞) -> ∞) -> ∞" (similar)
- *    - Prover doesn't recursively apply ∞ axiom yet
- *
- * 5. Inverse of combined operators:
- *    - "!♂x♀ = ♂♂x" (requires understanding !(♂(x♀)) = ♂♂x)
- *
- * These tests are documented here to track what needs to be implemented
- * in future development phases.
- */
-describe('Integration: Currently unsupported features (documented)', () => {
-  it.skip('ab = a -> b (multi-char implicit links)', () => {
-    // This would require treating multi-char identifiers as link chains
-    const result = verifyFormula('ab = a -> b')
-    expect(result.success).toBe(true)
-  })
-
-  it.skip('∞ = ∞ -> ∞ -> ∞ (recursive ∞ axiom)', () => {
-    // Requires recursive application of ∞ axiom
-    const result = verifyFormula('∞ = ∞ -> ∞ -> ∞')
-    expect(result.success).toBe(true)
-  })
-
-  it.skip('♂♀ = ∞ (standalone ♂♀)', () => {
-    // Parser doesn't support ♂♀ without operand
-    // This would require grammar changes
   })
 })

--- a/tests/unit/interactive.test.ts
+++ b/tests/unit/interactive.test.ts
@@ -120,15 +120,15 @@ describe('Interactive Proof Mode', () => {
       expect(reflexivityStep!.confidence).toBe(1.0)
     })
 
-    it('should suggest A5 axiom for male expressions', () => {
-      session.addGoalFromString('♂v = ♂v -> v')
+    it('should suggest A5 axiom for canonical end projection', () => {
+      session.addGoalFromString('v♂ = v♂ -> v')
       const steps = session.getAvailableSteps()
       const maleStep = steps.find(s => s.axiom?.id === 'A5')
       expect(maleStep).toBeDefined()
     })
 
-    it('should suggest A6 axiom for female expressions', () => {
-      session.addGoalFromString('r♀ = r -> r♀')
+    it('should suggest A6 axiom for canonical start projection', () => {
+      session.addGoalFromString('♀r = r -> ♀r')
       const steps = session.getAvailableSteps()
       const femaleStep = steps.find(s => s.axiom?.id === 'A6')
       expect(femaleStep).toBeDefined()
@@ -157,7 +157,7 @@ describe('Interactive Proof Mode', () => {
     })
 
     it('should have unique IDs for all steps', () => {
-      session.addGoalFromString('♂∞ = ♂∞ -> ∞')
+      session.addGoalFromString('∞♂ = ∞♂ -> ∞')
       const steps = session.getAvailableSteps()
       const ids = steps.map(s => s.id)
       const uniqueIds = new Set(ids)
@@ -174,14 +174,12 @@ describe('Interactive Proof Mode', () => {
 
     it('should apply step by ID', () => {
       session.addGoalFromString('a = a')
-      // Get steps - they are now cached
       const steps = session.getAvailableSteps()
       expect(steps.length).toBeGreaterThan(0)
-      const step = steps[0] // First step is highest confidence after sorting
+      const step = steps[0]
       expect(step).toBeDefined()
       expect(step.id).toBeDefined()
 
-      // Apply using the step ID - works because steps are cached
       const result = session.applyStep(step.id)
       expect(result.success).toBe(true)
     })
@@ -248,11 +246,9 @@ describe('Interactive Proof Mode', () => {
 
     it('should stop at max iterations', () => {
       const session = createProofSession('automatic')
-      // Add a goal that might take many iterations
       session.addGoalFromString('(aa -> bb) = (cc -> dd)')
       const results = session.runAutomatic()
 
-      // Should eventually stop even if not proved
       expect(results.length).toBeLessThanOrEqual(100)
     })
   })
@@ -358,9 +354,8 @@ describe('Interactive Proof Mode', () => {
     })
 
     it('should jump to specific history point', () => {
-      // Verify history exists before jumping
       expect(session.getHistory().length).toBeGreaterThan(0)
-      const targetIndex = 1 // Second action
+      const targetIndex = 1
 
       const result = session.jumpToHistory(targetIndex)
       expect(result).toBe(true)
@@ -396,11 +391,11 @@ describe('Interactive Proof Mode', () => {
         const steps = getSuggestedSteps(goal, state)
 
         expect(steps.length).toBeGreaterThan(0)
-        expect(steps.length).toBeLessThanOrEqual(5) // Default max
+        expect(steps.length).toBeLessThanOrEqual(5)
       })
 
       it('should respect maxSteps parameter', () => {
-        const goal = normalize(parseExpr('♂v = ♂v -> v'))
+        const goal = normalize(parseExpr('v♂ = v♂ -> v'))
         const state = createProverState()
         const steps = getSuggestedSteps(goal, state, 2)
 
@@ -424,8 +419,8 @@ describe('Interactive Proof Mode', () => {
         expect(result.success).toBe(true)
       })
 
-      it('should prove ♂v = ♂v -> v', () => {
-        const goal = normalize(parseExpr('♂v = ♂v -> v'))
+      it('should prove canonical end-projection fixture', () => {
+        const goal = normalize(parseExpr('v♂ = v♂ -> v'))
         const result = quickProof(goal)
 
         expect(result.success).toBe(true)
@@ -469,17 +464,17 @@ describe('Interactive Proof Mode', () => {
       expect(state.provenImplications.length).toBeGreaterThan(0)
     })
 
-    it('should prove with A5 axiom expansion', () => {
+    it('should prove with A5 axiom expansion through canonical end projection', () => {
       const session = createProofSession()
-      session.addGoalFromString('♂v = (♂v -> v) -> v')
+      session.addGoalFromString('v♂ = (v♂ -> v) -> v')
       session.runAutomatic()
 
       expect(session.status).toBe('completed')
     })
 
-    it('should prove with A6 axiom expansion', () => {
+    it('should prove with A6 axiom expansion through canonical start projection', () => {
       const session = createProofSession()
-      session.addGoalFromString('r♀ = r -> (r -> r♀)')
+      session.addGoalFromString('♀r = r -> (r -> ♀r)')
       session.runAutomatic()
 
       expect(session.status).toBe('completed')

--- a/tests/unit/linkGraph.test.ts
+++ b/tests/unit/linkGraph.test.ts
@@ -47,14 +47,16 @@ describe('LinkGraph', () => {
     })
 
     it('projects male and female self-closing forms', () => {
-      const male = projectToGraph(normalize(parseExpr('♂x')))
-      const female = projectToGraph(normalize(parseExpr('x♀')))
+      const male = projectToGraph(normalize(parseExpr('x♂')))
+      const female = projectToGraph(normalize(parseExpr('♀x')))
 
       expect(male.nodes.filter(n => n.nodeType === 'unary')).toHaveLength(1)
+      expect(male.nodes.find(n => n.nodeType === 'unary')?.label).toBe('x♂')
       expect(male.edges.filter(e => e.edgeType === 'self-start')).toHaveLength(1)
       expect(male.edges.filter(e => e.edgeType === 'link-end')).toHaveLength(1)
 
       expect(female.nodes.filter(n => n.nodeType === 'unary')).toHaveLength(1)
+      expect(female.nodes.find(n => n.nodeType === 'unary')?.label).toBe('♀x')
       expect(female.edges.filter(e => e.edgeType === 'link-start')).toHaveLength(1)
       expect(female.edges.filter(e => e.edgeType === 'self-end')).toHaveLength(1)
     })

--- a/tests/unit/mtsCanonicalizationConformance.test.ts
+++ b/tests/unit/mtsCanonicalizationConformance.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { parseExpr } from '../../src/core/parser'
+import { toMtsSource } from '../../src/core/mtsSource'
+
+interface CanonicalizationCase {
+  id: string
+  source: string
+  canonical: string
+}
+
+interface ConformanceCorpus {
+  schema: string
+  canonicalization: CanonicalizationCase[]
+}
+
+function loadCorpus(): ConformanceCorpus {
+  const path = resolve(
+    process.cwd(),
+    'contracts/anum_docs-v0.2/mts-conformance-v0.2.json'
+  )
+  return JSON.parse(readFileSync(path, 'utf8')) as ConformanceCorpus
+}
+
+describe('MTS v0.2 upstream canonicalization conformance', () => {
+  const corpus = loadCorpus()
+
+  it('uses canonicalization vectors from the pinned upstream corpus', () => {
+    expect(corpus.schema).toBe('mts-conformance/v0.2')
+    expect(corpus.canonicalization.length).toBeGreaterThan(0)
+  })
+
+  for (const testCase of corpus.canonicalization) {
+    it(testCase.id, () => {
+      expect(toMtsSource(parseExpr(testCase.source))).toBe(testCase.canonical)
+    })
+  }
+
+  it('preserves canonical projection fixity during parse/serialize round-trip', () => {
+    const canonical = '(=) : {♀◁ = ♀▷, ◁♂ = ▷♂}'
+    expect(toMtsSource(parseExpr(canonical))).toBe(canonical)
+  })
+})

--- a/tests/unit/mtsLexerConformance.test.ts
+++ b/tests/unit/mtsLexerConformance.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { tokenize, toMtsConformanceToken } from '../../src/core/lexer'
+
+interface LexingCase {
+  id: string
+  source: string
+  tokens: string[]
+}
+
+interface ConformanceCorpus {
+  schema: string
+  lexing: LexingCase[]
+}
+
+function loadCorpus(): ConformanceCorpus {
+  const path = resolve(
+    process.cwd(),
+    'contracts/anum_docs-v0.2/mts-conformance-v0.2.json'
+  )
+  return JSON.parse(readFileSync(path, 'utf8')) as ConformanceCorpus
+}
+
+describe('MTS v0.2 upstream lexer conformance', () => {
+  const corpus = loadCorpus()
+
+  it('uses the pinned v0.2 corpus', () => {
+    expect(corpus.schema).toBe('mts-conformance/v0.2')
+    expect(corpus.lexing.length).toBeGreaterThan(0)
+  })
+
+  for (const testCase of corpus.lexing) {
+    it(testCase.id, () => {
+      const actual = tokenize(testCase.source)
+        .filter(token => token.type !== 'EOF')
+        .map(toMtsConformanceToken)
+
+      expect(actual).not.toContain(null)
+      expect(actual).toEqual(testCase.tokens)
+    })
+  }
+
+  it('keeps square brackets lexically independent from pronouns', () => {
+    const tokens = tokenize('◁[]▷').filter(token => token.type !== 'EOF')
+
+    expect(tokens.map(token => token.value)).toEqual(['◁', '[', ']', '▷'])
+    expect(tokens.map(token => token.type)).toEqual([
+      'CONTEXT_START',
+      'LBRACKET',
+      'RBRACKET',
+      'CONTEXT_END',
+    ])
+  })
+
+  it('accepts the canonical link glyph without changing its token class', () => {
+    const tokens = tokenize('◁ ⟼ ▷')
+    expect(tokens.map(token => token.type)).toEqual([
+      'CONTEXT_START',
+      'ARROW',
+      'CONTEXT_END',
+      'EOF',
+    ])
+    expect(tokens[1].value).toBe('⟼')
+  })
+})

--- a/tests/unit/mtsParserV02.test.ts
+++ b/tests/unit/mtsParserV02.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  ContextPronounExpr,
+  DefExpr,
+  EqExpr,
+  FemaleExpr,
+  LiteralExpr,
+  MaleExpr,
+  RoundExpr,
+  SetExpr,
+  SquareExpr,
+} from '../../src/core/ast'
+import { astToString } from '../../src/core/ast'
+import { parseExpr } from '../../src/core/parser'
+
+const ROOT_V02 = [
+  '∞ : {◁ = ∞, ▷ = ∞}',
+  '() : ♀() ⟼ ()♂',
+  '([) : (♀∞)',
+  '(]) : (∞♂)',
+  '(⟼) : (♀∞ ⟼ ∞♂)',
+  '(↛) : (∞♂ ⟼ ♀∞)',
+  '[1] : (⟼)',
+  '[0] : (↛)',
+  '(=) : {♀◁ = ♀▷, ◁♂ = ▷♂}',
+  '(!=) : ¬(=)',
+]
+
+describe('MTS v0.2 canonical parser surface', () => {
+  it('parses every canonical root line as one definition', () => {
+    for (const source of ROOT_V02) {
+      expect(parseExpr(source).type, source).toBe('Definition')
+    }
+  })
+
+  it('keeps meaning-of-equality distinct from equality judgment', () => {
+    const meaning = parseExpr('(=)') as RoundExpr
+    const judgment = parseExpr('a = b') as EqExpr
+
+    expect(meaning.type).toBe('Round')
+    expect((meaning.content as LiteralExpr).type).toBe('Literal')
+    expect((meaning.content as LiteralExpr).value).toBe('=')
+    expect(judgment.type).toBe('Equality')
+  })
+
+  it('keeps empty round and square forms as explicit AST nodes', () => {
+    expect(parseExpr('()')).toMatchObject({ type: 'Round', content: null })
+    expect(parseExpr('[]')).toMatchObject({ type: 'Square', content: null })
+    expect(parseExpr('[1]')).toMatchObject({
+      type: 'Square',
+      content: { type: 'Num', value: 1 },
+    })
+  })
+
+  it('parses the two atomic pronouns and separate ancestor ascent', () => {
+    expect(parseExpr('◁')).toMatchObject({ type: 'ContextPronoun', pole: 'start', up: 0 })
+    expect(parseExpr('▷')).toMatchObject({ type: 'ContextPronoun', pole: 'end', up: 0 })
+    expect(parseExpr('↑↑◁')).toMatchObject({ type: 'ContextPronoun', pole: 'start', up: 2 })
+    expect(() => parseExpr('↑')).toThrow(/Expected ◁ or ▷/)
+  })
+
+  it('uses canonical projection orientation', () => {
+    const start = parseExpr('♀◁') as FemaleExpr
+    const end = parseExpr('▷♂') as MaleExpr
+
+    expect(start.type).toBe('Female')
+    expect((start.operand as ContextPronounExpr).pole).toBe('start')
+    expect(end.type).toBe('Male')
+    expect((end.operand as ContextPronounExpr).pole).toBe('end')
+    expect(astToString(start)).toBe('♀◁')
+    expect(astToString(end)).toBe('▷♂')
+  })
+
+  it('parses aroot definition as a bundle of two contextual judgments', () => {
+    const definition = parseExpr('∞ : {◁ = ∞, ▷ = ∞}') as DefExpr
+    const bundle = definition.form as SetExpr
+
+    expect(bundle.type).toBe('Set')
+    expect(bundle.elements).toHaveLength(2)
+    expect(bundle.elements.every(item => item.type === 'Equality')).toBe(true)
+  })
+
+  it('distinguishes square container from literal square boundary in round form', () => {
+    const square = parseExpr('[0]') as SquareExpr
+    const leftMeaning = parseExpr('([)') as RoundExpr
+    const rightMeaning = parseExpr('(])') as RoundExpr
+
+    expect(square.type).toBe('Square')
+    expect(leftMeaning.content).toMatchObject({ type: 'Literal', value: '[' })
+    expect(rightMeaning.content).toMatchObject({ type: 'Literal', value: ']' })
+  })
+})

--- a/tests/unit/normalizer.test.ts
+++ b/tests/unit/normalizer.test.ts
@@ -30,17 +30,14 @@ describe('Normalizer', () => {
     })
 
     it('should expand power a^2', () => {
-      // a^2 = (a -> a)
       expect(canonical('a^2')).toBe('(a->a)')
     })
 
     it('should expand power a^3', () => {
-      // a^3 = ((a -> a) -> a)
       expect(canonical('a^3')).toBe('((a->a)->a)')
     })
 
     it('should expand power a^4', () => {
-      // a^4 = (((a -> a) -> a) -> a)
       expect(canonical('a^4')).toBe('(((a->a)->a)->a)')
     })
   })
@@ -50,16 +47,16 @@ describe('Normalizer', () => {
       expect(canonical('!!x')).toBe('x')
     })
 
-    it('should convert !(♂x) -> x♀', () => {
-      expect(canonical('!♂x')).toBe('x♀')
+    it('should map inversion of end projection to start projection', () => {
+      expect(canonical('!x♂')).toBe('♀x')
     })
 
-    it('should convert !(x♀) -> ♂x', () => {
-      expect(canonical('!x♀')).toBe('♂x')
+    it('should map inversion of start projection to end projection', () => {
+      expect(canonical('!♀x')).toBe('x♂')
     })
 
-    it('should handle nested negations', () => {
-      expect(canonical('!!!x')).toBe('!x')
+    it('should print the canonical inversion glyph', () => {
+      expect(canonical('!!!x')).toBe('¬x')
       expect(canonical('!!!!x')).toBe('x')
     })
   })
@@ -78,7 +75,6 @@ describe('Normalizer', () => {
     })
 
     it('should handle normalized equivalence', () => {
-      // After normalization, these should be equal
       const a = normExpr('!!x')
       const b = normExpr('x')
       expect(astEqual(a, b)).toBe(true)
@@ -87,34 +83,38 @@ describe('Normalizer', () => {
 
   describe('Guarded recursion check', () => {
     it('should accept valid recursive definition', () => {
-      // ♂x : (♂x -> x) is valid because ♂x appears under ->
       expect(() => normExpr('abc : (abc -> x)')).not.toThrow()
     })
 
-    it('should accept ∞ definition', () => {
-      // ∞ : (∞ -> ∞) is valid because ∞ appears under ->
+    it('should accept recursive definition under link constructor', () => {
       expect(() => normExpr('inf : (inf -> inf)')).not.toThrow()
     })
 
     it('should reject unguarded recursion', () => {
-      // x : x is not valid
       expect(() => normExpr('x : x')).toThrow(NormalizationError)
     })
 
-    it('should reject unguarded recursion in complex expression', () => {
-      // x : ♂x is not valid (♂ doesn't guard recursion)
-      expect(() => normExpr('myvar : ♂myvar')).toThrow(NormalizationError)
+    it('should reject unguarded recursion under projection', () => {
+      expect(() => normExpr('myvar : myvar♂')).toThrow(NormalizationError)
     })
   })
 
   describe('Canonical string', () => {
-    it('should produce consistent canonical form', () => {
-      // These should have the same canonical form
+    it('should make non-empty round grouping semantically transparent', () => {
       expect(canonical('a -> b -> c')).toBe(canonical('(a -> b) -> c'))
     })
 
     it('should distinguish different structures', () => {
       expect(canonical('a -> b -> c')).not.toBe(canonical('a -> (b -> c)'))
+    })
+
+    it('should preserve empty round form as an atom', () => {
+      expect(canonical('()')).toBe('()')
+    })
+
+    it('should preserve square and context forms', () => {
+      expect(canonical('[1]')).toBe('[1]')
+      expect(canonical('↑◁')).toBe('↑◁')
     })
 
     it('should sort set elements', () => {
@@ -124,20 +124,15 @@ describe('Normalizer', () => {
 
   describe('Normalization caching', () => {
     beforeEach(() => {
-      // Clear cache before each test
       clearNormalizationCache()
       setNormalizationCacheEnabled(true)
     })
 
     it('should cache normalization results', () => {
       const expr = 'a -> b -> c'
-
-      // First normalization - should be a cache miss
       normalize(parseExpr(expr))
       const stats1 = getNormalizationCacheStats()
       expect(stats1.misses).toBeGreaterThan(0)
-
-      // Second normalization of the same expression - should be a cache hit
       normalize(parseExpr(expr))
       const stats2 = getNormalizationCacheStats()
       expect(stats2.hits).toBeGreaterThan(0)
@@ -156,8 +151,6 @@ describe('Normalizer', () => {
       const result1 = normalize(parseExpr(expr))
       const result2 = normalize(parseExpr(expr))
       expect(toCanonicalString(result1)).toBe(toCanonicalString(result2))
-
-      // Stats should not change when caching is disabled
       const stats = getNormalizationCacheStats()
       expect(stats.hits).toBe(0)
       expect(stats.misses).toBe(0)
@@ -168,7 +161,6 @@ describe('Normalizer', () => {
       normalize(parseExpr(expr))
       const stats1 = getNormalizationCacheStats()
       expect(stats1.size).toBeGreaterThan(0)
-
       clearNormalizationCache()
       const stats2 = getNormalizationCacheStats()
       expect(stats2.size).toBe(0)
@@ -179,18 +171,12 @@ describe('Normalizer', () => {
     it('should track cache statistics correctly', () => {
       const expr1 = 'a -> b'
       const expr2 = 'c -> d'
-
-      // First calls are misses
       normalize(parseExpr(expr1))
       normalize(parseExpr(expr2))
-
       const statsAfterMisses = getNormalizationCacheStats()
       expect(statsAfterMisses.size).toBe(2)
-
-      // Second calls are hits
       normalize(parseExpr(expr1))
       normalize(parseExpr(expr2))
-
       const statsAfterHits = getNormalizationCacheStats()
       expect(statsAfterHits.hits).toBe(2)
     })
@@ -199,20 +185,14 @@ describe('Normalizer', () => {
       const expr = 'a^3'
       const result1 = normalize(parseExpr(expr))
       const result2 = normalize(parseExpr(expr))
-
-      // Both should produce ((a->a)->a)
       expect(toCanonicalString(result1)).toBe('((a->a)->a)')
       expect(toCanonicalString(result2)).toBe('((a->a)->a)')
     })
 
     it('should handle different normalization options separately', () => {
       const expr = parseExpr('a !-> b')
-
-      // Default options (desugar enabled)
       const result1 = normalize(expr)
       expect(result1.type).toBe('Not')
-
-      // Custom options (desugar disabled)
       const result2 = normalize(expr, { desugarNotLink: false })
       expect(result2.type).toBe('NotLink')
     })
@@ -220,17 +200,12 @@ describe('Normalizer', () => {
     it('should calculate hit rate correctly', () => {
       clearNormalizationCache()
       const expr = 'a -> b'
-
-      // 2 misses
       normalize(parseExpr(expr))
       normalize(parseExpr('c -> d'))
-
-      // 2 hits
       normalize(parseExpr(expr))
       normalize(parseExpr('c -> d'))
-
       const stats = getNormalizationCacheStats()
-      expect(stats.hitRate).toBe(0.5) // 2 hits / 4 total = 0.5
+      expect(stats.hitRate).toBe(0.5)
     })
   })
 })

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for МТС parser
+ * Unit tests for the МТС parser consumed from anum_docs.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -8,8 +8,7 @@ import { parse, parseExpr, parseWithRecovery, ParseError } from '../../src/core/
 describe('Parser', () => {
   describe('Basic expressions', () => {
     it('should parse infinity', () => {
-      const ast = parseExpr('∞')
-      expect(ast.type).toBe('Infinity')
+      expect(parseExpr('∞').type).toBe('Infinity')
     })
 
     it('should parse numeric constants', () => {
@@ -23,198 +22,170 @@ describe('Parser', () => {
       expect((ast as any).name).toBe('x')
     })
 
-    it('should parse abit literals (single quotes for quaternary abits)', () => {
+    it('should parse legacy serialized abit literals independently from L2 square forms', () => {
       const ast = parseExpr("'01[]'")
       expect(ast.type).toBe('AbitLit')
       expect((ast as any).value).toBe('01[]')
     })
 
-    it('should parse single abit character', () => {
-      const ast = parseExpr("'0'")
-      expect(ast.type).toBe('AbitLit')
-      expect((ast as any).value).toBe('0')
-    })
-
-    it('should parse abit sequence in expression context', () => {
-      const ast = parseExpr("'[01]' -> '[]'")
-      expect(ast.type).toBe('Link')
-      expect((ast as any).left.type).toBe('AbitLit')
-      expect((ast as any).right.type).toBe('AbitLit')
-    })
-
-    it('should parse string literals (double quotes for string anums)', () => {
-      const ast = parseExpr('"hello"')
-      expect(ast.type).toBe('StringLit')
-      expect((ast as any).value).toBe('hello')
-    })
-
-    it('should parse empty string literal', () => {
-      const ast = parseExpr('""')
-      expect(ast.type).toBe('StringLit')
-      expect((ast as any).value).toBe('')
-    })
-
-    it('should parse string literal with UTF-8 characters', () => {
+    it('should parse string literals', () => {
       const ast = parseExpr('"связь"')
       expect(ast.type).toBe('StringLit')
       expect((ast as any).value).toBe('связь')
     })
 
-    it('should parse string literal in expression context', () => {
-      const ast = parseExpr('"hello" -> "world"')
-      expect(ast.type).toBe('Link')
-      expect((ast as any).left.type).toBe('StringLit')
-      expect((ast as any).right.type).toBe('StringLit')
+    it('should parse canonical square forms', () => {
+      expect(parseExpr('[]').type).toBe('Square')
+      expect(parseExpr('[1]').type).toBe('Square')
+      expect(parseExpr('[0]').type).toBe('Square')
     })
 
-    it('should parse brackets', () => {
-      expect(parseExpr('[').type).toBe('Bracket')
-      expect(parseExpr(']').type).toBe('Bracket')
+    it('should not treat a bare square boundary as an L2 form', () => {
+      expect(() => parseExpr('[')).toThrow(ParseError)
+      expect(() => parseExpr(']')).toThrow(ParseError)
+    })
+
+    it('should parse literal square boundary glyphs inside round forms', () => {
+      const left = parseExpr('([)')
+      const right = parseExpr('(])')
+      expect(left.type).toBe('Round')
+      expect(right.type).toBe('Round')
+      expect((left as any).content.type).toBe('Literal')
+      expect((right as any).content.type).toBe('Literal')
+    })
+
+    it('should parse atomic context pronouns and ascent', () => {
+      expect(parseExpr('◁').type).toBe('ContextPronoun')
+      expect(parseExpr('▷').type).toBe('ContextPronoun')
+      const parent = parseExpr('↑◁') as any
+      expect(parent.type).toBe('ContextPronoun')
+      expect(parent.up).toBe(1)
     })
   })
 
   describe('Link expressions', () => {
-    it('should parse simple link', () => {
-      const ast = parseExpr('a -> b')
+    it('should parse the canonical link glyph', () => {
+      const ast = parseExpr('a ⟼ b')
       expect(ast.type).toBe('Link')
       expect((ast as any).left.type).toBe('Identifier')
       expect((ast as any).right.type).toBe('Identifier')
     })
 
-    it('should parse left-associative chains', () => {
-      const ast = parseExpr('a -> b -> c')
+    it('should preserve left-associative chains', () => {
+      const ast = parseExpr('a ⟼ b ⟼ c')
       expect(ast.type).toBe('Link')
-      // Should be ((a -> b) -> c)
       expect((ast as any).left.type).toBe('Link')
       expect((ast as any).right.type).toBe('Identifier')
     })
-
-    it('should parse not-link', () => {
-      const ast = parseExpr('a !-> b')
-      expect(ast.type).toBe('NotLink')
-    })
   })
 
-  describe('Prefix operators', () => {
-    it('should parse male prefix', () => {
-      const ast = parseExpr('♂x')
-      expect(ast.type).toBe('Male')
-      expect((ast as any).operand.type).toBe('Identifier')
-    })
-
-    it('should parse nested male', () => {
-      const ast = parseExpr('♂♂x')
-      expect(ast.type).toBe('Male')
-      expect((ast as any).operand.type).toBe('Male')
-    })
-
-    it('should parse not prefix', () => {
-      const ast = parseExpr('!x')
-      expect(ast.type).toBe('Not')
-    })
-
-    it('should parse combined prefixes', () => {
-      const ast = parseExpr('!♂x')
-      expect(ast.type).toBe('Not')
-      expect((ast as any).operand.type).toBe('Male')
-    })
-  })
-
-  describe('Postfix operators', () => {
-    it('should parse female postfix', () => {
-      const ast = parseExpr('x♀')
+  describe('Canonical projections and inversion', () => {
+    it('should parse start projection as prefix ♀F', () => {
+      const ast = parseExpr('♀x')
       expect(ast.type).toBe('Female')
       expect((ast as any).operand.type).toBe('Identifier')
     })
 
-    it('should parse nested female', () => {
-      const ast = parseExpr('x♀♀')
+    it('should parse nested start projections', () => {
+      const ast = parseExpr('♀♀x')
       expect(ast.type).toBe('Female')
       expect((ast as any).operand.type).toBe('Female')
     })
 
-    it('should parse power', () => {
-      const ast = parseExpr('a^2')
-      expect(ast.type).toBe('Power')
-      expect((ast as any).exponent).toBe(2)
+    it('should parse end projection as postfix F♂', () => {
+      const ast = parseExpr('x♂')
+      expect(ast.type).toBe('Male')
+      expect((ast as any).operand.type).toBe('Identifier')
+    })
+
+    it('should parse nested end projections', () => {
+      const ast = parseExpr('x♂♂')
+      expect(ast.type).toBe('Male')
+      expect((ast as any).operand.type).toBe('Male')
+    })
+
+    it('should parse inversion with canonical glyph', () => {
+      const ast = parseExpr('¬x')
+      expect(ast.type).toBe('Not')
     })
   })
 
-  describe('Definitions and equalities', () => {
+  describe('Definitions and judgments', () => {
     it('should parse definition', () => {
-      const ast = parseExpr('∞ : ∞ -> ∞')
-      expect(ast.type).toBe('Definition')
+      expect(parseExpr('∞ : {◁ = ∞, ▷ = ∞}').type).toBe('Definition')
     })
 
     it('should parse equality', () => {
-      const ast = parseExpr('a = b')
-      expect(ast.type).toBe('Equality')
+      expect(parseExpr('a = b').type).toBe('Equality')
     })
 
     it('should parse inequality', () => {
-      const ast = parseExpr('a != b')
-      expect(ast.type).toBe('Inequality')
+      expect(parseExpr('a != b').type).toBe('Inequality')
     })
   })
 
-  describe('Sets', () => {
-    it('should parse empty-ish set', () => {
-      // Note: our grammar requires at least one element
+  describe('Bundles', () => {
+    it('should parse one-element bundle', () => {
       const ast = parseExpr('{ a }')
       expect(ast.type).toBe('Set')
       expect((ast as any).elements.length).toBe(1)
     })
 
-    it('should parse multi-element set', () => {
+    it('should parse multi-element bundle', () => {
       const ast = parseExpr('{ a, b, c }')
       expect(ast.type).toBe('Set')
       expect((ast as any).elements.length).toBe(3)
     })
   })
 
-  describe('Parentheses', () => {
-    it('should parse parenthesized expression', () => {
+  describe('Round forms', () => {
+    it('should preserve explicit round form in AST', () => {
       const ast = parseExpr('(a)')
-      expect(ast.type).toBe('Identifier')
+      expect(ast.type).toBe('Round')
+      expect((ast as any).content.type).toBe('Identifier')
     })
 
-    it('should override associativity', () => {
-      const ast = parseExpr('a -> (b -> c)')
+    it('should preserve grouping structure', () => {
+      const ast = parseExpr('a ⟼ (b ⟼ c)')
       expect(ast.type).toBe('Link')
-      // Right side should be a link, not identifier
-      expect((ast as any).right.type).toBe('Link')
+      expect((ast as any).right.type).toBe('Round')
+      expect((ast as any).right.content.type).toBe('Link')
+    })
+
+    it('should preserve empty round form as a formal atom', () => {
+      const ast = parseExpr('()')
+      expect(ast.type).toBe('Round')
+      expect((ast as any).content).toBeNull()
+    })
+
+    it('should distinguish literal (=) from equality operator', () => {
+      const literal = parseExpr('(=)')
+      const judgment = parseExpr('a = b')
+      expect(literal.type).toBe('Round')
+      expect((literal as any).content.type).toBe('Literal')
+      expect(judgment.type).toBe('Equality')
     })
   })
 
-  describe('Complex expressions', () => {
-    it('should parse МТС axioms', () => {
-      // А4: ∞ : (∞ -> ∞)
-      const ast1 = parseExpr('∞ : (∞ -> ∞)')
-      expect(ast1.type).toBe('Definition')
+  describe('Canonical root definitions', () => {
+    const root = [
+      '∞ : {◁ = ∞, ▷ = ∞}',
+      '() : ♀() ⟼ ()♂',
+      '([) : (♀∞)',
+      '(]) : (∞♂)',
+      '(⟼) : (♀∞ ⟼ ∞♂)',
+      '(↛) : (∞♂ ⟼ ♀∞)',
+      '[1] : (⟼)',
+      '[0] : (↛)',
+      '(=) : {♀◁ = ♀▷, ◁♂ = ▷♂}',
+      '(!=) : ¬(=)',
+    ]
 
-      // А5: ♂x : (♂x -> x)
-      const ast2 = parseExpr('♂x : (♂x -> x)')
-      expect(ast2.type).toBe('Definition')
-
-      // А6: x♀ : (x -> x♀)
-      const ast3 = parseExpr('x♀ : (x -> x♀)')
-      expect(ast3.type).toBe('Definition')
-
-      // А8: 1 : (♂∞ -> ∞♀)
-      const ast4 = parseExpr('1 : (♂∞ -> ∞♀)')
-      expect(ast4.type).toBe('Definition')
-    })
-
-    it('should parse complex equalities', () => {
-      // From mtl_formulas.mtc
-      const ast = parseExpr('a -> b -> c = (a -> b) -> c')
-      expect(ast.type).toBe('Equality')
-    })
-
-    it('should parse complex inequalities', () => {
-      const ast = parseExpr('♂∞♀ != ∞')
-      expect(ast.type).toBe('Inequality')
-    })
+    for (const formula of root) {
+      it(`should parse ${formula}`, () => {
+        expect(parseExpr(formula).type).toBe('Definition')
+      })
+    }
   })
 
   describe('File parsing', () => {
@@ -226,121 +197,45 @@ describe('Parser', () => {
 
     it('should parse multiple statements with newlines', () => {
       const file = parse('a = b\nc = d')
-      expect(file.type).toBe('File')
       expect(file.statements.length).toBe(2)
     })
 
-    it('should parse multiple statements without separators', () => {
-      const file = parse('a = b\nc = d\ne = f')
-      expect(file.type).toBe('File')
-      expect(file.statements.length).toBe(3)
-    })
-
-    it('should parse mixed separators (commas and newlines)', () => {
-      const file = parse('a = b\nc = d,\ne = f')
-      expect(file.type).toBe('File')
-      expect(file.statements.length).toBe(3)
-    })
-
     it('should parse empty file', () => {
-      const file = parse('')
-      expect(file.statements.length).toBe(0)
+      expect(parse('').statements.length).toBe(0)
     })
   })
 
-  describe('Error handling', () => {
+  describe('Error handling and recovery', () => {
     it('should throw on unexpected token', () => {
       expect(() => parseExpr(')')).toThrow(ParseError)
     })
-  })
 
-  describe('Partial parsing with error recovery', () => {
-    it('should return partial AST when error occurs after valid statements', () => {
-      const input = `
-a = b
-c = d
-e = f)
-      `.trim()
-
-      const result = parseWithRecovery(input)
-
-      // Should have parsed three statements successfully (e = f is valid)
+    it('should return partial AST after valid statements', () => {
+      const result = parseWithRecovery('a = b\nc = d\ne = f)')
       expect(result.file).not.toBeNull()
       expect(result.file?.statements.length).toBe(3)
-
-      // Should have error information
       expect(result.error).not.toBeNull()
-      expect(result.error?.message).toContain('Parse error')
       expect(result.errorLocation).toBeDefined()
     })
 
-    it('should return null file when error occurs on first statement', () => {
-      const input = `
-)
-a = b
-      `.trim()
-
-      const result = parseWithRecovery(input)
-
-      // No valid statements parsed
+    it('should return null file when error occurs first', () => {
+      const result = parseWithRecovery(')\na = b')
       expect(result.file).toBeNull()
-
-      // Should have error information
       expect(result.error).not.toBeNull()
-      expect(result.errorLocation).toBeDefined()
     })
 
-    it('should handle error from issue #48 example', () => {
-      const input = `
-∞ = ∞ -> ∞
-♂v = ♂v -> v
-r♀ = r -> r♀
-!♂x = x♀
-!x♀ = ♂x)
-a -> b -> c = (a -> b) -> c
-      `.trim()
-
+    it('should report error line after canonical formulas', () => {
+      const input = ['∞ = ∞ ⟼ ∞', '♀x = ♀x', 'x♂ = x♂)'].join('\n')
       const result = parseWithRecovery(input)
-
-      // Line 5 is "!x♀ = ♂x)" which parses as "!x♀ = ♂x" followed by stray ")"
-      // So 5 valid statements should be parsed (lines 1-5)
-      expect(result.file).not.toBeNull()
-      expect(result.file?.statements.length).toBe(5)
-
-      // Should have error on the closing paren
-      expect(result.error).not.toBeNull()
-      expect(result.error?.message).toContain('RPAREN')
-      expect(result.errorLocation?.start.line).toBe(5)
+      expect(result.file?.statements.length).toBe(3)
+      expect(result.errorLocation?.start.line).toBe(3)
     })
 
-    it('should return no error when parsing is fully successful', () => {
-      const input = `
-a = b
-c = d
-      `.trim()
-
-      const result = parseWithRecovery(input)
-
-      // Should have parsed all statements
-      expect(result.file).not.toBeNull()
+    it('should return no error for successful parse', () => {
+      const result = parseWithRecovery('a = b\nc = d')
       expect(result.file?.statements.length).toBe(2)
-
-      // Should have no error
       expect(result.error).toBeNull()
       expect(result.errorLocation).toBeUndefined()
-    })
-
-    it('should provide correct error location', () => {
-      const input = 'a = b\nc = d)'
-
-      const result = parseWithRecovery(input)
-
-      // Should have parsed two statements (a = b and c = d are valid)
-      expect(result.file?.statements.length).toBe(2)
-
-      // Error should be on line 2 (the ')' part)
-      expect(result.errorLocation?.start.line).toBe(2)
-      expect(result.error?.message).toContain('RPAREN')
     })
   })
 })

--- a/tests/unit/proofCache.test.ts
+++ b/tests/unit/proofCache.test.ts
@@ -197,7 +197,7 @@ describe('ProofCache', () => {
     it('should generate state signature from definitions', () => {
       const definitions = new Map<string, ASTNode>()
       definitions.set('x', parseExpr('∞ -> ∞'))
-      definitions.set('y', parseExpr('♂∞'))
+      definitions.set('y', parseExpr('∞♂'))
 
       const signature = generateStateSignature(definitions)
 
@@ -279,7 +279,7 @@ describe('ProofCache', () => {
     })
 
     it('should handle complex expressions', () => {
-      const expr = parseExpr('(♂∞ -> ∞♀) = 1')
+      const expr = parseExpr('(∞♂ -> ♀∞) = 1')
       const result: ProofResult = {
         success: true,
         message: 'Complex proof',

--- a/tests/unit/proofExport.test.ts
+++ b/tests/unit/proofExport.test.ts
@@ -55,14 +55,14 @@ describe('Proof Export Module', () => {
       expect(astToLaTeX(node)).toBe('a \\neq b')
     })
 
-    it('should convert male expression to LaTeX', () => {
-      const node = parseExpr('♂x')
-      expect(astToLaTeX(node)).toBe('\\male{x}')
+    it('should preserve canonical postfix end projection in LaTeX', () => {
+      const node = parseExpr('x♂')
+      expect(astToLaTeX(node)).toBe('x\\male{}')
     })
 
-    it('should convert female expression to LaTeX', () => {
-      const node = parseExpr('x♀')
-      expect(astToLaTeX(node)).toBe('x\\female')
+    it('should preserve canonical prefix start projection in LaTeX', () => {
+      const node = parseExpr('♀x')
+      expect(astToLaTeX(node)).toBe('\\female{}x')
     })
 
     it('should convert negation to LaTeX', () => {
@@ -82,9 +82,15 @@ describe('Proof Export Module', () => {
       expect(astToLaTeX(node1)).toBe('1')
     })
 
-    it('should convert complex expressions', () => {
-      const node = parseExpr('♂∞ -> ∞♀')
-      expect(astToLaTeX(node)).toBe('(\\male{\\infty} \\to \\infty\\female)')
+    it('should convert canonical projection expressions', () => {
+      const node = parseExpr('♀∞ -> ∞♂')
+      expect(astToLaTeX(node)).toBe('(\\female{}\\infty \\to \\infty\\male{})')
+    })
+
+    it('should export canonical containers and context pronouns', () => {
+      expect(astToLaTeX(parseExpr('(=)'))).toBe('(=)')
+      expect(astToLaTeX(parseExpr('[1]'))).toBe('[1]')
+      expect(astToLaTeX(parseExpr('↑◁'))).toBe('\\text{↑◁}')
     })
   })
 
@@ -93,14 +99,16 @@ describe('Proof Export Module', () => {
       expect(stringToLaTeX('∞')).toBe('\\infty')
     })
 
-    it('should convert arrow', () => {
+    it('should convert arrows', () => {
+      expect(stringToLaTeX('a ⟼ b')).toBe('a \\to b')
+      expect(stringToLaTeX('a ↛ b')).toBe('a \\nrightarrow b')
       expect(stringToLaTeX('a → b')).toBe('a \\to b')
       expect(stringToLaTeX('a -> b')).toBe('a \\to b')
     })
 
-    it('should convert male/female symbols', () => {
-      expect(stringToLaTeX('♂x')).toBe('\\male{}x')
-      expect(stringToLaTeX('x♀')).toBe('x\\female{}')
+    it('should preserve canonical male/female fixity', () => {
+      expect(stringToLaTeX('x♂')).toBe('x\\male{}')
+      expect(stringToLaTeX('♀x')).toBe('\\female{}x')
     })
 
     it('should convert inequality', () => {
@@ -124,13 +132,10 @@ describe('Proof Export Module', () => {
       expect(latex).toContain('a = a')
     })
 
-    it('should export failed proof to LaTeX', () => {
-      // Use ♂∞ = ∞♀ which should fail because they are structurally different
-      const { result, goal } = verifyExpression('♂∞ = ∞♀')
+    it('should export a structurally different canonical projection goal', () => {
+      const { result, goal } = verifyExpression('∞♂ = ♀∞')
       const latex = exportToLaTeX(result, goal)
 
-      // Note: This may or may not fail depending on prover implementation
-      // Just verify the export works
       expect(latex).toContain('Результат')
     })
 
@@ -147,7 +152,6 @@ describe('Proof Export Module', () => {
       const { result, goal } = verifyExpression('∞ = ∞ -> ∞')
       const latex = exportToLaTeX(result, goal, { useProofEnvironment: true })
 
-      // Only check if proof steps exist
       if (result.proofSteps && result.proofSteps.length > 0) {
         expect(latex).toContain('\\begin{proof}')
         expect(latex).toContain('\\end{proof}')
@@ -181,12 +185,10 @@ describe('Proof Export Module', () => {
       expect(text).toContain('✓ Доказано')
     })
 
-    it('should export failed proof to text', () => {
-      // Use an expression that fails - verifying any export contains required structure
-      const { result, goal } = verifyExpression('♂∞ = ∞♀')
+    it('should export canonical projection goal to text', () => {
+      const { result, goal } = verifyExpression('∞♂ = ♀∞')
       const text = exportToText(result, goal)
 
-      // Note: Just verify export works, don't depend on proof result
       expect(text).toContain('ДОКАЗАТЕЛЬСТВО МТС')
       expect(text).toContain('Результат')
     })
@@ -236,13 +238,11 @@ describe('Proof Export Module', () => {
       expect(data.goal).toBe('(a=a)')
     })
 
-    it('should export failed proof to JSON', () => {
-      // Test that JSON export works regardless of proof outcome
-      const { result, goal, state } = verifyExpression('♂∞ = ∞♀')
+    it('should export canonical projection goal to JSON', () => {
+      const { result, goal, state } = verifyExpression('∞♂ = ♀∞')
       const json = exportToJSON(result, goal, state)
       const data: ProofExportData = JSON.parse(json)
 
-      // Verify JSON structure
       expect(data.version).toBe('1.0')
       expect(typeof data.success).toBe('boolean')
       expect(data.goal).toBeDefined()
@@ -341,7 +341,6 @@ describe('Proof Export Module', () => {
       const { result, goal } = verifyExpression('∞ = ∞ -> ∞')
       const dot = exportToDOT(result, goal, { includeAxiomLabels: true })
 
-      // May or may not have axiom labels depending on proof steps
       expect(dot).toContain('digraph')
     })
 
@@ -361,7 +360,6 @@ describe('Proof Export Module', () => {
       const dotColorful = exportToDOT(result, goal, { colorScheme: 'colorful' })
       const dotMono = exportToDOT(result, goal, { colorScheme: 'monochrome' })
 
-      // All should be valid DOT format
       expect(dotDefault).toContain('fillcolor')
       expect(dotColorful).toContain('fillcolor')
       expect(dotMono).toContain('fillcolor')
@@ -374,7 +372,6 @@ describe('Proof Export Module', () => {
       const dotEllipse = exportToDOT(result, goal, { nodeShape: 'ellipse' })
       const dotDiamond = exportToDOT(result, goal, { nodeShape: 'diamond' })
 
-      // Goal node is always ellipse, but step nodes use the configured shape
       expect(dotBox).toContain('shape=')
       expect(dotEllipse).toContain('shape=')
       expect(dotDiamond).toContain('shape=')
@@ -440,37 +437,35 @@ describe('Proof Export Module', () => {
       const json = exportToJSON(result, goal)
       const dot = exportToDOT(result, goal)
 
-      // All formats should work
       expect(latex.length).toBeGreaterThan(0)
       expect(text.length).toBeGreaterThan(0)
       expect(json.length).toBeGreaterThan(0)
       expect(dot.length).toBeGreaterThan(0)
     })
 
-    it('should export proof for male axiom (A5)', () => {
-      const { result, goal } = verifyExpression('♂v = ♂v -> v')
+    it('should export proof for end-projection axiom (legacy A5 semantics)', () => {
+      const { result, goal } = verifyExpression('v♂ = v♂ -> v')
 
       const text = exportToText(result, goal)
       expect(text).toContain('✓ Доказано')
     })
 
-    it('should export proof for female axiom (A6)', () => {
-      const { result, goal } = verifyExpression('r♀ = r -> r♀')
+    it('should export proof for start-projection axiom (legacy A6 semantics)', () => {
+      const { result, goal } = verifyExpression('♀r = r -> ♀r')
 
       const text = exportToText(result, goal)
       expect(text).toContain('✓ Доказано')
     })
 
-    it('should export proof for inversion axiom (A7)', () => {
-      const { result, goal } = verifyExpression('!♂x = x♀')
+    it('should export proof for inversion axiom (legacy A7 semantics)', () => {
+      const { result, goal } = verifyExpression('!x♂ = ♀x')
 
       const text = exportToText(result, goal)
       expect(text).toContain('✓ Доказано')
     })
 
     it('should handle various proofs with hints', () => {
-      // Test with an expression - just verify export works
-      const { result, goal } = verifyExpression('♂∞ = ∞♀')
+      const { result, goal } = verifyExpression('∞♂ = ♀∞')
 
       const text = exportToText(result, goal)
       expect(text).toContain('ДОКАЗАТЕЛЬСТВО МТС')

--- a/tests/unit/proofMetrics.test.ts
+++ b/tests/unit/proofMetrics.test.ts
@@ -376,7 +376,7 @@ describe('ProofMetrics', () => {
     })
 
     it('should attach metrics to inequality verification', () => {
-      const expr = parseExpr('♂∞ != ∞♀')
+      const expr = parseExpr('∞♂ != ♀∞')
       const result = verify(expr, state)
 
       expect(result.metrics).toBeDefined()

--- a/tests/unit/prover.test.ts
+++ b/tests/unit/prover.test.ts
@@ -40,7 +40,7 @@ describe('Prover', () => {
 
     it('should fail on conflicting structures', () => {
       const a = normalize(parseExpr('a -> b'))
-      const b = normalize(parseExpr('♂c'))
+      const b = normalize(parseExpr('c♂'))
       expect(unify(a, b)).toBeNull()
     })
 
@@ -52,7 +52,6 @@ describe('Prover', () => {
     })
 
     it('should fail occurs check', () => {
-      // Can't unify x with (x -> a)
       const a = normalize(parseExpr('x'))
       const b = normalize(parseExpr('x -> a'))
       expect(unify(a, b)).toBeNull()
@@ -86,31 +85,27 @@ describe('Prover', () => {
     })
 
     it('should fail on different structures', () => {
-      // Use multi-character identifiers to avoid being treated as variables
       const a1 = normalize(parseExpr('aa -> bb'))
       const b1 = normalize(parseExpr('bb -> aa'))
       const result = checkEquality(a1, b1, state())
       expect(result.success).toBe(false)
     })
 
-    it('should use ♂ axiom', () => {
-      // ♂x = ♂x -> x
-      const left = normalize(parseExpr('♂a'))
-      const right = normalize(parseExpr('♂a -> a'))
+    it('should use end-projection axiom', () => {
+      const left = normalize(parseExpr('a♂'))
+      const right = normalize(parseExpr('a♂ -> a'))
       const result = checkEquality(left, right, state())
       expect(result.success).toBe(true)
     })
 
-    it('should use ♀ axiom', () => {
-      // x♀ = x -> x♀
-      const left = normalize(parseExpr('a♀'))
-      const right = normalize(parseExpr('a -> a♀'))
+    it('should use start-projection axiom', () => {
+      const left = normalize(parseExpr('♀a'))
+      const right = normalize(parseExpr('a -> ♀a'))
       const result = checkEquality(left, right, state())
       expect(result.success).toBe(true)
     })
 
     it('should use ∞ axiom', () => {
-      // ∞ = ∞ -> ∞
       const left = normalize(parseExpr('∞'))
       const right = normalize(parseExpr('∞ -> ∞'))
       const result = checkEquality(left, right, state())
@@ -120,7 +115,6 @@ describe('Prover', () => {
 
   describe('Inequality checking', () => {
     it('should prove inequality when equality fails', () => {
-      // Use multi-character identifiers to avoid being treated as variables
       const aa = normalize(parseExpr('aa'))
       const bb = normalize(parseExpr('bb'))
       const result = checkInequality(aa, bb, state())
@@ -143,7 +137,6 @@ describe('Prover', () => {
     })
 
     it('should verify inequality statement', () => {
-      // Use multi-character identifiers to avoid being treated as variables
       const neq = normalize(parseExpr('aa != bb'))
       const result = verify(neq, state())
       expect(result.success).toBe(true)
@@ -159,23 +152,20 @@ describe('Prover', () => {
   })
 
   describe('MTL formulas tests', () => {
-    // Tests based on tests/mtl_formulas.mtc
-
     it('should verify ab = a -> b', () => {
-      // This is definitional, handled by parser
       const eq = normalize(parseExpr('a -> b = a -> b'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
     })
 
-    it('should verify ♂v = ♂v -> v', () => {
-      const eq = normalize(parseExpr('♂v = ♂v -> v'))
+    it('should verify v♂ = v♂ -> v', () => {
+      const eq = normalize(parseExpr('v♂ = v♂ -> v'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
     })
 
-    it('should verify r♀ = r -> r♀', () => {
-      const eq = normalize(parseExpr('r♀ = r -> r♀'))
+    it('should verify ♀r = r -> ♀r', () => {
+      const eq = normalize(parseExpr('♀r = r -> ♀r'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
     })
@@ -186,16 +176,14 @@ describe('Prover', () => {
       expect(result.success).toBe(true)
     })
 
-    it('should verify !♂x = x♀ (via normalization)', () => {
-      // After normalization, !♂x becomes x♀
-      const eq = normalize(parseExpr('!♂x = x♀'))
+    it('should verify !x♂ = ♀x (via normalization)', () => {
+      const eq = normalize(parseExpr('!x♂ = ♀x'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
     })
 
-    it('should verify !x♀ = ♂x (via normalization)', () => {
-      // After normalization, !x♀ becomes ♂x
-      const eq = normalize(parseExpr('!x♀ = ♂x'))
+    it('should verify !♀x = x♂ (via normalization)', () => {
+      const eq = normalize(parseExpr('!♀x = x♂'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
     })
@@ -252,7 +240,7 @@ describe('Prover', () => {
     })
 
     it('should include before/after transformations when applicable', () => {
-      const eq = normalize(parseExpr('♂a = ♂a -> a'))
+      const eq = normalize(parseExpr('a♂ = a♂ -> a'))
       const result = verify(eq, state())
       expect(result.proofSteps).toBeDefined()
       const axiomStep = result.proofSteps!.find(s => s.axiom?.id === 'A5')
@@ -283,15 +271,15 @@ describe('Prover', () => {
       expect(result.appliedAxioms!.some(a => a.id === 'A4')).toBe(true)
     })
 
-    it('should track A5 for male axiom', () => {
-      const eq = normalize(parseExpr('♂a = ♂a -> a'))
+    it('should track A5 for end-projection axiom', () => {
+      const eq = normalize(parseExpr('a♂ = a♂ -> a'))
       const result = verify(eq, state())
       expect(result.appliedAxioms).toBeDefined()
       expect(result.appliedAxioms!.some(a => a.id === 'A5')).toBe(true)
     })
 
-    it('should track A6 for female axiom', () => {
-      const eq = normalize(parseExpr('a♀ = a -> a♀'))
+    it('should track A6 for start-projection axiom', () => {
+      const eq = normalize(parseExpr('♀a = a -> ♀a'))
       const result = verify(eq, state())
       expect(result.appliedAxioms).toBeDefined()
       expect(result.appliedAxioms!.some(a => a.id === 'A6')).toBe(true)
@@ -316,8 +304,7 @@ describe('Prover', () => {
 
   describe('Verification hints', () => {
     it('should return hints for failed verification', () => {
-      // Use multi-character identifiers to avoid being treated as variables
-      const eq = normalize(parseExpr('♂∞ = ∞♀'))
+      const eq = normalize(parseExpr('∞♂ = ♀∞'))
       const result = verify(eq, state())
       expect(result.success).toBe(false)
       expect(result.hints).toBeDefined()
@@ -325,16 +312,15 @@ describe('Prover', () => {
     })
 
     it('should suggest related axioms in hints', () => {
-      // Male expression that can't be unified
-      const eq = normalize(parseExpr('♂aa = bb'))
+      const eq = normalize(parseExpr('aa♂ = bb'))
       const result = verify(eq, state())
       expect(result.success).toBe(false)
       const axiomHint = result.hints!.find(h => h.relatedAxiom === 'A5')
       expect(axiomHint).toBeDefined()
     })
 
-    it('should provide hint about duality for ♂ vs ♀', () => {
-      const eq = normalize(parseExpr('♂∞ = ∞♀'))
+    it('should provide hint about duality for end vs start projection', () => {
+      const eq = normalize(parseExpr('∞♂ = ♀∞'))
       const result = verify(eq, state())
       expect(result.success).toBe(false)
       const dualityHint = result.hints!.find(h => h.message.includes('дуальны'))
@@ -342,7 +328,7 @@ describe('Prover', () => {
     })
 
     it('should provide structural hints for type mismatch', () => {
-      const eq = normalize(parseExpr('∞ = ♂aa'))
+      const eq = normalize(parseExpr('∞ = aa♂'))
       const result = verify(eq, state())
       expect(result.success).toBe(false)
       expect(result.hints).toBeDefined()
@@ -431,7 +417,6 @@ describe('Prover', () => {
     })
 
     it('should still respect the original ∞ = ∞ -> ∞ case', () => {
-      // This is a regression test to ensure the simple case still works
       const eq = normalize(parseExpr('∞ = ∞ -> ∞'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
@@ -439,90 +424,88 @@ describe('Prover', () => {
     })
   })
 
-  describe('Male expansion (issue #53)', () => {
-    it('should verify ♂v = ♂v -> v -> v -> v (left-associative)', () => {
-      const eq = normalize(parseExpr('♂v = ♂v -> v -> v -> v'))
+  describe('End projection expansion (legacy issue #53 semantics)', () => {
+    it('should verify v♂ = v♂ -> v -> v -> v (left-associative)', () => {
+      const eq = normalize(parseExpr('v♂ = v♂ -> v -> v -> v'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
       expect(result.appliedAxioms!.some(a => a.id === 'A5')).toBe(true)
     })
 
-    it('should verify ♂v = (♂v -> v) -> v', () => {
-      const eq = normalize(parseExpr('♂v = (♂v -> v) -> v'))
+    it('should verify v♂ = (v♂ -> v) -> v', () => {
+      const eq = normalize(parseExpr('v♂ = (v♂ -> v) -> v'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
       expect(result.appliedAxioms!.some(a => a.id === 'A5')).toBe(true)
     })
 
-    it('should verify ♂v = ((♂v -> v) -> v) -> v', () => {
-      const eq = normalize(parseExpr('♂v = ((♂v -> v) -> v) -> v'))
+    it('should verify v♂ = ((v♂ -> v) -> v) -> v', () => {
+      const eq = normalize(parseExpr('v♂ = ((v♂ -> v) -> v) -> v'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
       expect(result.appliedAxioms!.some(a => a.id === 'A5')).toBe(true)
     })
 
-    it('should verify (♂v -> v) -> v = ♂v (reverse direction)', () => {
-      const eq = normalize(parseExpr('(♂v -> v) -> v = ♂v'))
+    it('should verify (v♂ -> v) -> v = v♂ (reverse direction)', () => {
+      const eq = normalize(parseExpr('(v♂ -> v) -> v = v♂'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
       expect(result.appliedAxioms!.some(a => a.id === 'A5')).toBe(true)
     })
 
-    it('should verify ((♂v -> v) -> v) -> v = ♂v (deep nesting)', () => {
-      const eq = normalize(parseExpr('((♂v -> v) -> v) -> v = ♂v'))
+    it('should verify ((v♂ -> v) -> v) -> v = v♂ (deep nesting)', () => {
+      const eq = normalize(parseExpr('((v♂ -> v) -> v) -> v = v♂'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
       expect(result.appliedAxioms!.some(a => a.id === 'A5')).toBe(true)
     })
 
-    it('should verify ♂a = ♂a -> a -> a -> a (3-level nesting)', () => {
-      const eq = normalize(parseExpr('♂a = ♂a -> a -> a -> a'))
+    it('should verify a♂ = a♂ -> a -> a -> a (3-level nesting)', () => {
+      const eq = normalize(parseExpr('a♂ = a♂ -> a -> a -> a'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
       expect(result.appliedAxioms!.some(a => a.id === 'A5')).toBe(true)
     })
 
-    it('should still respect the original ♂x = ♂x -> x case', () => {
-      // This is a regression test to ensure the simple case still works
-      const eq = normalize(parseExpr('♂a = ♂a -> a'))
+    it('should still respect the original end-projection expansion case', () => {
+      const eq = normalize(parseExpr('a♂ = a♂ -> a'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
       expect(result.appliedAxioms!.some(a => a.id === 'A5')).toBe(true)
     })
   })
 
-  describe('Female expansion (issue #53)', () => {
-    it('should verify r♀ = r -> (r -> r♀)', () => {
-      const eq = normalize(parseExpr('r♀ = r -> (r -> r♀)'))
+  describe('Start projection expansion (legacy issue #53 semantics)', () => {
+    it('should verify ♀r = r -> (r -> ♀r)', () => {
+      const eq = normalize(parseExpr('♀r = r -> (r -> ♀r)'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
       expect(result.appliedAxioms!.some(a => a.id === 'A6')).toBe(true)
     })
 
-    it('should verify r♀ = r -> (r -> (r -> r♀))', () => {
-      const eq = normalize(parseExpr('r♀ = r -> (r -> (r -> r♀))'))
+    it('should verify ♀r = r -> (r -> (r -> ♀r))', () => {
+      const eq = normalize(parseExpr('♀r = r -> (r -> (r -> ♀r))'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
       expect(result.appliedAxioms!.some(a => a.id === 'A6')).toBe(true)
     })
 
-    it('should verify r -> (r -> r♀) = r♀ (reverse direction)', () => {
-      const eq = normalize(parseExpr('r -> (r -> r♀) = r♀'))
+    it('should verify r -> (r -> ♀r) = ♀r (reverse direction)', () => {
+      const eq = normalize(parseExpr('r -> (r -> ♀r) = ♀r'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
       expect(result.appliedAxioms!.some(a => a.id === 'A6')).toBe(true)
     })
 
-    it('should verify r -> (r -> (r -> r♀)) = r♀ (deep nesting)', () => {
-      const eq = normalize(parseExpr('r -> (r -> (r -> r♀)) = r♀'))
+    it('should verify r -> (r -> (r -> ♀r)) = ♀r (deep nesting)', () => {
+      const eq = normalize(parseExpr('r -> (r -> (r -> ♀r)) = ♀r'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
       expect(result.appliedAxioms!.some(a => a.id === 'A6')).toBe(true)
     })
 
-    it('should still respect the original x♀ = x -> x♀ case', () => {
-      // This is a regression test to ensure the simple case still works
-      const eq = normalize(parseExpr('r♀ = r -> r♀'))
+    it('should still respect the original start-projection expansion case', () => {
+      const eq = normalize(parseExpr('♀r = r -> ♀r'))
       const result = verify(eq, state())
       expect(result.success).toBe(true)
       expect(result.appliedAxioms!.some(a => a.id === 'A6')).toBe(true)
@@ -532,12 +515,10 @@ describe('Prover', () => {
   describe('Extended resolution - Symmetry (A1)', () => {
     it('should use symmetry: if (a = b) is proven, then (b = a) is valid', () => {
       const s = state()
-      // First prove a = b (will be stored in proven equalities)
       const eq1 = normalize(parseExpr('∞ = ∞ -> ∞'))
       const result1 = verify(eq1, s)
       expect(result1.success).toBe(true)
 
-      // Now the symmetric version should also work via transitivity/symmetry mechanism
       const eq2 = normalize(parseExpr('∞ -> ∞ = ∞'))
       const result2 = verify(eq2, s)
       expect(result2.success).toBe(true)
@@ -554,13 +535,11 @@ describe('Prover', () => {
 
     it('should apply symmetry for complex expressions', () => {
       const s = state()
-      // Prove ♂v = ♂v -> v
-      const eq1 = normalize(parseExpr('♂v = ♂v -> v'))
+      const eq1 = normalize(parseExpr('v♂ = v♂ -> v'))
       const result1 = verify(eq1, s)
       expect(result1.success).toBe(true)
 
-      // Now ♂v -> v = ♂v should work via symmetry
-      const eq2 = normalize(parseExpr('♂v -> v = ♂v'))
+      const eq2 = normalize(parseExpr('v♂ -> v = v♂'))
       const result2 = verify(eq2, s)
       expect(result2.success).toBe(true)
     })
@@ -570,31 +549,24 @@ describe('Prover', () => {
     it('should prove transitivity: if (a = b) and (b = c) then (a = c)', () => {
       const s = state()
 
-      // First prove a = b
       const eq1 = normalize(parseExpr('∞ = ∞ -> ∞'))
       const result1 = verify(eq1, s)
       expect(result1.success).toBe(true)
 
-      // Now prove that (∞ -> ∞) = some other form
-      // Let's use the recursive collapse: ∞ -> ∞ -> ∞ also collapses to ∞
       const eq2 = normalize(parseExpr('∞ -> ∞ = ∞ -> ∞ -> ∞'))
       const result2 = verify(eq2, s)
       expect(result2.success).toBe(true)
 
-      // Transitivity should allow us to conclude ∞ = ∞ -> ∞ -> ∞
-      // This follows from ∞ = (∞ -> ∞) and (∞ -> ∞) = (∞ -> ∞ -> ∞)
       expect(s.provenEqualities.length).toBeGreaterThan(1)
     })
 
     it('should track multiple equalities for transitivity chains', () => {
       const s = state()
 
-      // Prove several equalities
       verify(normalize(parseExpr('aa = aa')), s)
       verify(normalize(parseExpr('bb = bb')), s)
       verify(normalize(parseExpr('cc = cc')), s)
 
-      // State should track all proven equalities
       expect(s.provenEqualities.length).toBeGreaterThanOrEqual(3)
     })
   })
@@ -602,8 +574,6 @@ describe('Prover', () => {
   describe('Extended resolution - Congruence (A2)', () => {
     it('should apply congruence: if (a = c) and (b = d) then (a -> b) = (c -> d)', () => {
       const s = state()
-
-      // With reflexivity, if a=a and b=b, then (a -> b) = (a -> b)
       const eq = normalize(parseExpr('a -> b = a -> b'))
       const result = verify(eq, s)
       expect(result.success).toBe(true)
@@ -612,12 +582,9 @@ describe('Prover', () => {
     it('should use congruence for link expressions with identical components', () => {
       const s = state()
 
-      // First prove ∞ = ∞ -> ∞
       const eq1 = normalize(parseExpr('∞ = ∞ -> ∞'))
       verify(eq1, s)
 
-      // Then congruence can be used to prove (∞ -> x) = ((∞ -> ∞) -> x)
-      // where the left parts are equal due to A4
       const eq2 = normalize(parseExpr('(∞ -> x) = ((∞ -> ∞) -> x)'))
       const result = verify(eq2, s)
       expect(result.success).toBe(true)
@@ -626,14 +593,11 @@ describe('Prover', () => {
     it('should use congruence with proven equalities', () => {
       const s = state()
 
-      // Prove ♂a = ♂a -> a (using A5)
-      const eq1 = normalize(parseExpr('♂a = ♂a -> a'))
+      const eq1 = normalize(parseExpr('a♂ = a♂ -> a'))
       const result1 = verify(eq1, s)
       expect(result1.success).toBe(true)
 
-      // Now try to use congruence with this equality
-      // (♂a -> b) should equal ((♂a -> a) -> b) if we can use congruence
-      const eq2 = normalize(parseExpr('(♂a -> b) = ((♂a -> a) -> b)'))
+      const eq2 = normalize(parseExpr('(a♂ -> b) = ((a♂ -> a) -> b)'))
       const result2 = verify(eq2, s)
       expect(result2.success).toBe(true)
     })
@@ -643,41 +607,34 @@ describe('Prover', () => {
     it('should not duplicate equalities', () => {
       const s = state()
 
-      // Prove the same equality twice
       verify(normalize(parseExpr('x = x')), s)
       const countAfterFirst = s.provenEqualities.length
 
       verify(normalize(parseExpr('x = x')), s)
       const countAfterSecond = s.provenEqualities.length
 
-      // Should not have added a duplicate
       expect(countAfterSecond).toBe(countAfterFirst)
     })
 
     it('should not add symmetric version as duplicate', () => {
       const s = state()
 
-      // Prove a = b
       verify(normalize(parseExpr('∞ = ∞ -> ∞')), s)
       const countAfterFirst = s.provenEqualities.length
 
-      // Prove b = a (symmetric)
       verify(normalize(parseExpr('∞ -> ∞ = ∞')), s)
       const countAfterSecond = s.provenEqualities.length
 
-      // Should recognize this as the same equality and not duplicate
       expect(countAfterSecond).toBe(countAfterFirst)
     })
 
     it('should preserve proven equalities across multiple verifications', () => {
       const s = state()
 
-      // Prove several distinct equalities
       verify(normalize(parseExpr('∞ = ∞ -> ∞')), s)
-      verify(normalize(parseExpr('♂v = ♂v -> v')), s)
-      verify(normalize(parseExpr('r♀ = r -> r♀')), s)
+      verify(normalize(parseExpr('v♂ = v♂ -> v')), s)
+      verify(normalize(parseExpr('♀r = r -> ♀r')), s)
 
-      // All should be tracked
       expect(s.provenEqualities.length).toBeGreaterThanOrEqual(3)
     })
   })
@@ -686,7 +643,6 @@ describe('Prover', () => {
     it('should register Link expressions as implications', () => {
       const s = state()
 
-      // Register an implication P -> Q
       const impl = normalize(parseExpr('a -> b'))
       const result = verify(impl, s)
 
@@ -697,50 +653,39 @@ describe('Prover', () => {
     it('should track proven facts', () => {
       const s = state()
 
-      // Register a fact and an implication
       const fact = normalize(parseExpr('∞'))
       const impl = normalize(parseExpr('∞ -> ∞'))
 
       verify(fact, s)
       verify(impl, s)
 
-      // Fact should be tracked
       expect(s.provenFacts.length).toBeGreaterThan(0)
     })
 
     it('should apply Modus Ponens to derive new facts', () => {
       const s = state()
 
-      // Add fact P (represented as a simple expression)
-      const factP = normalize(parseExpr('♂∞'))
-
-      // Register the fact manually using addProvenFact
+      const factP = normalize(parseExpr('∞♂'))
       addProvenFact(s, factP)
 
-      // Register implication P -> Q (♂∞ -> ∞♀)
-      const implPQ = normalize(parseExpr('♂∞ -> ∞♀')) as any
+      const implPQ = normalize(parseExpr('∞♂ -> ♀∞')) as any
       addProvenImplication(s, factP, implPQ.right, 'test implication')
 
-      // Apply Modus Ponens
       applyModusPonens(s)
 
-      // Q should be derived
-      const qStr = toCanonicalString(normalize(parseExpr('∞♀')))
+      const qStr = toCanonicalString(normalize(parseExpr('♀∞')))
       expect(s.facts.has(qStr)).toBe(true)
     })
 
     it('should use tryModusPonens to prove consequent', () => {
       const s = state()
 
-      // Add fact P
-      const factP = normalize(parseExpr('♂∞'))
+      const factP = normalize(parseExpr('∞♂'))
       addProvenFact(s, factP)
 
-      // Register implication P -> Q
-      const factQ = normalize(parseExpr('∞♀'))
+      const factQ = normalize(parseExpr('♀∞'))
       addProvenImplication(s, factP, factQ, 'test')
 
-      // Try to prove Q using MP
       const result = tryModusPonens(factQ, s)
       expect(result.found).toBe(true)
     })
@@ -748,23 +693,18 @@ describe('Prover', () => {
     it('should handle chains of implications', () => {
       const s = state()
 
-      // P
-      const factP = normalize(parseExpr('♂∞'))
+      const factP = normalize(parseExpr('∞♂'))
       addProvenFact(s, factP)
 
-      // P -> Q
-      const factQ = normalize(parseExpr('∞♀'))
+      const factQ = normalize(parseExpr('♀∞'))
       addProvenImplication(s, factP, factQ, 'P -> Q')
 
-      // Q -> R
       const factR = normalize(parseExpr('∞'))
       addProvenImplication(s, factQ, factR, 'Q -> R')
 
-      // Apply MP twice to derive R
-      applyModusPonens(s) // First pass: P, P->Q ⊢ Q
-      applyModusPonens(s) // Second pass: Q, Q->R ⊢ R
+      applyModusPonens(s)
+      applyModusPonens(s)
 
-      // R should be derived
       const rStr = toCanonicalString(factR)
       expect(s.facts.has(rStr)).toBe(true)
     })
@@ -772,16 +712,13 @@ describe('Prover', () => {
     it('should include MP axiom in proof steps for implications', () => {
       const s = state()
 
-      // Add some facts first
-      const factP = normalize(parseExpr('♂∞'))
+      const factP = normalize(parseExpr('∞♂'))
       addProvenFact(s, factP)
 
-      // Register P -> Q implication
-      const factQ = normalize(parseExpr('∞♀'))
+      const factQ = normalize(parseExpr('♀∞'))
       addProvenImplication(s, factP, factQ, 'test')
 
-      // Verify an implication
-      const impl = normalize(parseExpr('♂∞ -> ∞♀'))
+      const impl = normalize(parseExpr('∞♂ -> ♀∞'))
       const result = verify(impl, s)
 
       expect(result.success).toBe(true)
@@ -792,11 +729,9 @@ describe('Prover', () => {
     it('should track implications from Link expressions', () => {
       const s = state()
 
-      // Verify a Link expression
       const link = normalize(parseExpr('a -> b'))
       verify(link, s)
 
-      // Check that implication is tracked
       expect(s.provenImplications.length).toBeGreaterThan(0)
       const impl = s.provenImplications[0]
       expect(impl.antecedent.type).toBe('Identifier')
@@ -806,7 +741,6 @@ describe('Prover', () => {
     it('should not duplicate implications', () => {
       const s = state()
 
-      // Verify the same Link expression twice
       const link1 = normalize(parseExpr('a -> b'))
       const link2 = normalize(parseExpr('a -> b'))
 
@@ -816,36 +750,30 @@ describe('Prover', () => {
       verify(link2, s)
       const countAfterSecond = s.provenImplications.length
 
-      // Should not duplicate
       expect(countAfterSecond).toBe(countAfterFirst)
     })
 
     it('should work with complex expressions', () => {
       const s = state()
 
-      // Register complex implication
-      const impl = normalize(parseExpr('(♂∞ -> ∞♀) -> (∞ -> ∞)'))
+      const impl = normalize(parseExpr('(∞♂ -> ♀∞) -> (∞ -> ∞)'))
       verify(impl, s)
 
-      // Implication should be tracked
       expect(s.provenImplications.length).toBeGreaterThan(0)
     })
 
     it('should derive facts from verified implications', () => {
       const s = state()
 
-      // First establish P as a fact
-      const factP = normalize(parseExpr('♂∞'))
+      const factP = normalize(parseExpr('∞♂'))
       addProvenFact(s, factP)
 
-      // Then verify the implication P -> Q
-      const impl = normalize(parseExpr('♂∞ -> ∞♀'))
+      const impl = normalize(parseExpr('∞♂ -> ♀∞'))
       const result = verify(impl, s)
 
       expect(result.success).toBe(true)
 
-      // Check if MP was applied (if not immediately, check derived facts)
-      const qStr = toCanonicalString(normalize(parseExpr('∞♀')))
+      const qStr = toCanonicalString(normalize(parseExpr('♀∞')))
       expect(s.facts.has(qStr)).toBe(true)
     })
   })


### PR DESCRIPTION
Refs #107.

Миграция **существующего** parser pipeline `aprover` на единый формальный язык из `anum_docs`. Параллельный `parserV2` не создаётся.

Сделано в Phase C:
- `src/core/lexer.ts` понимает canonical `⟼`, `↛`, атомарные `◁`/`▷` и отдельный `↑`;
- квадратные скобки всегда остаются независимыми lexical tokens;
- pinned upstream `mts-conformance/v0.2` lexing vectors исполняются напрямую;
- AST получил `ContextPronoun`, `Square`, `Round`, `Literal` и occurrence-safe контейнеры;
- parser сохраняет различие `(=)` и оператора `=`, а также `(⟼)`, `(↛)`, `()`, `[1]`, `[0]`, `([)`, `(])`;
- canonical projection orientation читается **только** как `♀F` и `F♂`; legacy `♂F / F♀` из parser удалён;
- challenge suite разбирает все 10 canonical root definitions из МТС v0.2;
- normalizer сохраняет `Round` в AST, но делает непустую круглую группировку семантически прозрачной;
- `proofCache`, `proofMetrics`, `linkGraph`, `proofExport`, `interactive`, `prover` и editor E2E parser-facing fixtures переведены на canonical projection syntax;
- `linkGraph` больше не содержит отдельной legacy-сериализации проекций;
- `proofExport.astToLaTeX()` сохраняет canonical fixity и умеет новые canonical AST nodes;
- добавлен один AST→MTS source formatter `toMtsSource` (не новый parser/normalizer path);
- pinned upstream `canonicalization` vectors теперь исполняются напрямую в TypeScript.

Граница текущего PR:
- Phase C меняет единый syntax/AST consumer contract;
- старая независимая proof semantics (`AXIOMS` v0.1, global congruence/transitivity и связанные правила) **не объявляется канонической МТС v0.2** и подлежит удалению/замене в Phase E из #107;
- compatibility grammar для старых проекций не возвращается.

PR остаётся draft до полностью зелёного CI. После зелёного CI и проверки `behind_by=0` может быть promoted/merged.