### PR TITLE
Pin mts-proof v0.2 contract from anum_docs

### DIFF
--- a/contracts/anum_docs-v0.2/mts-proof-v0.2.json
+++ b/contracts/anum_docs-v0.2/mts-proof-v0.2.json
@@ -1,0 +1,48 @@
+{
+  "schema": "mts-proof/v0.2",
+  "status": "candidate",
+  "dependsOn": "mts-contract/v0.2",
+  "purpose": "trusted replay of accepted contextual interpretation; no additional inference rules",
+  "proofObject": {
+    "contractVersion": "mts-contract/v0.2",
+    "steps": "ordered InterpretStep[]"
+  },
+  "interpretStep": {
+    "rule": "interpret",
+    "expression": "canonical MTS v0.2 source",
+    "context": {
+      "start": "LinkRef",
+      "end": "LinkRef",
+      "parent": "optional recursive ContextFrame"
+    },
+    "symbols": "name -> LinkRef",
+    "distinguishedMemory": "array of {id,start,end}",
+    "expected": {
+      "success": "boolean",
+      "substitutions": "array of {path:int[],link:LinkRef}",
+      "aliases": "array of {path:int[],targetPath:int[]}"
+    }
+  },
+  "checker": {
+    "trustedRuleSet": ["interpret"],
+    "replaysCanonicalInterpreter": true,
+    "usesDisplayLabelsAsIdentity": false,
+    "mayMaterialize": false,
+    "checks": [
+      "contractVersion",
+      "rule",
+      "success",
+      "substitutions",
+      "aliases"
+    ]
+  },
+  "explicitlyNotTrusted": [
+    "lowercase-metavariables",
+    "global-textual-substitution",
+    "global-equality-rewrite",
+    "symmetry",
+    "transitivity",
+    "congruence",
+    "modus-ponens"
+  ]
+}

--- a/contracts/anum_docs-v0.2/provenance.json
+++ b/contracts/anum_docs-v0.2/provenance.json
@@ -8,5 +8,10 @@
   "conformance": {
     "path": "contracts/mts-conformance-v0.2.json",
     "gitBlobSha": "96303366a8808d9e67ee548b445fcdbf2233f336"
+  },
+  "proof": {
+    "path": "contracts/mts-proof-v0.2.json",
+    "sourceCommit": "d4d8e7c2291d26ea868d01dcc66f90d1c319c6e9",
+    "gitBlobSha": "7c125771be689ce2c825f5fa1be4674527f15dbb"
   }
 }

--- a/tests/unit/mtsContract.test.ts
+++ b/tests/unit/mtsContract.test.ts
@@ -13,6 +13,7 @@ const conformancePath = resolve(
   process.cwd(),
   'contracts/anum_docs-v0.2/mts-conformance-v0.2.json'
 )
+const proofPath = resolve(process.cwd(), 'contracts/anum_docs-v0.2/mts-proof-v0.2.json')
 const provenancePath = resolve(process.cwd(), 'contracts/anum_docs-v0.2/provenance.json')
 
 function readJson(path: string): unknown {
@@ -32,6 +33,20 @@ interface Provenance {
   sourceCommit: string
   contract: { path: string; gitBlobSha: string }
   conformance: { path: string; gitBlobSha: string }
+  proof: { path: string; sourceCommit: string; gitBlobSha: string }
+}
+
+interface ProofContractV02 {
+  schema: string
+  status: string
+  dependsOn: string
+  checker: {
+    trustedRuleSet: string[]
+    replaysCanonicalInterpreter: boolean
+    usesDisplayLabelsAsIdentity: boolean
+    mayMaterialize: boolean
+  }
+  explicitlyNotTrusted: string[]
 }
 
 function readProvenance(): Provenance {
@@ -59,6 +74,26 @@ describe('pinned anum_docs MTS v0.2 contract', () => {
     expect(gitBlobSha(conformancePath)).toBe(provenance.conformance.gitBlobSha)
     expect(provenance.contract.gitBlobSha).toBe('fb414a1541f3430fa9292c0fdfd89ca07d5db8ea')
     expect(provenance.conformance.gitBlobSha).toBe('96303366a8808d9e67ee548b445fcdbf2233f336')
+  })
+
+  it('pins the proof contract from its newer upstream commit without rewriting old provenance', () => {
+    const provenance = readProvenance()
+    const proof = readJson(proofPath) as ProofContractV02
+
+    expect(provenance.proof.sourceCommit).toBe(
+      'd4d8e7c2291d26ea868d01dcc66f90d1c319c6e9'
+    )
+    expect(gitBlobSha(proofPath)).toBe(provenance.proof.gitBlobSha)
+    expect(provenance.proof.gitBlobSha).toBe('7c125771be689ce2c825f5fa1be4674527f15dbb')
+    expect(proof.schema).toBe('mts-proof/v0.2')
+    expect(proof.status).toBe('candidate')
+    expect(proof.dependsOn).toBe('mts-contract/v0.2')
+    expect(proof.checker.trustedRuleSet).toEqual(['interpret'])
+    expect(proof.checker.replaysCanonicalInterpreter).toBe(true)
+    expect(proof.checker.usesDisplayLabelsAsIdentity).toBe(false)
+    expect(proof.checker.mayMaterialize).toBe(false)
+    expect(proof.explicitlyNotTrusted).toContain('transitivity')
+    expect(proof.explicitlyNotTrusted).toContain('modus-ponens')
   })
 
   it('treats the two context pronouns as atomic non-bracket code points', () => {


### PR DESCRIPTION
Refs #116, #107.

Первый безопасный шаг Phase E: фиксирует upstream proof replay contract **без добавления второго prover implementation**.

Что меняется:
- byte-identical `contracts/anum_docs-v0.2/mts-proof-v0.2.json` из `anum_docs`;
- provenance отдельно фиксирует source commit `d4d8e7c2291d26ea868d01dcc66f90d1c319c6e9` и Git blob SHA proof artifact, не переписывая provenance старых contract/conformance artifacts;
- unit test пересчитывает реальный Git blob SHA и проверяет candidate status, единственный trusted rule `interpret`, read-only semantics и explicit non-trust для transitivity/Modus Ponens.

Этот PR намеренно не добавляет TypeScript checker и не меняет legacy consumers. Он только создаёт tamper-proof upstream boundary; следующий migration PR сможет заменить old proof path, не изобретая локальные правила.