### PR TITLE
Подключить canonical interpreter к production MemoryView

### DIFF
--- a/src/core/memoryView.ts
+++ b/src/core/memoryView.ts
@@ -1,0 +1,99 @@
+import type { LinkRef, MemoryView } from './interpreter'
+
+export interface DistinguishedLink {
+  readonly id: LinkRef
+  readonly start: LinkRef
+  readonly end: LinkRef
+}
+
+function pairKey(start: LinkRef, end: LinkRef): string {
+  return `${start}:${end}`
+}
+
+/**
+ * Immutable application adapter for the read-only memory surface consumed by
+ * canonical MTS v0.2 interpretation.
+ *
+ * Construction is the explicit boundary where already-distinguished links are
+ * supplied by the application/storage layer. Interpretation itself receives no
+ * mutation API and therefore cannot realize missing links or projections.
+ */
+export class ExplicitMemoryView implements MemoryView {
+  private readonly linksById: ReadonlyMap<LinkRef, readonly [LinkRef, LinkRef]>
+  private readonly linksByPoles: ReadonlyMap<string, LinkRef>
+  private readonly startProjections: ReadonlyMap<LinkRef, LinkRef>
+  private readonly endProjections: ReadonlyMap<LinkRef, LinkRef>
+
+  constructor(links: readonly DistinguishedLink[]) {
+    const byId = new Map<LinkRef, readonly [LinkRef, LinkRef]>()
+    const byPoles = new Map<string, LinkRef>()
+
+    for (const link of links) {
+      if (byId.has(link.id)) {
+        throw new Error(`Duplicate memory link id ${link.id}`)
+      }
+
+      const key = pairKey(link.start, link.end)
+      const existing = byPoles.get(key)
+      if (existing !== undefined && existing !== link.id) {
+        throw new Error(
+          `Ambiguous canonical Link identity for (${link.start}, ${link.end}): ${existing} and ${link.id}`
+        )
+      }
+
+      byId.set(link.id, [link.start, link.end] as const)
+      byPoles.set(key, link.id)
+    }
+
+    const startProjections = new Map<LinkRef, LinkRef>()
+    const endProjections = new Map<LinkRef, LinkRef>()
+
+    for (const [link, poles] of byId) {
+      const [start, end] = poles
+      if (start === link) {
+        const existing = startProjections.get(end)
+        if (existing !== undefined && existing !== link) {
+          throw new Error(`Ambiguous start projection for form ${end}`)
+        }
+        startProjections.set(end, link)
+      }
+      if (end === link) {
+        const existing = endProjections.get(start)
+        if (existing !== undefined && existing !== link) {
+          throw new Error(`Ambiguous end projection for form ${start}`)
+        }
+        endProjections.set(start, link)
+      }
+    }
+
+    this.linksById = byId
+    this.linksByPoles = byPoles
+    this.startProjections = startProjections
+    this.endProjections = endProjections
+  }
+
+  poles(link: LinkRef): readonly [LinkRef, LinkRef] {
+    const poles = this.linksById.get(link)
+    if (!poles) throw new Error(`Unknown memory link ${link}`)
+    return poles
+  }
+
+  findLink(start: LinkRef, end: LinkRef): LinkRef | undefined {
+    return this.linksByPoles.get(pairKey(start, end))
+  }
+
+  findStartProjection(form: LinkRef): LinkRef | undefined {
+    return this.startProjections.get(form)
+  }
+
+  findEndProjection(form: LinkRef): LinkRef | undefined {
+    return this.endProjections.get(form)
+  }
+
+  /** Deterministic copy useful for diagnostics and non-mutation assertions. */
+  entries(): readonly (readonly [LinkRef, readonly [LinkRef, LinkRef]])[] {
+    return [...this.linksById.entries()]
+      .sort(([left], [right]) => left - right)
+      .map(([link, poles]) => [link, [poles[0], poles[1]] as const] as const)
+  }
+}

--- a/tests/unit/memoryView.test.ts
+++ b/tests/unit/memoryView.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { ExplicitMemoryView } from '../../src/core/memoryView'
+
+describe('ExplicitMemoryView', () => {
+  it('indexes distinguished links and canonical projections without mutation APIs', () => {
+    const memory = new ExplicitMemoryView([
+      { id: 10, start: 1, end: 2 },
+      { id: 20, start: 20, end: 10 },
+      { id: 30, start: 10, end: 30 },
+    ])
+
+    expect(memory.poles(10)).toEqual([1, 2])
+    expect(memory.findLink(1, 2)).toBe(10)
+    expect(memory.findStartProjection(10)).toBe(20)
+    expect(memory.findEndProjection(10)).toBe(30)
+    expect(memory.findLink(2, 1)).toBeUndefined()
+    expect(memory.entries()).toEqual([
+      [10, [1, 2]],
+      [20, [20, 10]],
+      [30, [10, 30]],
+    ])
+  })
+
+  it('rejects duplicate link ids', () => {
+    expect(
+      () =>
+        new ExplicitMemoryView([
+          { id: 10, start: 1, end: 2 },
+          { id: 10, start: 3, end: 4 },
+        ])
+    ).toThrow('Duplicate memory link id 10')
+  })
+
+  it('rejects two identities for the same canonical link', () => {
+    expect(
+      () =>
+        new ExplicitMemoryView([
+          { id: 10, start: 1, end: 2 },
+          { id: 11, start: 1, end: 2 },
+        ])
+    ).toThrow('Ambiguous canonical Link identity')
+  })
+
+  it('throws when poles are requested for an unknown link', () => {
+    const memory = new ExplicitMemoryView([])
+    expect(() => memory.poles(999)).toThrow('Unknown memory link 999')
+  })
+})

--- a/tests/unit/mtsInterpretationConformance.test.ts
+++ b/tests/unit/mtsInterpretationConformance.test.ts
@@ -2,13 +2,9 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
+import { interpretConstraints, type ContextFrame } from '../../src/core/interpreter'
+import { ExplicitMemoryView } from '../../src/core/memoryView'
 import { parseExpr } from '../../src/core/parser'
-import {
-  interpretConstraints,
-  type ContextFrame,
-  type LinkRef,
-  type MemoryView,
-} from '../../src/core/interpreter'
 
 interface LinkSpec {
   id: number
@@ -43,41 +39,6 @@ interface ConformanceCorpus {
   interpretation: InterpretationCase[]
 }
 
-class CorpusMemory implements MemoryView {
-  readonly links: Map<LinkRef, readonly [LinkRef, LinkRef]>
-
-  constructor(links: LinkSpec[]) {
-    this.links = new Map(links.map(link => [link.id, [link.start, link.end] as const]))
-  }
-
-  poles(link: LinkRef): readonly [LinkRef, LinkRef] {
-    const poles = this.links.get(link)
-    if (!poles) throw new Error(`Unknown memory link ${link}`)
-    return poles
-  }
-
-  findLink(start: LinkRef, end: LinkRef): LinkRef | undefined {
-    for (const [link, poles] of this.links) {
-      if (poles[0] === start && poles[1] === end) return link
-    }
-    return undefined
-  }
-
-  findStartProjection(form: LinkRef): LinkRef | undefined {
-    for (const [link, poles] of this.links) {
-      if (poles[0] === link && poles[1] === form) return link
-    }
-    return undefined
-  }
-
-  findEndProjection(form: LinkRef): LinkRef | undefined {
-    for (const [link, poles] of this.links) {
-      if (poles[0] === form && poles[1] === link) return link
-    }
-    return undefined
-  }
-}
-
 function loadCorpus(): ConformanceCorpus {
   const path = resolve(process.cwd(), 'contracts/anum_docs-v0.2/mts-conformance-v0.2.json')
   return JSON.parse(readFileSync(path, 'utf8')) as ConformanceCorpus
@@ -89,10 +50,6 @@ function contextFrame(spec: ContextSpec): ContextFrame {
     end: spec.end,
     parent: spec.parent ? contextFrame(spec.parent) : undefined,
   }
-}
-
-function snapshotMemory(memory: CorpusMemory): Array<[number, readonly [number, number]]> {
-  return [...memory.links.entries()].map(([link, poles]) => [link, [...poles] as const])
 }
 
 describe('MTS v0.2 upstream interpretation conformance', () => {
@@ -107,8 +64,8 @@ describe('MTS v0.2 upstream interpretation conformance', () => {
 
   for (const testCase of corpus.interpretation) {
     it(testCase.id, () => {
-      const memory = new CorpusMemory(testCase.memory.links)
-      const before = snapshotMemory(memory)
+      const memory = new ExplicitMemoryView(testCase.memory.links)
+      const before = memory.entries()
 
       const result = interpretConstraints(
         parseExpr(testCase.source),
@@ -121,7 +78,7 @@ describe('MTS v0.2 upstream interpretation conformance', () => {
       expect(result.substitutions).toEqual(testCase.expected.substitutions)
       expect(result.aliases).toEqual(testCase.expected.aliases)
       expect(result.trace.map(event => event.split(':', 1)[0])).toEqual(testCase.expected.traceKinds)
-      expect(snapshotMemory(memory)).toEqual(before)
+      expect(memory.entries()).toEqual(before)
     })
   }
 })


### PR DESCRIPTION
## Что меняется

Продолжение #107, Phase D.

- добавлен `src/core/memoryView.ts` с единым immutable `ExplicitMemoryView`;
- adapter реализует ровно read-only `MemoryView`, требуемый canonical interpreter;
- уже различённые связи передаются явно на границе application/storage layer;
- `interpret` не получает mutation API и не может неявно `realize` отсутствующие связи;
- exact link и start/end projection lookup индексированы;
- constructor отвергает duplicate ids и неоднозначную canonical Link identity `(start,end) -> разные LinkRef`;
- upstream interpretation conformance теперь исполняется через production adapter, test-only `CorpusMemory` удалён;
- добавлены unit tests на lookup, projections и identity guards.

Это намеренно не связывает interpreter с `linkGraph`: visual graph хранит occurrence identity и не является ассоциативной памятью.

Следующий слой после этого PR — application session/model, который подаёт в interpreter `ContextFrame`, symbol bindings и `ExplicitMemoryView`, а UI отображает substitutions / aliases / trace.