### PR TITLE
Добавить untrusted interpret-proof search с independent replay

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -126,6 +126,16 @@ export {
   checkProof,
 } from './proofReplay'
 
+// Untrusted proof construction. Its output becomes trusted only after checkProof().
+export type {
+  InterpretProofSearchInput,
+  ProvenSearchResult,
+  NotProvenSearchResult,
+  ProofSearchErrorResult,
+  InterpretProofSearchResult,
+} from './proofSearch'
+export { searchInterpretProof } from './proofSearch'
+
 export type {
   ProofContextView,
   ProofSubstitutionView,

--- a/src/core/proofSearch.ts
+++ b/src/core/proofSearch.ts
@@ -1,0 +1,143 @@
+import type { ContextFrame, InterpretationAlias, InterpretationSubstitution, LinkRef } from './interpreter'
+import { InterpretationSession } from './interpretationSession'
+import type { DistinguishedLink } from './memoryView'
+import { parseExpr } from './parser'
+import {
+  MTS_CONTRACT_VERSION,
+  MTS_PROOF_SCHEMA,
+  MTS_TRUSTED_PROOF_RULE,
+  type InterpretProofStep,
+  type MtsProofObjectV02,
+} from './proofReplay'
+import { toMtsSource } from './mtsSource'
+
+export interface InterpretProofSearchInput {
+  readonly expression: string
+  readonly context: ContextFrame
+  readonly symbols?: Readonly<Record<string, LinkRef>>
+  readonly distinguishedMemory?: readonly DistinguishedLink[]
+}
+
+export interface ProvenSearchResult {
+  readonly status: 'proven'
+  readonly proof: MtsProofObjectV02
+}
+
+export interface NotProvenSearchResult {
+  readonly status: 'not-proven'
+  readonly reason: 'not-matched'
+}
+
+export interface ProofSearchErrorResult {
+  readonly status: 'error'
+  readonly stage: 'parse' | 'interpret'
+  readonly message: string
+}
+
+export type InterpretProofSearchResult =
+  | ProvenSearchResult
+  | NotProvenSearchResult
+  | ProofSearchErrorResult
+
+function cloneContext(frame: ContextFrame): ContextFrame {
+  return Object.freeze({
+    start: frame.start,
+    end: frame.end,
+    ...(frame.parent === undefined ? {} : { parent: cloneContext(frame.parent) }),
+  })
+}
+
+function cloneSymbols(
+  source: Readonly<Record<string, LinkRef>> | undefined
+): Readonly<Record<string, LinkRef>> | undefined {
+  return source === undefined ? undefined : Object.freeze({ ...source })
+}
+
+function cloneMemory(
+  source: readonly DistinguishedLink[] | undefined
+): readonly DistinguishedLink[] | undefined {
+  if (source === undefined) return undefined
+  return Object.freeze(
+    source.map(link => Object.freeze({ id: link.id, start: link.start, end: link.end }))
+  )
+}
+
+function cloneSubstitutions(
+  source: readonly InterpretationSubstitution[]
+): readonly InterpretationSubstitution[] {
+  return Object.freeze(
+    source.map(item => Object.freeze({ path: Object.freeze([...item.path]), link: item.link }))
+  )
+}
+
+function cloneAliases(source: readonly InterpretationAlias[]): readonly InterpretationAlias[] {
+  return Object.freeze(
+    source.map(item =>
+      Object.freeze({
+        path: Object.freeze([...item.path]),
+        targetPath: Object.freeze([...item.targetPath]),
+      })
+    )
+  )
+}
+
+function message(cause: unknown): string {
+  return cause instanceof Error ? cause.message : 'Unknown proof search error'
+}
+
+/**
+ * Untrusted single-step proof search for the current mts-proof/v0.2 contract.
+ *
+ * This function does not check its own output and does not define trusted
+ * semantics. It only asks the canonical interpreter for a successful match and
+ * packages that witness as an mts-proof/v0.2 artifact. Trust is established by
+ * independently replaying the returned artifact with checkProof().
+ */
+export function searchInterpretProof(input: InterpretProofSearchInput): InterpretProofSearchResult {
+  let expression
+  try {
+    expression = parseExpr(input.expression)
+  } catch (cause) {
+    return { status: 'error', stage: 'parse', message: message(cause) }
+  }
+
+  const context = cloneContext(input.context)
+  const symbols = cloneSymbols(input.symbols)
+  const distinguishedMemory = cloneMemory(input.distinguishedMemory)
+
+  try {
+    const session = new InterpretationSession({
+      context,
+      symbols,
+      links: distinguishedMemory ?? [],
+    })
+    const result = session.interpret(expression)
+
+    if (!result.success) {
+      return { status: 'not-proven', reason: 'not-matched' }
+    }
+
+    const step: InterpretProofStep = Object.freeze({
+      rule: MTS_TRUSTED_PROOF_RULE,
+      expression: toMtsSource(expression),
+      context,
+      ...(symbols === undefined ? {} : { symbols }),
+      ...(distinguishedMemory === undefined ? {} : { distinguishedMemory }),
+      expected: Object.freeze({
+        success: true,
+        substitutions: cloneSubstitutions(result.substitutions),
+        aliases: cloneAliases(result.aliases),
+      }),
+    })
+
+    const proof: MtsProofObjectV02 = Object.freeze({
+      schema: MTS_PROOF_SCHEMA,
+      contractVersion: MTS_CONTRACT_VERSION,
+      steps: Object.freeze([step]),
+    })
+
+    return { status: 'proven', proof }
+  } catch (cause) {
+    return { status: 'error', stage: 'interpret', message: message(cause) }
+  }
+}

--- a/src/core/proofSearch.ts
+++ b/src/core/proofSearch.ts
@@ -1,3 +1,4 @@
+import type { ASTNode } from './ast'
 import type { ContextFrame, InterpretationAlias, InterpretationSubstitution, LinkRef } from './interpreter'
 import { InterpretationSession } from './interpretationSession'
 import type { DistinguishedLink } from './memoryView'
@@ -94,7 +95,7 @@ function message(cause: unknown): string {
  * independently replaying the returned artifact with checkProof().
  */
 export function searchInterpretProof(input: InterpretProofSearchInput): InterpretProofSearchResult {
-  let expression
+  let expression: ASTNode
   try {
     expression = parseExpr(input.expression)
   } catch (cause) {

--- a/tests/unit/proofSearch.test.ts
+++ b/tests/unit/proofSearch.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import { checkProof, type MtsProofObjectV02 } from '../../src/core/proofReplay'
+import { searchInterpretProof } from '../../src/core/proofSearch'
+
+describe('untrusted interpret proof search', () => {
+  it('constructs a canonical proof witness that the independent checker accepts', () => {
+    const result = searchInterpretProof({
+      expression: '  []=◁  ',
+      context: { start: 10, end: 12 },
+    })
+
+    expect(result.status).toBe('proven')
+    if (result.status !== 'proven') throw new Error('expected a proof witness')
+
+    expect(result.proof.steps[0].expression).toBe('[] = ◁')
+    expect(result.proof.steps[0].expected).toEqual({
+      success: true,
+      substitutions: [{ path: [0], link: 10 }],
+      aliases: [],
+    })
+    expect(checkProof(result.proof)).toBe(true)
+  })
+
+  it('returns not-proven for a failed match instead of manufacturing a proof', () => {
+    const result = searchInterpretProof({
+      expression: '◁ = ▷',
+      context: { start: 10, end: 12 },
+    })
+
+    expect(result).toEqual({ status: 'not-proven', reason: 'not-matched' })
+  })
+
+  it('separates parse errors from interpretation errors', () => {
+    const parseFailure = searchInterpretProof({
+      expression: '↑ = []',
+      context: { start: 10, end: 12 },
+    })
+    expect(parseFailure.status).toBe('error')
+    if (parseFailure.status !== 'error') throw new Error('expected parse error')
+    expect(parseFailure.stage).toBe('parse')
+
+    const interpretationFailure = searchInterpretProof({
+      expression: 'x = ◁',
+      context: { start: 10, end: 12 },
+    })
+    expect(interpretationFailure.status).toBe('error')
+    if (interpretationFailure.status !== 'error') throw new Error('expected interpretation error')
+    expect(interpretationFailure.stage).toBe('interpret')
+    expect(interpretationFailure.message).toContain('not bound')
+  })
+
+  it('captures structural decomposition in a replayable proof object', () => {
+    const result = searchInterpretProof({
+      expression: '30 = [] ⟼ []',
+      context: { start: 10, end: 12 },
+      symbols: { '30': 30 },
+      distinguishedMemory: [{ id: 30, start: 2, end: 3 }],
+    })
+
+    expect(result.status).toBe('proven')
+    if (result.status !== 'proven') throw new Error('expected structural proof')
+    expect(result.proof.steps[0].expected.substitutions).toEqual([
+      { path: [1, 0], link: 2 },
+      { path: [1, 1], link: 3 },
+    ])
+    expect(checkProof(result.proof)).toBe(true)
+  })
+
+  it('snapshots caller-owned context, symbols and distinguished memory', () => {
+    const context = { start: 10, end: 12, parent: { start: 20, end: 22 } }
+    const symbols = { x: 30 }
+    const distinguishedMemory = [{ id: 30, start: 2, end: 3 }]
+
+    const result = searchInterpretProof({
+      expression: '[] = x',
+      context,
+      symbols,
+      distinguishedMemory,
+    })
+    expect(result.status).toBe('proven')
+    if (result.status !== 'proven') throw new Error('expected proof')
+
+    context.start = 999
+    context.parent.start = 999
+    symbols.x = 999
+    distinguishedMemory[0].start = 999
+
+    const step = result.proof.steps[0]
+    expect(step.context).toEqual({ start: 10, end: 12, parent: { start: 20, end: 22 } })
+    expect(step.symbols).toEqual({ x: 30 })
+    expect(step.distinguishedMemory).toEqual([{ id: 30, start: 2, end: 3 }])
+    expect(checkProof(result.proof)).toBe(true)
+  })
+
+  it('does not make search output trusted: a forged copy is rejected by replay', () => {
+    const result = searchInterpretProof({
+      expression: '[] = ◁',
+      context: { start: 10, end: 12 },
+    })
+    expect(result.status).toBe('proven')
+    if (result.status !== 'proven') throw new Error('expected proof')
+
+    const forged = JSON.parse(JSON.stringify(result.proof)) as MtsProofObjectV02
+    ;(forged.steps[0].expected.substitutions[0] as { path: number[]; link: number }).link = 12
+
+    expect(checkProof(forged)).toBe(false)
+  })
+})


### PR DESCRIPTION
Refs #123, #107.

Минимальный Phase F search vertical slice для текущего candidate `mts-proof/v0.2`.

- новый `proofSearch.ts` отделён от trusted `proofReplay.ts`;
- search использует canonical parser + `InterpretationSession` и не вызывает checker;
- proof object создаётся только для successful `interpret` match;
- failed match возвращает `not-proven`, parse/interpret errors различаются;
- expression canonicalized через единый `toMtsSource` formatter;
- ContextFrame/symbols/distinguished memory/substitutions/aliases копируются в immutable snapshot;
- rule берётся только из upstream constant `MTS_TRUSTED_PROOF_RULE = interpret`;
- tests независимо передают search-generated artifact в `checkProof`;
- mutation test показывает, что forged copy checker отвергает;
- public core API явно разделяет untrusted search и trusted replay.

Никаких новых inference rules, transitivity/congruence/MP, multi-step search или Vue generation UI.

Merge только после полного зелёного CI и `behind_by=0`.