### PR TITLE
Добавить presentation layer canonical interpreter

### DIFF
--- a/src/components/InterpretationPanel.vue
+++ b/src/components/InterpretationPanel.vue
@@ -1,0 +1,190 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { InterpretationResult } from '../core/interpreter'
+import { presentInterpretation } from '../core/interpretationPresentation'
+
+const props = defineProps<{
+  result: InterpretationResult | null
+  error?: string | null
+}>()
+
+const view = computed(() => (props.result ? presentInterpretation(props.result) : null))
+</script>
+
+<template>
+  <section class="interpretation-panel" aria-label="MTS interpretation">
+    <header class="interpretation-header">
+      <span class="interpretation-icon">MTS</span>
+      <span class="interpretation-title">Canonical interpretation</span>
+      <span
+        v-if="view"
+        class="interpretation-status"
+        :class="view.status === 'matched' ? 'status-matched' : 'status-not-matched'"
+      >
+        {{ view.status === 'matched' ? 'matched' : 'not matched' }}
+      </span>
+    </header>
+
+    <div class="interpretation-content">
+      <div v-if="error" class="interpretation-error" role="alert">
+        {{ error }}
+      </div>
+
+      <div v-else-if="!view" class="interpretation-empty">
+        No interpretation result
+      </div>
+
+      <template v-else>
+        <section class="interpretation-section">
+          <h3>Substitutions</h3>
+          <div v-if="view.substitutions.length === 0" class="section-empty">None</div>
+          <dl v-else class="mapping-list">
+            <template v-for="item in view.substitutions" :key="`${item.occurrence}:${item.link}`">
+              <dt><code>[] @ {{ item.occurrence }}</code></dt>
+              <dd><code>LinkRef {{ item.link }}</code></dd>
+            </template>
+          </dl>
+        </section>
+
+        <section class="interpretation-section">
+          <h3>Aliases</h3>
+          <div v-if="view.aliases.length === 0" class="section-empty">None</div>
+          <dl v-else class="mapping-list">
+            <template v-for="item in view.aliases" :key="`${item.occurrence}:${item.target}`">
+              <dt><code>[] @ {{ item.occurrence }}</code></dt>
+              <dd><code>→ [] @ {{ item.target }}</code></dd>
+            </template>
+          </dl>
+        </section>
+
+        <section class="interpretation-section">
+          <h3>Resolution trace</h3>
+          <div v-if="view.trace.length === 0" class="section-empty">None</div>
+          <ol v-else class="trace-list">
+            <li v-for="(step, index) in view.trace" :key="`${index}:${step}`">
+              <code>{{ step }}</code>
+            </li>
+          </ol>
+        </section>
+      </template>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.interpretation-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--bg-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.interpretation-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--accent-color);
+  border-bottom: 1px solid var(--border-color);
+  font-size: 0.85rem;
+}
+
+.interpretation-icon {
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text-color);
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.interpretation-title {
+  color: #94a3b8;
+}
+
+.interpretation-status {
+  margin-left: auto;
+  padding: 0.15rem 0.45rem;
+  border-radius: 3px;
+  font-size: 0.75rem;
+}
+
+.status-matched {
+  color: var(--success-color);
+  background: rgba(74, 222, 128, 0.1);
+}
+
+.status-not-matched {
+  color: var(--error-color);
+  background: rgba(248, 113, 113, 0.1);
+}
+
+.interpretation-content {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 0.75rem;
+}
+
+.interpretation-empty,
+.section-empty {
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.interpretation-error {
+  color: var(--error-color);
+  font-size: 0.85rem;
+}
+
+.interpretation-section + .interpretation-section {
+  margin-top: 1rem;
+}
+
+.interpretation-section h3 {
+  margin: 0 0 0.5rem;
+  color: #94a3b8;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.mapping-list {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0.35rem 0.75rem;
+  margin: 0;
+}
+
+.mapping-list dt,
+.mapping-list dd {
+  min-width: 0;
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+.mapping-list dd {
+  color: #94a3b8;
+}
+
+.mapping-list code,
+.trace-list code {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  word-break: break-word;
+}
+
+.trace-list {
+  margin: 0;
+  padding-left: 1.5rem;
+  color: #94a3b8;
+  font-size: 0.8rem;
+}
+
+.trace-list li + li {
+  margin-top: 0.25rem;
+}
+</style>

--- a/src/core/interpretationPresentation.ts
+++ b/src/core/interpretationPresentation.ts
@@ -1,0 +1,44 @@
+import type { InterpretationResult, OccurrencePath } from './interpreter'
+
+export interface InterpretationSubstitutionView {
+  readonly occurrence: string
+  readonly link: string
+}
+
+export interface InterpretationAliasView {
+  readonly occurrence: string
+  readonly target: string
+}
+
+export interface InterpretationPresentation {
+  readonly status: 'matched' | 'not-matched'
+  readonly substitutions: readonly InterpretationSubstitutionView[]
+  readonly aliases: readonly InterpretationAliasView[]
+  readonly trace: readonly string[]
+}
+
+/** Human-readable structural occurrence label. Empty path denotes the expression root. */
+export function formatOccurrencePath(path: OccurrencePath): string {
+  return path.length === 0 ? 'root' : path.join('.')
+}
+
+/**
+ * Convert the canonical interpreter result into immutable UI data.
+ *
+ * This module intentionally performs no interpretation, matching, memory lookup,
+ * or mutation. It is only the presentation boundary for an already-computed result.
+ */
+export function presentInterpretation(result: InterpretationResult): InterpretationPresentation {
+  return {
+    status: result.success ? 'matched' : 'not-matched',
+    substitutions: result.substitutions.map(item => ({
+      occurrence: formatOccurrencePath(item.path),
+      link: String(item.link),
+    })),
+    aliases: result.aliases.map(item => ({
+      occurrence: formatOccurrencePath(item.path),
+      target: formatOccurrencePath(item.targetPath),
+    })),
+    trace: [...result.trace],
+  }
+}

--- a/tests/unit/InterpretationPanel.test.ts
+++ b/tests/unit/InterpretationPanel.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import InterpretationPanel from '../../src/components/InterpretationPanel.vue'
+
+describe('InterpretationPanel', () => {
+  it('renders substitutions, aliases and resolution trace from canonical result', () => {
+    const wrapper = mount(InterpretationPanel, {
+      props: {
+        result: {
+          success: true,
+          substitutions: [{ path: [0], link: 10 }],
+          aliases: [{ path: [1], targetPath: [0] }],
+          trace: ['equality', 'bind:0->10'],
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('matched')
+    expect(wrapper.text()).toContain('[] @ 0')
+    expect(wrapper.text()).toContain('LinkRef 10')
+    expect(wrapper.text()).toContain('[] @ 1')
+    expect(wrapper.text()).toContain('→ [] @ 0')
+    expect(wrapper.text()).toContain('equality')
+    expect(wrapper.text()).toContain('bind:0->10')
+  })
+
+  it('renders an interpreter error separately from a failed match', () => {
+    const wrapper = mount(InterpretationPanel, {
+      props: {
+        result: null,
+        error: 'Symbol "x" is not bound',
+      },
+    })
+
+    expect(wrapper.get('[role="alert"]').text()).toContain('Symbol "x" is not bound')
+    expect(wrapper.text()).not.toContain('not matched')
+  })
+
+  it('renders failed matching as a normal canonical result', () => {
+    const wrapper = mount(InterpretationPanel, {
+      props: {
+        result: {
+          success: false,
+          substitutions: [],
+          aliases: [],
+          trace: ['inequality'],
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('not matched')
+    expect(wrapper.text()).toContain('inequality')
+  })
+})

--- a/tests/unit/interpretationPresentation.test.ts
+++ b/tests/unit/interpretationPresentation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatOccurrencePath, presentInterpretation } from '../../src/core/interpretationPresentation'
+
+describe('interpretation presentation', () => {
+  it('formats structural occurrence paths without inventing semantic labels', () => {
+    expect(formatOccurrencePath([])).toBe('root')
+    expect(formatOccurrencePath([0, 1, 0])).toBe('0.1.0')
+  })
+
+  it('maps canonical interpretation data without changing it', () => {
+    const result = {
+      success: true,
+      substitutions: [
+        { path: [0], link: 10 },
+        { path: [1, 0], link: 20 },
+      ],
+      aliases: [{ path: [1], targetPath: [0] }],
+      trace: ['equality', 'context:◁->10', 'bind:1->20'],
+    } as const
+
+    expect(presentInterpretation(result)).toEqual({
+      status: 'matched',
+      substitutions: [
+        { occurrence: '0', link: '10' },
+        { occurrence: '1.0', link: '20' },
+      ],
+      aliases: [{ occurrence: '1', target: '0' }],
+      trace: ['equality', 'context:◁->10', 'bind:1->20'],
+    })
+
+    expect(result.trace).toEqual(['equality', 'context:◁->10', 'bind:1->20'])
+  })
+
+  it('keeps a failed match distinct from an interpreter error', () => {
+    expect(
+      presentInterpretation({
+        success: false,
+        substitutions: [],
+        aliases: [],
+        trace: ['inequality'],
+      })
+    ).toEqual({
+      status: 'not-matched',
+      substitutions: [],
+      aliases: [],
+      trace: ['inequality'],
+    })
+  })
+})


### PR DESCRIPTION
Refs #107.

Продолжение Phase D без добавления второй semantics.

Что меняется:
- добавлен pure `interpretationPresentation.ts`, который только преобразует уже вычисленный `InterpretationResult` в immutable view model;
- добавлен `InterpretationPanel.vue`, отображающий `substitutions`, `aliases` и `resolution trace`;
- failed match отделён от interpreter error;
- occurrence identity показывается структурным AST path, а не display label;
- presentation layer не знает о parser, MemoryView, realize/delete или правилах доказательства;
- добавлены unit/component tests.

Граница PR:
- этот PR создаёт presentation component для canonical runtime;
- он не вводит новый interpreter/prover path и не меняет МТС contract;
- wiring конкретного `InterpretationSession` к пользовательскому runtime/configuration остаётся отдельной application integration задачей, чтобы UI не выдумывал context/memory из старого prover state.