### PR TITLE
Добавить UI загрузки и independent replay mts-proof/v0.2

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@ import Editor from './components/Editor.vue'
 import ASTViewer from './components/ASTViewer.vue'
 import ErrorPanel from './components/ErrorPanel.vue'
 import LinkGraphViewer from './components/LinkGraphViewer.vue'
+import ProofReplayPanel from './components/ProofReplayPanel.vue'
 import SplitPane from './components/SplitPane.vue'
 import {
   readFileContent,
@@ -51,6 +52,8 @@ const ast = ref<MtsFile | null>(null)
 
 const showAST = ref(true)
 const showGraph = ref(false)
+const showProofReplay = ref(false)
+const proofSource = ref('')
 const highlightedLoc = ref<SourceLocation | null>(null)
 const highlightedNodeLoc = ref<SourceLocation | null>(null)
 
@@ -70,6 +73,7 @@ const autosaveInterval = ref<ReturnType<typeof setInterval> | null>(null)
 const handleSplitResize = () => window.dispatchEvent(new Event('resize'))
 const toggleAST = () => (showAST.value = !showAST.value)
 const toggleGraph = () => (showGraph.value = !showGraph.value)
+const toggleProofReplay = () => (showProofReplay.value = !showProofReplay.value)
 
 const handleNodeHover = (loc: SourceLocation | null) => {
   highlightedLoc.value = loc
@@ -211,6 +215,7 @@ const handleKeyDown = (event: KeyboardEvent) => {
     handleNewFile()
   } else if (event.key === 'Escape') {
     showRecentFiles.value = false
+    showProofReplay.value = false
   }
 }
 
@@ -266,6 +271,14 @@ onUnmounted(() => {
             </div>
           </div>
           <button class="toolbar-btn" title="Сохранить код (Ctrl+S)" @click="handleSaveCode">💾 <span>Сохранить</span></button>
+          <button
+            class="toolbar-btn proof-replay-toggle"
+            :class="{ active: showProofReplay }"
+            title="Trusted proof replay"
+            @click="toggleProofReplay"
+          >
+            PRF <span>Proof</span>
+          </button>
         </div>
         <div class="view-controls">
           <button
@@ -293,8 +306,14 @@ onUnmounted(() => {
     </header>
 
     <div class="runtime-note">
-      Trusted proof path: <code>mts-proof/v0.2</code> replay-only. Старые A0–A11/MP semantics удаляются в Phase E; proof search вернётся только поверх trusted checker.
+      Trusted proof path: <code>mts-proof/v0.2</code> replay-only. Legacy A0–A11/MP semantics удалены; proof search будет строиться только поверх independent checker.
     </div>
+
+    <ProofReplayPanel
+      v-if="showProofReplay"
+      v-model="proofSource"
+      @close="showProofReplay = false"
+    />
 
     <div v-if="showConversion && conversionSteps.length" class="conversion-panel">
       <div v-for="(step, index) in conversionSteps" :key="index" class="conversion-step">
@@ -444,7 +463,7 @@ button { font-family: inherit; }
 .header-right, .toolbar, .view-controls { display: flex; align-items: center; gap: .35rem; }
 .toolbar-btn, .toggle-btn, .recent-clear-btn { background: var(--accent-color); color: #cbd5e1; border: 1px solid var(--border-color); padding: .35rem .55rem; border-radius: 4px; cursor: pointer; }
 .toolbar-btn:hover, .toggle-btn:hover, .recent-clear-btn:hover { color: white; }
-.toggle-btn.active { border-color: #667eea; color: white; }
+.toolbar-btn.active, .toggle-btn.active { border-color: #667eea; color: white; }
 .toggle-btn:disabled { opacity: .45; cursor: not-allowed; }
 .dropdown-container { position: relative; }
 .recent-files-dropdown { position: absolute; right: 0; top: calc(100% + .25rem); z-index: 20; min-width: 290px; background: var(--panel-bg); border: 1px solid var(--border-color); border-radius: 4px; padding: .35rem; }

--- a/src/components/ProofReplayPanel.vue
+++ b/src/components/ProofReplayPanel.vue
@@ -1,0 +1,348 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { presentProofArtifactJson } from '../core/proofArtifactPresentation'
+
+const props = defineProps<{
+  modelValue: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+  close: []
+}>()
+
+const fileInput = ref<HTMLInputElement | null>(null)
+const view = computed(() => presentProofArtifactJson(props.modelValue))
+
+const updateSource = (event: Event) => {
+  emit('update:modelValue', (event.target as HTMLTextAreaElement).value)
+}
+
+const openFile = () => fileInput.value?.click()
+
+const loadFile = async (event: Event) => {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (!file) return
+  emit('update:modelValue', await file.text())
+  input.value = ''
+}
+
+const clear = () => emit('update:modelValue', '')
+</script>
+
+<template>
+  <section class="proof-replay-panel" data-testid="proof-replay-panel">
+    <header class="proof-replay-header">
+      <div>
+        <strong>Trusted proof replay</strong>
+        <span class="proof-replay-subtitle">mts-proof/v0.2 · replay-only</span>
+      </div>
+      <div class="proof-replay-actions">
+        <input
+          ref="fileInput"
+          class="proof-file-input"
+          type="file"
+          accept=".json,application/json"
+          @change="loadFile"
+        />
+        <button type="button" class="proof-action" @click="openFile">Load JSON</button>
+        <button type="button" class="proof-action" @click="clear">Clear</button>
+        <button type="button" class="proof-action close" aria-label="Close proof replay" @click="emit('close')">
+          ×
+        </button>
+      </div>
+    </header>
+
+    <div class="proof-replay-body">
+      <label class="proof-source-label" for="proof-artifact-source">Proof artifact JSON</label>
+      <textarea
+        id="proof-artifact-source"
+        class="proof-source"
+        :value="modelValue"
+        spellcheck="false"
+        placeholder="Paste an mts-proof/v0.2 JSON artifact here"
+        @input="updateSource"
+      />
+
+      <div class="proof-result" :class="`status-${view.status}`">
+        <div v-if="view.status === 'empty'" class="proof-empty">
+          Load or paste a proof artifact. The artifact is validated before independent replay.
+        </div>
+
+        <div v-else-if="view.status === 'invalid'" class="proof-invalid">
+          <strong>Validation error</strong>
+          <code v-if="view.errorPath">{{ view.errorPath }}</code>
+          <span>{{ view.error }}</span>
+        </div>
+
+        <template v-else>
+          <div class="proof-summary">
+            <span class="proof-verdict" :class="{ accepted: view.accepted, rejected: !view.accepted }">
+              {{ view.accepted ? 'REPLAY ACCEPTED' : 'REPLAY REJECTED' }}
+            </span>
+            <code>{{ view.schema }}</code>
+            <code>{{ view.contractVersion }}</code>
+          </div>
+
+          <div class="proof-steps">
+            <article v-for="step in view.steps" :key="step.index" class="proof-step">
+              <div class="proof-step-header">
+                <span class="proof-step-number">#{{ step.index }}</span>
+                <code>{{ step.rule }}</code>
+                <span class="step-verdict" :class="{ accepted: step.accepted, rejected: !step.accepted }">
+                  {{ step.accepted ? 'accepted' : 'rejected' }}
+                </span>
+              </div>
+
+              <code class="proof-expression">{{ step.expression }}</code>
+
+              <div class="proof-section">
+                <span class="proof-section-title">Context</span>
+                <div class="context-rows">
+                  <code v-for="frame in step.context" :key="frame.depth">
+                    {{ frame.depth === 0 ? 'current' : `parent↑${frame.depth}` }}:
+                    ◁={{ frame.start }} · ▷={{ frame.end }}
+                  </code>
+                </div>
+              </div>
+
+              <div class="proof-meta">
+                <span>symbols: {{ step.symbolCount }}</span>
+                <span>distinguished links: {{ step.distinguishedLinkCount }}</span>
+              </div>
+
+              <div class="proof-section">
+                <span class="proof-section-title">Expected substitutions</span>
+                <div v-if="step.substitutions.length" class="proof-values">
+                  <code v-for="item in step.substitutions" :key="`${item.occurrence}:${item.link}`">
+                    [] @ {{ item.occurrence }} → LinkRef {{ item.link }}
+                  </code>
+                </div>
+                <span v-else class="proof-none">none</span>
+              </div>
+
+              <div class="proof-section">
+                <span class="proof-section-title">Expected aliases</span>
+                <div v-if="step.aliases.length" class="proof-values">
+                  <code v-for="item in step.aliases" :key="`${item.occurrence}:${item.target}`">
+                    [] @ {{ item.occurrence }} → [] @ {{ item.target }}
+                  </code>
+                </div>
+                <span v-else class="proof-none">none</span>
+              </div>
+            </article>
+          </div>
+        </template>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.proof-replay-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 240px;
+  max-height: 48vh;
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.proof-replay-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.55rem 0.75rem;
+  background: var(--accent-color);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.proof-replay-header > div:first-child {
+  display: flex;
+  align-items: baseline;
+  gap: 0.65rem;
+}
+
+.proof-replay-subtitle,
+.proof-source-label,
+.proof-meta,
+.proof-none {
+  color: #94a3b8;
+  font-size: 0.72rem;
+}
+
+.proof-replay-actions {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.proof-file-input {
+  display: none;
+}
+
+.proof-action {
+  padding: 0.25rem 0.5rem;
+  color: #cbd5e1;
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.proof-action:hover {
+  color: white;
+}
+
+.proof-action.close {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.proof-replay-body {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.8fr) minmax(360px, 1.2fr);
+  gap: 0.6rem;
+  min-height: 0;
+  padding: 0.6rem;
+  overflow: hidden;
+}
+
+.proof-source-label {
+  grid-column: 1;
+}
+
+.proof-source {
+  grid-column: 1;
+  min-height: 160px;
+  width: 100%;
+  resize: vertical;
+  padding: 0.55rem;
+  color: #e2e8f0;
+  background: #0f172a;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.75rem;
+}
+
+.proof-result {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  min-height: 0;
+  overflow: auto;
+  padding: 0.55rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.proof-empty,
+.proof-invalid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: #94a3b8;
+}
+
+.proof-invalid {
+  color: var(--error-color);
+}
+
+.proof-summary,
+.proof-step-header,
+.proof-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.proof-summary {
+  margin-bottom: 0.6rem;
+}
+
+.proof-verdict,
+.step-verdict {
+  padding: 0.12rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.accepted {
+  color: var(--success-color);
+  background: rgba(74, 222, 128, 0.1);
+}
+
+.rejected {
+  color: var(--error-color);
+  background: rgba(248, 113, 113, 0.1);
+}
+
+.proof-steps,
+.proof-values,
+.context-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.proof-step {
+  padding: 0.55rem;
+  background: rgba(15, 23, 42, 0.55);
+  border-left: 3px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.proof-step-number {
+  color: #94a3b8;
+  font-size: 0.72rem;
+}
+
+.proof-expression {
+  display: block;
+  margin: 0.5rem 0;
+  color: #c4b5fd;
+}
+
+.proof-section {
+  margin-top: 0.45rem;
+}
+
+.proof-section-title {
+  display: block;
+  margin-bottom: 0.2rem;
+  color: #94a3b8;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.proof-values code,
+.context-rows code {
+  font-size: 0.72rem;
+}
+
+@media (max-width: 900px) {
+  .proof-replay-panel {
+    max-height: 60vh;
+  }
+
+  .proof-replay-body {
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+  }
+
+  .proof-source {
+    min-height: 120px;
+  }
+
+  .proof-result {
+    min-height: 160px;
+  }
+}
+</style>

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -126,6 +126,18 @@ export {
   checkProof,
 } from './proofReplay'
 
+export type {
+  ProofContextView,
+  ProofSubstitutionView,
+  ProofAliasView,
+  ProofStepReplayView,
+  EmptyProofArtifactView,
+  InvalidProofArtifactView,
+  ReplayedProofArtifactView,
+  ProofArtifactView,
+} from './proofArtifactPresentation'
+export { presentProofArtifactJson } from './proofArtifactPresentation'
+
 export type { StringAnumOptions, ConversionStep, StringAnumStats } from './stringAnum'
 export {
   StringAnumError,

--- a/src/core/proofArtifactPresentation.ts
+++ b/src/core/proofArtifactPresentation.ts
@@ -1,0 +1,123 @@
+import {
+  ProofObjectValidationError,
+  checkInterpretProofStep,
+  checkProof,
+  parseProofJson,
+  type MtsProofObjectV02,
+} from './proofReplay'
+import { formatOccurrencePath } from './interpretationPresentation'
+import type { ContextFrame } from './interpreter'
+
+export interface ProofContextView {
+  readonly depth: number
+  readonly start: number
+  readonly end: number
+}
+
+export interface ProofSubstitutionView {
+  readonly occurrence: string
+  readonly link: number
+}
+
+export interface ProofAliasView {
+  readonly occurrence: string
+  readonly target: string
+}
+
+export interface ProofStepReplayView {
+  readonly index: number
+  readonly rule: 'interpret'
+  readonly expression: string
+  readonly accepted: boolean
+  readonly context: readonly ProofContextView[]
+  readonly substitutions: readonly ProofSubstitutionView[]
+  readonly aliases: readonly ProofAliasView[]
+  readonly symbolCount: number
+  readonly distinguishedLinkCount: number
+}
+
+export interface EmptyProofArtifactView {
+  readonly status: 'empty'
+}
+
+export interface InvalidProofArtifactView {
+  readonly status: 'invalid'
+  readonly error: string
+  readonly errorPath?: string
+}
+
+export interface ReplayedProofArtifactView {
+  readonly status: 'accepted' | 'rejected'
+  readonly schema: string
+  readonly contractVersion: string
+  readonly accepted: boolean
+  readonly steps: readonly ProofStepReplayView[]
+}
+
+export type ProofArtifactView =
+  | EmptyProofArtifactView
+  | InvalidProofArtifactView
+  | ReplayedProofArtifactView
+
+function contextView(frame: ContextFrame): ProofContextView[] {
+  const result: ProofContextView[] = []
+  let current: ContextFrame | undefined = frame
+  let depth = 0
+  while (current) {
+    result.push({ depth, start: current.start, end: current.end })
+    current = current.parent
+    depth += 1
+  }
+  return result
+}
+
+function replaySteps(proof: MtsProofObjectV02): ProofStepReplayView[] {
+  return proof.steps.map((step, index) => ({
+    index: index + 1,
+    rule: step.rule,
+    expression: step.expression,
+    accepted: checkInterpretProofStep(step),
+    context: contextView(step.context),
+    substitutions: step.expected.substitutions.map(item => ({
+      occurrence: formatOccurrencePath(item.path),
+      link: item.link,
+    })),
+    aliases: step.expected.aliases.map(item => ({
+      occurrence: formatOccurrencePath(item.path),
+      target: formatOccurrencePath(item.targetPath),
+    })),
+    symbolCount: Object.keys(step.symbols ?? {}).length,
+    distinguishedLinkCount: step.distinguishedMemory?.length ?? 0,
+  }))
+}
+
+/**
+ * Build a presentation-only view from an untrusted proof JSON artifact.
+ *
+ * Validation and replay remain delegated to proofReplay.ts. This function only
+ * shapes already validated/replayed data for application presentation.
+ */
+export function presentProofArtifactJson(source: string): ProofArtifactView {
+  if (!source.trim()) return { status: 'empty' }
+
+  try {
+    const proof = parseProofJson(source)
+    const steps = replaySteps(proof)
+    const accepted = checkProof(proof)
+    return {
+      status: accepted ? 'accepted' : 'rejected',
+      schema: proof.schema,
+      contractVersion: proof.contractVersion,
+      accepted,
+      steps,
+    }
+  } catch (cause) {
+    if (cause instanceof ProofObjectValidationError) {
+      return { status: 'invalid', error: cause.message, errorPath: cause.path }
+    }
+    return {
+      status: 'invalid',
+      error: cause instanceof Error ? cause.message : 'Unknown proof artifact error',
+    }
+  }
+}

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -42,6 +42,65 @@ test.describe('aprover canonical MTS v0.2 UI', () => {
     await expect(page.locator('text=statements verified')).toHaveCount(0)
   })
 
+  test('loads and independently replays an mts-proof/v0.2 artifact', async ({ page }) => {
+    const artifact = JSON.stringify({
+      schema: 'mts-proof/v0.2',
+      contractVersion: 'mts-contract/v0.2',
+      steps: [
+        {
+          rule: 'interpret',
+          expression: '[] = ◁',
+          context: { start: 10, end: 12 },
+          expected: {
+            success: true,
+            substitutions: [{ path: [0], link: 10 }],
+            aliases: [],
+          },
+        },
+      ],
+    })
+
+    await page.locator('.proof-replay-toggle').click()
+    await expect(page.getByTestId('proof-replay-panel')).toBeVisible()
+    await page.locator('#proof-artifact-source').fill(artifact)
+
+    await expect(page.locator('.proof-verdict')).toContainText('REPLAY ACCEPTED')
+    await expect(page.locator('.proof-summary')).toContainText('mts-proof/v0.2')
+    await expect(page.locator('.proof-expression')).toContainText('[] = ◁')
+    await expect(page.locator('.proof-step')).toContainText('[] @ 0 → LinkRef 10')
+  })
+
+  test('separates proof validation errors from replay rejection', async ({ page }) => {
+    await page.locator('.proof-replay-toggle').click()
+    const source = page.locator('#proof-artifact-source')
+
+    await source.fill(
+      JSON.stringify({
+        schema: 'mts-proof/v0.2',
+        contractVersion: 'mts-contract/v0.2',
+        steps: [
+          {
+            rule: 'interpret',
+            expression: '[] = ◁',
+            context: { start: 10, end: 12 },
+            expected: {
+              success: true,
+              substitutions: [{ path: [0], link: 12 }],
+              aliases: [],
+            },
+          },
+        ],
+      })
+    )
+    await expect(page.locator('.proof-verdict')).toContainText('REPLAY REJECTED')
+    await expect(page.locator('.proof-invalid')).toHaveCount(0)
+
+    await source.fill('{"schema":"wrong","contractVersion":"mts-contract/v0.2","steps":[]}')
+    await expect(page.locator('.proof-invalid')).toContainText('Validation error')
+    await expect(page.locator('.proof-invalid')).toContainText('$.schema')
+    await expect(page.locator('.proof-verdict')).toHaveCount(0)
+  })
+
   test('keeps AST inspection and source highlighting', async ({ page }) => {
     const editor = page.locator('.code-input')
     await editor.fill('[] = ◁')
@@ -78,6 +137,7 @@ test.describe('aprover canonical MTS v0.2 UI', () => {
     await expect(page.locator('.toolbar-btn[title*="Открыть"]')).toBeVisible()
     await expect(page.locator('.toolbar-btn[title*="Сохранить"]')).toBeVisible()
     await expect(page.locator('.recent-btn')).toBeVisible()
+    await expect(page.locator('.proof-replay-toggle')).toBeVisible()
     await expect(page.locator('.toolbar-btn[title*="Результаты"]')).toHaveCount(0)
   })
 

--- a/tests/unit/ProofReplayPanel.test.ts
+++ b/tests/unit/ProofReplayPanel.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import ProofReplayPanel from '../../src/components/ProofReplayPanel.vue'
+import { MTS_CONTRACT_VERSION, MTS_PROOF_SCHEMA } from '../../src/core/proofReplay'
+
+function artifact(link = 10): string {
+  return JSON.stringify({
+    schema: MTS_PROOF_SCHEMA,
+    contractVersion: MTS_CONTRACT_VERSION,
+    steps: [
+      {
+        rule: 'interpret',
+        expression: '[] = ◁',
+        context: { start: 10, end: 12, parent: { start: 20, end: 22 } },
+        expected: {
+          success: true,
+          substitutions: [{ path: [0], link }],
+          aliases: [],
+        },
+      },
+    ],
+  })
+}
+
+describe('ProofReplayPanel', () => {
+  it('shows an independently accepted proof with step/context/substitution details', () => {
+    const wrapper = mount(ProofReplayPanel, { props: { modelValue: artifact() } })
+
+    expect(wrapper.text()).toContain('REPLAY ACCEPTED')
+    expect(wrapper.text()).toContain(MTS_PROOF_SCHEMA)
+    expect(wrapper.text()).toContain(MTS_CONTRACT_VERSION)
+    expect(wrapper.text()).toContain('[] = ◁')
+    expect(wrapper.text()).toContain('current: ◁=10 · ▷=12')
+    expect(wrapper.text()).toContain('parent↑1: ◁=20 · ▷=22')
+    expect(wrapper.text()).toContain('[] @ 0 → LinkRef 10')
+  })
+
+  it('shows a replay rejection separately from validation errors', () => {
+    const wrapper = mount(ProofReplayPanel, { props: { modelValue: artifact(12) } })
+
+    expect(wrapper.text()).toContain('REPLAY REJECTED')
+    expect(wrapper.text()).not.toContain('Validation error')
+  })
+
+  it('shows validator errors for malformed/untrusted artifacts', () => {
+    const wrapper = mount(ProofReplayPanel, {
+      props: {
+        modelValue: '{"schema":"wrong","contractVersion":"mts-contract/v0.2","steps":[]}',
+      },
+    })
+
+    expect(wrapper.text()).toContain('Validation error')
+    expect(wrapper.text()).toContain('$.schema')
+    expect(wrapper.text()).not.toContain('REPLAY REJECTED')
+  })
+
+  it('emits proof JSON edits without interpreting them in the component', async () => {
+    const wrapper = mount(ProofReplayPanel, { props: { modelValue: '' } })
+    await wrapper.get('textarea').setValue('{"schema":"mts-proof/v0.2"}')
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['{"schema":"mts-proof/v0.2"}'])
+  })
+
+  it('emits close from the presentation control', async () => {
+    const wrapper = mount(ProofReplayPanel, { props: { modelValue: '' } })
+    await wrapper.get('[aria-label="Close proof replay"]').trigger('click')
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+})

--- a/tests/unit/proofArtifactPresentation.test.ts
+++ b/tests/unit/proofArtifactPresentation.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import { presentProofArtifactJson } from '../../src/core/proofArtifactPresentation'
+import { MTS_CONTRACT_VERSION, MTS_PROOF_SCHEMA } from '../../src/core/proofReplay'
+
+function artifact(link = 10) {
+  return JSON.stringify({
+    schema: MTS_PROOF_SCHEMA,
+    contractVersion: MTS_CONTRACT_VERSION,
+    steps: [
+      {
+        rule: 'interpret',
+        expression: '[] = ◁',
+        context: { start: 10, end: 12, parent: { start: 20, end: 22 } },
+        symbols: { x: 30 },
+        distinguishedMemory: [{ id: 30, start: 2, end: 3 }],
+        expected: {
+          success: true,
+          substitutions: [{ path: [0], link }],
+          aliases: [],
+        },
+      },
+    ],
+  })
+}
+
+describe('proof artifact presentation', () => {
+  it('keeps an empty source distinct from invalid proof data', () => {
+    expect(presentProofArtifactJson('')).toEqual({ status: 'empty' })
+  })
+
+  it('presents a validated and independently accepted proof', () => {
+    const view = presentProofArtifactJson(artifact())
+    expect(view.status).toBe('accepted')
+    if (view.status !== 'accepted') throw new Error('expected accepted proof')
+
+    expect(view.schema).toBe(MTS_PROOF_SCHEMA)
+    expect(view.contractVersion).toBe(MTS_CONTRACT_VERSION)
+    expect(view.steps).toHaveLength(1)
+    expect(view.steps[0]).toMatchObject({
+      index: 1,
+      rule: 'interpret',
+      expression: '[] = ◁',
+      accepted: true,
+      context: [
+        { depth: 0, start: 10, end: 12 },
+        { depth: 1, start: 20, end: 22 },
+      ],
+      substitutions: [{ occurrence: '0', link: 10 }],
+      aliases: [],
+      symbolCount: 1,
+      distinguishedLinkCount: 1,
+    })
+  })
+
+  it('distinguishes a structurally valid forged proof from validation failure', () => {
+    const view = presentProofArtifactJson(artifact(12))
+    expect(view.status).toBe('rejected')
+    if (view.status !== 'rejected') throw new Error('expected replay rejection')
+    expect(view.accepted).toBe(false)
+    expect(view.steps[0].accepted).toBe(false)
+  })
+
+  it('presents validator errors without treating them as failed proofs', () => {
+    const view = presentProofArtifactJson('{"schema":"wrong","contractVersion":"mts-contract/v0.2","steps":[]}')
+    expect(view.status).toBe('invalid')
+    if (view.status !== 'invalid') throw new Error('expected validation failure')
+    expect(view.errorPath).toBe('$.schema')
+    expect(view.error).toContain('mts-proof/v0.2')
+  })
+})


### PR DESCRIPTION
Refs #121, #107.

Phase F application consumer поверх уже смерженного trusted replay boundary.

- добавлен pure `proofArtifactPresentation.ts`: `untrusted JSON -> parseProofJson -> checkProof/checkInterpretProofStep -> immutable view model`;
- validation error отделён от structurally valid, но forged/rejected proof;
- добавлен `ProofReplayPanel.vue` с отдельным proof JSON workflow и file input;
- UI показывает schema/contract provenance, ordered steps, expression, recursive context, expected substitutions/aliases и per-step replay verdict;
- `App.vue` только хранит JSON text/toggle и рендерит panel; обычный `.mtl/.astr/.anum` editor path не смешивается с proof artifact;
- presentation layer не вводит inference rules и не строит memory/context;
- public core API экспортирует presentation model;
- unit/component/E2E tests покрывают accepted/rejected/invalid artifacts.

Trusted rule set остаётся только `interpret`. Proof search и генерация proof objects не входят в PR.

Merge только после полного зелёного CI и `behind_by=0`.