### PR TITLE
Добавить application session для canonical interpreter

### DIFF
--- a/src/core/interpretationSession.ts
+++ b/src/core/interpretationSession.ts
@@ -1,0 +1,43 @@
+import type { ASTNode } from './ast'
+import {
+  interpretConstraints,
+  type ContextFrame,
+  type InterpretationResult,
+  type LinkRef,
+} from './interpreter'
+import { ExplicitMemoryView, type DistinguishedLink } from './memoryView'
+
+export interface InterpretationSessionConfig {
+  readonly context: ContextFrame
+  readonly symbols?: Readonly<Record<string, LinkRef>>
+  readonly links: readonly DistinguishedLink[]
+}
+
+/**
+ * Application boundary around canonical MTS v0.2 interpretation.
+ *
+ * The session owns only immutable input state: an explicit read-only memory
+ * snapshot, a context frame and symbol bindings. It exposes no realize/delete
+ * operations, so UI code cannot accidentally turn interpretation into memory
+ * mutation.
+ */
+export class InterpretationSession {
+  readonly context: ContextFrame
+  readonly symbols: Readonly<Record<string, LinkRef>>
+  readonly memory: ExplicitMemoryView
+
+  constructor(config: InterpretationSessionConfig) {
+    this.context = config.context
+    this.symbols = Object.freeze({ ...(config.symbols ?? {}) })
+    this.memory = new ExplicitMemoryView(config.links)
+  }
+
+  interpret(expression: ASTNode): InterpretationResult {
+    return interpretConstraints(expression, this.context, this.memory, this.symbols)
+  }
+
+  /** Stable diagnostic snapshot for UI/tests; interpretation never changes it. */
+  memorySnapshot(): ReturnType<ExplicitMemoryView['entries']> {
+    return this.memory.entries()
+  }
+}

--- a/tests/unit/interpretationSession.test.ts
+++ b/tests/unit/interpretationSession.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { InterpretationSession } from '../../src/core/interpretationSession'
+import { parseExpr } from '../../src/core/parser'
+
+describe('InterpretationSession', () => {
+  it('feeds canonical interpreter with one immutable application snapshot', () => {
+    const session = new InterpretationSession({
+      context: { start: 1, end: 2 },
+      symbols: { x: 10 },
+      links: [{ id: 10, start: 1, end: 2 }],
+    })
+    const before = session.memorySnapshot()
+
+    const result = session.interpret(parseExpr('[] = x'))
+
+    expect(result.success).toBe(true)
+    expect(result.substitutions).toEqual([{ path: [0], link: 10 }])
+    expect(result.aliases).toEqual([])
+    expect(session.memorySnapshot()).toEqual(before)
+  })
+
+  it('keeps context pronouns in the application frame instead of materializing them', () => {
+    const session = new InterpretationSession({
+      context: { start: 10, end: 20, parent: { start: 30, end: 40 } },
+      links: [],
+    })
+
+    expect(session.interpret(parseExpr('◁ = ◁')).success).toBe(true)
+    expect(session.interpret(parseExpr('↑▷ = ↑▷')).success).toBe(true)
+    expect(session.memorySnapshot()).toEqual([])
+  })
+
+  it('does not expose caller mutations of the symbols object as session state', () => {
+    const symbols = { x: 10 }
+    const session = new InterpretationSession({
+      context: { start: 1, end: 2 },
+      symbols,
+      links: [{ id: 10, start: 1, end: 2 }],
+    })
+
+    symbols.x = 99
+
+    expect(session.interpret(parseExpr('[] = x')).substitutions).toEqual([
+      { path: [0], link: 10 },
+    ])
+  })
+})


### PR DESCRIPTION
## Что меняется

Продолжение #107, Phase D.

- добавлен `InterpretationSession` как application boundary вокруг единственного canonical `interpretConstraints`;
- session принимает `ContextFrame`, symbol bindings и explicit distinguished links;
- внутри строится production `ExplicitMemoryView`, без второго memory/interpreter path;
- symbol bindings копируются и замораживаются на границе session;
- наружу не экспортируются `realize/delete` операции, поэтому UI не может превратить `interpret` в mutation;
- добавлен deterministic `memorySnapshot()` для diagnostics/non-mutation assertions;
- unit tests проверяют substitutions, context pronouns и неизменность snapshot/bindings.

Следующий слой после этого PR — presentation model/component для отображения `substitutions / aliases / trace` из `InterpretationResult`, не добавляя семантику в Vue.