### PR TITLE
Валидировать untrusted mts-proof/v0.2 artifacts перед replay

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -119,6 +119,9 @@ export {
   MTS_PROOF_SCHEMA,
   MTS_CONTRACT_VERSION,
   MTS_TRUSTED_PROOF_RULE,
+  ProofObjectValidationError,
+  parseProofObject,
+  parseProofJson,
   checkInterpretProofStep,
   checkProof,
 } from './proofReplay'

--- a/src/core/proofReplay.ts
+++ b/src/core/proofReplay.ts
@@ -1,6 +1,11 @@
 import { parseExpr } from './parser'
 import { InterpretationSession } from './interpretationSession'
-import type { ContextFrame, InterpretationAlias, InterpretationSubstitution } from './interpreter'
+import type {
+  ContextFrame,
+  InterpretationAlias,
+  InterpretationSubstitution,
+  OccurrencePath,
+} from './interpreter'
 import type { DistinguishedLink } from './memoryView'
 
 export const MTS_PROOF_SCHEMA = 'mts-proof/v0.2' as const
@@ -26,6 +31,182 @@ export interface MtsProofObjectV02 {
   readonly schema: typeof MTS_PROOF_SCHEMA
   readonly contractVersion: typeof MTS_CONTRACT_VERSION
   readonly steps: readonly InterpretProofStep[]
+}
+
+export class ProofObjectValidationError extends Error {
+  readonly path: string
+
+  constructor(path: string, message: string) {
+    super(`${path}: ${message}`)
+    this.name = 'ProofObjectValidationError'
+    this.path = path
+  }
+}
+
+type UnknownRecord = Record<string, unknown>
+
+function fail(path: string, message: string): never {
+  throw new ProofObjectValidationError(path, message)
+}
+
+function record(value: unknown, path: string): UnknownRecord {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    fail(path, 'expected object')
+  }
+  return value as UnknownRecord
+}
+
+function stringValue(value: unknown, path: string): string {
+  if (typeof value !== 'string') fail(path, 'expected string')
+  return value
+}
+
+function booleanValue(value: unknown, path: string): boolean {
+  if (typeof value !== 'boolean') fail(path, 'expected boolean')
+  return value
+}
+
+function linkRef(value: unknown, path: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value)) {
+    fail(path, 'expected integer LinkRef')
+  }
+  return value
+}
+
+function occurrencePath(value: unknown, path: string): OccurrencePath {
+  if (!Array.isArray(value)) fail(path, 'expected occurrence path array')
+  return value.map((part, index) => {
+    if (typeof part !== 'number' || !Number.isSafeInteger(part) || part < 0) {
+      fail(`${path}[${index}]`, 'expected non-negative integer path segment')
+    }
+    return part
+  })
+}
+
+function contextFrame(value: unknown, path: string): ContextFrame {
+  const source = record(value, path)
+  const frame: ContextFrame = {
+    start: linkRef(source.start, `${path}.start`),
+    end: linkRef(source.end, `${path}.end`),
+  }
+  if (source.parent === undefined) return frame
+  return { ...frame, parent: contextFrame(source.parent, `${path}.parent`) }
+}
+
+function symbols(value: unknown, path: string): Readonly<Record<string, number>> | undefined {
+  if (value === undefined) return undefined
+  const source = record(value, path)
+  const result: Record<string, number> = {}
+  for (const [name, reference] of Object.entries(source)) {
+    result[name] = linkRef(reference, `${path}.${JSON.stringify(name)}`)
+  }
+  return result
+}
+
+function distinguishedMemory(
+  value: unknown,
+  path: string
+): readonly DistinguishedLink[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value)) fail(path, 'expected distinguished memory array')
+  return value.map((entry, index) => {
+    const source = record(entry, `${path}[${index}]`)
+    return {
+      id: linkRef(source.id, `${path}[${index}].id`),
+      start: linkRef(source.start, `${path}[${index}].start`),
+      end: linkRef(source.end, `${path}[${index}].end`),
+    }
+  })
+}
+
+function substitutions(value: unknown, path: string): readonly InterpretationSubstitution[] {
+  if (!Array.isArray(value)) fail(path, 'expected substitutions array')
+  return value.map((entry, index) => {
+    const source = record(entry, `${path}[${index}]`)
+    return {
+      path: occurrencePath(source.path, `${path}[${index}].path`),
+      link: linkRef(source.link, `${path}[${index}].link`),
+    }
+  })
+}
+
+function aliases(value: unknown, path: string): readonly InterpretationAlias[] {
+  if (!Array.isArray(value)) fail(path, 'expected aliases array')
+  return value.map((entry, index) => {
+    const source = record(entry, `${path}[${index}]`)
+    return {
+      path: occurrencePath(source.path, `${path}[${index}].path`),
+      targetPath: occurrencePath(source.targetPath, `${path}[${index}].targetPath`),
+    }
+  })
+}
+
+function expectedResult(value: unknown, path: string): ProofExpectedResult {
+  const source = record(value, path)
+  return {
+    success: booleanValue(source.success, `${path}.success`),
+    substitutions: substitutions(source.substitutions, `${path}.substitutions`),
+    aliases: aliases(source.aliases, `${path}.aliases`),
+  }
+}
+
+function interpretStep(value: unknown, path: string): InterpretProofStep {
+  const source = record(value, path)
+  const rule = stringValue(source.rule, `${path}.rule`)
+  if (rule !== MTS_TRUSTED_PROOF_RULE) {
+    fail(`${path}.rule`, `unsupported trusted rule ${JSON.stringify(rule)}`)
+  }
+
+  const step: InterpretProofStep = {
+    rule: MTS_TRUSTED_PROOF_RULE,
+    expression: stringValue(source.expression, `${path}.expression`),
+    context: contextFrame(source.context, `${path}.context`),
+    expected: expectedResult(source.expected, `${path}.expected`),
+  }
+
+  const decodedSymbols = symbols(source.symbols, `${path}.symbols`)
+  const decodedMemory = distinguishedMemory(source.distinguishedMemory, `${path}.distinguishedMemory`)
+  return {
+    ...step,
+    ...(decodedSymbols === undefined ? {} : { symbols: decodedSymbols }),
+    ...(decodedMemory === undefined ? {} : { distinguishedMemory: decodedMemory }),
+  }
+}
+
+/** Decode an untrusted external value into the exact supported mts-proof/v0.2 surface. */
+export function parseProofObject(value: unknown): MtsProofObjectV02 {
+  const source = record(value, '$')
+  const schema = stringValue(source.schema, '$.schema')
+  if (schema !== MTS_PROOF_SCHEMA) {
+    fail('$.schema', `expected ${MTS_PROOF_SCHEMA}, got ${JSON.stringify(schema)}`)
+  }
+
+  const contractVersion = stringValue(source.contractVersion, '$.contractVersion')
+  if (contractVersion !== MTS_CONTRACT_VERSION) {
+    fail(
+      '$.contractVersion',
+      `expected ${MTS_CONTRACT_VERSION}, got ${JSON.stringify(contractVersion)}`
+    )
+  }
+
+  if (!Array.isArray(source.steps)) fail('$.steps', 'expected steps array')
+  return {
+    schema: MTS_PROOF_SCHEMA,
+    contractVersion: MTS_CONTRACT_VERSION,
+    steps: source.steps.map((step, index) => interpretStep(step, `$.steps[${index}]`)),
+  }
+}
+
+/** Parse and validate an untrusted JSON proof artifact. */
+export function parseProofJson(source: string): MtsProofObjectV02 {
+  let value: unknown
+  try {
+    value = JSON.parse(source) as unknown
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : 'invalid JSON'
+    fail('$', `invalid JSON: ${message}`)
+  }
+  return parseProofObject(value)
 }
 
 function comparePath(left: readonly number[], right: readonly number[]): number {
@@ -92,9 +273,12 @@ export function checkInterpretProofStep(step: InterpretProofStep): boolean {
   }
 }
 
-/** Independently replay every trusted step in a proof object. */
+/** Independently validate and replay every trusted step in a proof object. */
 export function checkProof(proof: MtsProofObjectV02): boolean {
-  if (proof.schema !== MTS_PROOF_SCHEMA) return false
-  if (proof.contractVersion !== MTS_CONTRACT_VERSION) return false
-  return proof.steps.every(checkInterpretProofStep)
+  try {
+    const decoded = parseProofObject(proof)
+    return decoded.steps.every(checkInterpretProofStep)
+  } catch {
+    return false
+  }
 }

--- a/tests/unit/proofReplay.test.ts
+++ b/tests/unit/proofReplay.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from 'vitest'
 import {
   MTS_CONTRACT_VERSION,
   MTS_PROOF_SCHEMA,
+  ProofObjectValidationError,
   checkProof,
+  parseProofJson,
+  parseProofObject,
   type MtsProofObjectV02,
 } from '../../src/core/proofReplay'
 
@@ -15,24 +18,20 @@ function proof(steps: MtsProofObjectV02['steps']): MtsProofObjectV02 {
   }
 }
 
+const substitutionStep: MtsProofObjectV02['steps'][number] = {
+  rule: 'interpret',
+  expression: '[] = ◁',
+  context: { start: 10, end: 12 },
+  expected: {
+    success: true,
+    substitutions: [{ path: [0], link: 10 }],
+    aliases: [],
+  },
+}
+
 describe('mts-proof/v0.2 replay checker', () => {
   it('replays occurrence-local substitution', () => {
-    expect(
-      checkProof(
-        proof([
-          {
-            rule: 'interpret',
-            expression: '[] = ◁',
-            context: { start: 10, end: 12 },
-            expected: {
-              success: true,
-              substitutions: [{ path: [0], link: 10 }],
-              aliases: [],
-            },
-          },
-        ])
-      )
-    ).toBe(true)
+    expect(checkProof(proof([substitutionStep]))).toBe(true)
   })
 
   it('rejects forged substitution', () => {
@@ -40,9 +39,7 @@ describe('mts-proof/v0.2 replay checker', () => {
       checkProof(
         proof([
           {
-            rule: 'interpret',
-            expression: '[] = ◁',
-            context: { start: 10, end: 12 },
+            ...substitutionStep,
             expected: {
               success: true,
               substitutions: [{ path: [0], link: 12 }],
@@ -79,25 +76,21 @@ describe('mts-proof/v0.2 replay checker', () => {
   })
 
   it('rejects unknown rules instead of extending trust', () => {
-    const candidate = proof([
-      {
-        rule: 'interpret',
-        expression: '[] = ◁',
-        context: { start: 10, end: 12 },
-        expected: {
-          success: true,
-          substitutions: [{ path: [0], link: 10 }],
-          aliases: [],
-        },
-      },
-    ]) as unknown as { schema: string; contractVersion: string; steps: Array<Record<string, unknown>> }
-
+    const candidate = proof([substitutionStep]) as unknown as {
+      schema: string
+      contractVersion: string
+      steps: Array<Record<string, unknown>>
+    }
     candidate.steps[0].rule = 'transitivity'
     expect(checkProof(candidate as unknown as MtsProofObjectV02)).toBe(false)
   })
 
   it('rejects wrong contract provenance', () => {
-    const candidate = proof([]) as unknown as { schema: string; contractVersion: string; steps: [] }
+    const candidate = proof([]) as unknown as {
+      schema: string
+      contractVersion: string
+      steps: []
+    }
     candidate.contractVersion = 'mts-contract/v0.1'
     expect(checkProof(candidate as unknown as MtsProofObjectV02)).toBe(false)
   })
@@ -117,5 +110,115 @@ describe('mts-proof/v0.2 replay checker', () => {
         ])
       )
     ).toBe(false)
+  })
+})
+
+describe('untrusted proof artifact validation', () => {
+  it('decodes valid JSON before independent replay', () => {
+    const source = JSON.stringify(proof([substitutionStep]))
+    const decoded = parseProofJson(source)
+
+    expect(decoded.schema).toBe(MTS_PROOF_SCHEMA)
+    expect(decoded.contractVersion).toBe(MTS_CONTRACT_VERSION)
+    expect(checkProof(decoded)).toBe(true)
+  })
+
+  it('rebuilds a clean object and drops untrusted extra fields', () => {
+    const decoded = parseProofObject({
+      schema: MTS_PROOF_SCHEMA,
+      contractVersion: MTS_CONTRACT_VERSION,
+      hiddenSemantics: 'must not survive',
+      steps: [
+        {
+          ...substitutionStep,
+          hiddenRuleData: { trusted: true },
+          expected: {
+            ...substitutionStep.expected,
+            hiddenExpectedData: 123,
+          },
+        },
+      ],
+    })
+
+    expect(decoded).toEqual(proof([substitutionStep]))
+    expect('hiddenSemantics' in decoded).toBe(false)
+    expect('hiddenRuleData' in decoded.steps[0]).toBe(false)
+    expect('hiddenExpectedData' in decoded.steps[0].expected).toBe(false)
+  })
+
+  it('reports malformed JSON as a validation error', () => {
+    expect(() => parseProofJson('{not-json')).toThrow(ProofObjectValidationError)
+    expect(() => parseProofJson('{not-json')).toThrow(/invalid JSON/)
+  })
+
+  it('rejects the wrong proof schema', () => {
+    expect(() =>
+      parseProofObject({
+        ...proof([]),
+        schema: 'mts-proof/v0.1',
+      })
+    ).toThrow(/\$\.schema/)
+  })
+
+  it('rejects an untrusted inference rule at the decoder boundary', () => {
+    expect(() =>
+      parseProofObject({
+        ...proof([]),
+        steps: [{ ...substitutionStep, rule: 'modus-ponens' }],
+      })
+    ).toThrow(/unsupported trusted rule/)
+  })
+
+  it('validates recursive context frames', () => {
+    expect(() =>
+      parseProofObject({
+        ...proof([]),
+        steps: [
+          {
+            ...substitutionStep,
+            context: { start: 10, end: 12, parent: { start: 'bad', end: 4 } },
+          },
+        ],
+      })
+    ).toThrow(/context\.parent\.start/)
+  })
+
+  it('requires integer LinkRefs in symbols and memory', () => {
+    expect(() =>
+      parseProofObject({
+        ...proof([]),
+        steps: [{ ...substitutionStep, symbols: { x: 1.5 } }],
+      })
+    ).toThrow(/integer LinkRef/)
+
+    expect(() =>
+      parseProofObject({
+        ...proof([]),
+        steps: [
+          {
+            ...substitutionStep,
+            distinguishedMemory: [{ id: 30, start: 2, end: '3' }],
+          },
+        ],
+      })
+    ).toThrow(/integer LinkRef/)
+  })
+
+  it('rejects invalid occurrence paths', () => {
+    expect(() =>
+      parseProofObject({
+        ...proof([]),
+        steps: [
+          {
+            ...substitutionStep,
+            expected: {
+              success: true,
+              substitutions: [{ path: [-1], link: 10 }],
+              aliases: [],
+            },
+          },
+        ],
+      })
+    ).toThrow(/non-negative integer path segment/)
   })
 })

--- a/tests/unit/proofReplay.test.ts
+++ b/tests/unit/proofReplay.test.ts
@@ -76,22 +76,20 @@ describe('mts-proof/v0.2 replay checker', () => {
   })
 
   it('rejects unknown rules instead of extending trust', () => {
-    const candidate = proof([substitutionStep]) as unknown as {
-      schema: string
-      contractVersion: string
-      steps: Array<Record<string, unknown>>
+    const candidate = {
+      schema: MTS_PROOF_SCHEMA,
+      contractVersion: MTS_CONTRACT_VERSION,
+      steps: [{ ...substitutionStep, rule: 'transitivity' }],
     }
-    candidate.steps[0].rule = 'transitivity'
     expect(checkProof(candidate as unknown as MtsProofObjectV02)).toBe(false)
   })
 
   it('rejects wrong contract provenance', () => {
-    const candidate = proof([]) as unknown as {
-      schema: string
-      contractVersion: string
-      steps: []
+    const candidate = {
+      schema: MTS_PROOF_SCHEMA,
+      contractVersion: 'mts-contract/v0.1',
+      steps: [],
     }
-    candidate.contractVersion = 'mts-contract/v0.1'
     expect(checkProof(candidate as unknown as MtsProofObjectV02)).toBe(false)
   })
 


### PR DESCRIPTION
Refs #119, #107.

Первый Phase F boundary после удаления legacy prover.

- `parseProofObject(unknown)` runtime-валидирует exact `mts-proof/v0.2` / `mts-contract/v0.2` artifact;
- `parseProofJson(string)` отделяет JSON parsing от trusted replay;
- recursive ContextFrame, integer LinkRef, occurrence paths, symbols, distinguished memory, substitutions и aliases проверяются структурно;
- разрешён только trusted rule `interpret`;
- decoder перестраивает clean typed object и отбрасывает extra/untrusted fields;
- `checkProof` теперь сам повторно проходит validation boundary, поэтому unsafe TypeScript cast не обходит contract checks;
- negative tests покрывают wrong schema/rule/context/path/LinkRef и malformed JSON;
- public core API экспортирует validation boundary рядом с checker.

Никаких новых inference rules, proof search или Vue semantics не добавляется.

Merge только после полного зелёного CI и `behind_by=0`.