### PR TITLE
Repin current anum_docs v0.2 contract bundle through recursive L3

### DIFF
--- a/contracts/anum_docs-v0.2/anum-boundary-projection-v0.2.json
+++ b/contracts/anum_docs-v0.2/anum-boundary-projection-v0.2.json
@@ -1,0 +1,50 @@
+{
+  "schema": "anum-boundary-projection/v0.2",
+  "status": "accepted-subset",
+  "dependsOn": "mts-contract/v0.2",
+  "context": "root",
+  "orientation": {
+    "open": "♀∞",
+    "close": "∞♂"
+  },
+  "projection": [
+    {
+      "raw": "[[",
+      "form": "♀∞ ⟼ ♀∞",
+      "kind": "boundary-form",
+      "protocolValue": null
+    },
+    {
+      "raw": "[]",
+      "form": "♀∞ ⟼ ∞♂",
+      "kind": "protocol-value",
+      "protocolValue": "1"
+    },
+    {
+      "raw": "][",
+      "form": "∞♂ ⟼ ♀∞",
+      "kind": "protocol-value",
+      "protocolValue": "0"
+    },
+    {
+      "raw": "]]",
+      "form": "∞♂ ⟼ ∞♂",
+      "kind": "boundary-form",
+      "protocolValue": null
+    }
+  ],
+  "scope": {
+    "absoluteRule": false,
+    "quoteContextApplies": false,
+    "relativeContextApplies": false,
+    "generalRawDenotationDefined": false
+  },
+  "derivation": [
+    "([) : (♀∞)",
+    "(]) : (∞♂)",
+    "(⟼) : (♀∞ ⟼ ∞♂)",
+    "(↛) : (∞♂ ⟼ ♀∞)",
+    "[1] : (⟼)",
+    "[0] : (↛)"
+  ]
+}

--- a/contracts/anum_docs-v0.2/anum-denotation-conformance-v0.2.json
+++ b/contracts/anum_docs-v0.2/anum-denotation-conformance-v0.2.json
@@ -69,7 +69,7 @@
         "kind": "quoted-raw",
         "raw": "[01]"
       },
-      "canonicalJson": "{\"kind\":\"quoted-raw\",\"raw\":\"[01]"}
+      "canonicalJson": "{\"kind\":\"quoted-raw\",\"raw\":\"[01]\"}"
     }
   ],
   "invalid": [

--- a/contracts/anum_docs-v0.2/anum-denotation-conformance-v0.2.json
+++ b/contracts/anum_docs-v0.2/anum-denotation-conformance-v0.2.json
@@ -1,0 +1,93 @@
+{
+  "schema": "anum-denotation-conformance/v0.2",
+  "contract": "anum-denotation/v0.2",
+  "status": "accepted",
+  "cases": [
+    {
+      "name": "anchor-only",
+      "value": {
+        "kind": "structural",
+        "anchors": ["one"],
+        "nodes": [],
+        "root": {"anchor": "one"}
+      },
+      "canonicalJson": "{\"anchors\":[\"one\"],\"kind\":\"structural\",\"nodes\":[],\"root\":{\"anchor\":\"one\"}}"
+    },
+    {
+      "name": "nested-link",
+      "value": {
+        "kind": "structural",
+        "anchors": ["left", "right"],
+        "nodes": [
+          {
+            "id": 0,
+            "start": {"anchor": "left"},
+            "end": {"anchor": "right"}
+          },
+          {
+            "id": 1,
+            "start": {"node": 0},
+            "end": {"anchor": "left"}
+          }
+        ],
+        "root": {"node": 1}
+      },
+      "canonicalJson": "{\"anchors\":[\"left\",\"right\"],\"kind\":\"structural\",\"nodes\":[{\"end\":{\"anchor\":\"right\"},\"id\":0,\"start\":{\"anchor\":\"left\"}},{\"end\":{\"anchor\":\"left\"},\"id\":1,\"start\":{\"node\":0}}],\"root\":{\"node\":1}}"
+    },
+    {
+      "name": "shared-substructure",
+      "value": {
+        "kind": "structural",
+        "anchors": ["a", "b"],
+        "nodes": [
+          {
+            "id": 0,
+            "start": {"anchor": "a"},
+            "end": {"anchor": "b"}
+          },
+          {
+            "id": 1,
+            "start": {"node": 0},
+            "end": {"node": 0}
+          }
+        ],
+        "root": {"node": 1}
+      },
+      "canonicalJson": "{\"anchors\":[\"a\",\"b\"],\"kind\":\"structural\",\"nodes\":[{\"end\":{\"anchor\":\"b\"},\"id\":0,\"start\":{\"anchor\":\"a\"}},{\"end\":{\"node\":0},\"id\":1,\"start\":{\"node\":0}}],\"root\":{\"node\":1}}"
+    },
+    {
+      "name": "unresolved-raw",
+      "value": {
+        "kind": "raw",
+        "raw": "[[01"
+      },
+      "canonicalJson": "{\"kind\":\"raw\",\"raw\":\"[[01\"}"
+    },
+    {
+      "name": "quoted-raw",
+      "value": {
+        "kind": "quoted-raw",
+        "raw": "[01]"
+      },
+      "canonicalJson": "{\"kind\":\"quoted-raw\",\"raw\":\"[01]"}
+    }
+  ],
+  "invalid": [
+    {
+      "name": "missing-anchor",
+      "reason": "every anchor reference must name a declared anchor"
+    },
+    {
+      "name": "forward-node-reference",
+      "reason": "node references may target only earlier nodes"
+    },
+    {
+      "name": "duplicate-node-id",
+      "reason": "node ids are contiguous and unique by construction"
+    },
+    {
+      "name": "mixed-ref-shape",
+      "reason": "a reference contains exactly one of anchor or node"
+    }
+  ]
+}

--- a/contracts/anum_docs-v0.2/anum-denotation-v0.2.json
+++ b/contracts/anum_docs-v0.2/anum-denotation-v0.2.json
@@ -1,0 +1,62 @@
+{
+  "schema": "anum-denotation/v0.2",
+  "status": "accepted",
+  "dependsOn": [
+    "mts-contract/v0.2",
+    "anum-boundary-projection/v0.2"
+  ],
+  "conformanceCorpus": "contracts/anum-denotation-conformance-v0.2.json",
+  "purpose": "storage-neutral L3-to-L4 structural denotation handoff",
+  "resultKinds": [
+    "structural",
+    "raw",
+    "quoted-raw"
+  ],
+  "referenceKinds": [
+    "anchor",
+    "node"
+  ],
+  "structural": {
+    "anchors": "sorted unique non-empty opaque string keys",
+    "nodes": "ordered nodes with contiguous ids 0..N-1",
+    "node": {
+      "id": "description-local integer",
+      "start": "DenotationRef",
+      "end": "DenotationRef"
+    },
+    "root": "DenotationRef",
+    "topology": "a node reference may target only an earlier node",
+    "sharing": "reusing one earlier node reference preserves explicit sharing"
+  },
+  "identity": {
+    "displayLabelIsIdentity": false,
+    "rawSpellingIsRuntimeIdentity": false,
+    "nodeIdentity": "description-local node id",
+    "anchorIdentity": "opaque external context key resolved only by L4 adapter",
+    "persistentLinkIdAllowed": false
+  },
+  "nonDenoting": {
+    "raw": "canonical or source raw payload retained without structural claim",
+    "quoted-raw": "description-level payload retained without structural claim"
+  },
+  "effects": {
+    "mayReadMemory": false,
+    "mayMutateMemory": false,
+    "mayRealize": false
+  },
+  "canonicalJson": {
+    "utf8": true,
+    "sortObjectKeys": true,
+    "compactSeparators": true,
+    "anchorsSorted": true,
+    "nodesInIdOrder": true
+  },
+  "explicitlyOutOfScope": [
+    "raw parser",
+    "recursive Anum decode grammar",
+    "persistent LinkId allocation",
+    "find",
+    "realize",
+    "delete"
+  ]
+}

--- a/contracts/anum_docs-v0.2/anum-pair-denotation-conformance-v0.2.json
+++ b/contracts/anum_docs-v0.2/anum-pair-denotation-conformance-v0.2.json
@@ -2,154 +2,21 @@
   "schema": "anum-pair-denotation-conformance/v0.2",
   "contract": "anum-pair-denotation/v0.2",
   "status": "accepted",
-  "positive": [
-    {
-      "name": "atom-zero",
-      "context": "root",
-      "raw": "0",
-      "denotation": {
-        "kind": "structural",
-        "anchors": ["protocol:0"],
-        "nodes": [],
-        "root": {"anchor": "protocol:0"}
-      },
-      "canonicalRaw": "0"
-    },
-    {
-      "name": "atom-one",
-      "context": "root",
-      "raw": "1",
-      "denotation": {
-        "kind": "structural",
-        "anchors": ["protocol:1"],
-        "nodes": [],
-        "root": {"anchor": "protocol:1"}
-      },
-      "canonicalRaw": "1"
-    },
-    {
-      "name": "pair-00",
-      "context": "root",
-      "raw": "00",
-      "denotation": {
-        "kind": "structural",
-        "anchors": ["protocol:0"],
-        "nodes": [
-          {
-            "id": 0,
-            "start": {"anchor": "protocol:0"},
-            "end": {"anchor": "protocol:0"}
-          }
-        ],
-        "root": {"node": 0}
-      },
-      "canonicalRaw": "00"
-    },
-    {
-      "name": "pair-01",
-      "context": "root",
-      "raw": "01",
-      "denotation": {
-        "kind": "structural",
-        "anchors": ["protocol:0", "protocol:1"],
-        "nodes": [
-          {
-            "id": 0,
-            "start": {"anchor": "protocol:0"},
-            "end": {"anchor": "protocol:1"}
-          }
-        ],
-        "root": {"node": 0}
-      },
-      "canonicalRaw": "01"
-    },
-    {
-      "name": "pair-10",
-      "context": "root",
-      "raw": "10",
-      "denotation": {
-        "kind": "structural",
-        "anchors": ["protocol:0", "protocol:1"],
-        "nodes": [
-          {
-            "id": 0,
-            "start": {"anchor": "protocol:1"},
-            "end": {"anchor": "protocol:0"}
-          }
-        ],
-        "root": {"node": 0}
-      },
-      "canonicalRaw": "10"
-    },
-    {
-      "name": "pair-11",
-      "context": "root",
-      "raw": "11",
-      "denotation": {
-        "kind": "structural",
-        "anchors": ["protocol:1"],
-        "nodes": [
-          {
-            "id": 0,
-            "start": {"anchor": "protocol:1"},
-            "end": {"anchor": "protocol:1"}
-          }
-        ],
-        "root": {"node": 0}
-      },
-      "canonicalRaw": "11"
-    }
-  ],
-  "aliases": [
-    {
-      "raw": "][",
-      "sameDenotationAs": "0",
-      "canonicalRaw": "0"
-    },
-    {
-      "raw": "[]",
-      "sameDenotationAs": "1",
-      "canonicalRaw": "1"
-    }
-  ],
-  "nonDenoting": [
-    {
-      "name": "open-open-root",
-      "context": "root",
-      "raw": "[[",
-      "kind": "raw"
-    },
-    {
-      "name": "close-close-root",
-      "context": "root",
-      "raw": "]]",
-      "kind": "raw"
-    },
-    {
-      "name": "longer-direct-sequence",
-      "context": "root",
-      "raw": "010",
-      "kind": "raw"
-    },
-    {
-      "name": "quote-one-level",
-      "context": "quote",
-      "raw": "[01]",
-      "kind": "quoted-raw",
-      "payload": "01"
-    },
-    {
-      "name": "quote-two-levels",
-      "context": "quote",
-      "raw": "[[01]]",
-      "kind": "quoted-raw",
-      "payload": "[01]"
-    },
-    {
-      "name": "relative-pair",
-      "context": "relative",
-      "raw": "01",
-      "kind": "raw"
-    }
+  "cases": [
+    {"name":"zero","raw":"0","context":"root","expected":{"kind":"structural","anchors":["protocol:0"],"nodes":[],"root":{"anchor":"protocol:0"}},"canonicalRaw":"0"},
+    {"name":"one","raw":"1","context":"root","expected":{"kind":"structural","anchors":["protocol:1"],"nodes":[],"root":{"anchor":"protocol:1"}},"canonicalRaw":"1"},
+    {"name":"root-link-alias","raw":"[]","context":"root","expected":{"kind":"structural","anchors":["protocol:1"],"nodes":[],"root":{"anchor":"protocol:1"}},"canonicalRaw":"1"},
+    {"name":"root-unlink-alias","raw":"][","context":"root","expected":{"kind":"structural","anchors":["protocol:0"],"nodes":[],"root":{"anchor":"protocol:0"}},"canonicalRaw":"0"},
+    {"name":"pair-00","raw":"00","context":"root","expected":{"kind":"structural","anchors":["protocol:0"],"nodes":[{"id":0,"start":{"anchor":"protocol:0"},"end":{"anchor":"protocol:0"}}],"root":{"node":0}},"canonicalRaw":"00"},
+    {"name":"pair-01","raw":"01","context":"root","expected":{"kind":"structural","anchors":["protocol:0","protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:0"},"end":{"anchor":"protocol:1"}}],"root":{"node":0}},"canonicalRaw":"01"},
+    {"name":"pair-10","raw":"10","context":"root","expected":{"kind":"structural","anchors":["protocol:0","protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:1"},"end":{"anchor":"protocol:0"}}],"root":{"node":0}},"canonicalRaw":"10"},
+    {"name":"pair-11","raw":"11","context":"root","expected":{"kind":"structural","anchors":["protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:1"},"end":{"anchor":"protocol:1"}}],"root":{"node":0}},"canonicalRaw":"11"},
+    {"name":"open-open-raw","raw":"[[","context":"root","expected":{"kind":"raw","raw":"[["},"canonicalRaw":null},
+    {"name":"close-close-raw","raw":"]]","context":"root","expected":{"kind":"raw","raw":"]]"},"canonicalRaw":null},
+    {"name":"long-sequence-raw","raw":"010","context":"root","expected":{"kind":"raw","raw":"010"},"canonicalRaw":null},
+    {"name":"bracket-composition-raw","raw":"[0]","context":"root","expected":{"kind":"raw","raw":"[0]"},"canonicalRaw":null},
+    {"name":"quote-envelope","raw":"[01]","context":"quote","expected":{"kind":"quoted-raw","raw":"01"},"canonicalRaw":null},
+    {"name":"quote-unwrapped","raw":"01","context":"quote","expected":{"kind":"quoted-raw","raw":"01"},"canonicalRaw":null},
+    {"name":"relative-pair","raw":"01","context":"relative","expected":{"kind":"raw","raw":"01"},"canonicalRaw":null}
   ]
 }

--- a/contracts/anum_docs-v0.2/anum-pair-denotation-conformance-v0.2.json
+++ b/contracts/anum_docs-v0.2/anum-pair-denotation-conformance-v0.2.json
@@ -1,0 +1,155 @@
+{
+  "schema": "anum-pair-denotation-conformance/v0.2",
+  "contract": "anum-pair-denotation/v0.2",
+  "status": "accepted",
+  "positive": [
+    {
+      "name": "atom-zero",
+      "context": "root",
+      "raw": "0",
+      "denotation": {
+        "kind": "structural",
+        "anchors": ["protocol:0"],
+        "nodes": [],
+        "root": {"anchor": "protocol:0"}
+      },
+      "canonicalRaw": "0"
+    },
+    {
+      "name": "atom-one",
+      "context": "root",
+      "raw": "1",
+      "denotation": {
+        "kind": "structural",
+        "anchors": ["protocol:1"],
+        "nodes": [],
+        "root": {"anchor": "protocol:1"}
+      },
+      "canonicalRaw": "1"
+    },
+    {
+      "name": "pair-00",
+      "context": "root",
+      "raw": "00",
+      "denotation": {
+        "kind": "structural",
+        "anchors": ["protocol:0"],
+        "nodes": [
+          {
+            "id": 0,
+            "start": {"anchor": "protocol:0"},
+            "end": {"anchor": "protocol:0"}
+          }
+        ],
+        "root": {"node": 0}
+      },
+      "canonicalRaw": "00"
+    },
+    {
+      "name": "pair-01",
+      "context": "root",
+      "raw": "01",
+      "denotation": {
+        "kind": "structural",
+        "anchors": ["protocol:0", "protocol:1"],
+        "nodes": [
+          {
+            "id": 0,
+            "start": {"anchor": "protocol:0"},
+            "end": {"anchor": "protocol:1"}
+          }
+        ],
+        "root": {"node": 0}
+      },
+      "canonicalRaw": "01"
+    },
+    {
+      "name": "pair-10",
+      "context": "root",
+      "raw": "10",
+      "denotation": {
+        "kind": "structural",
+        "anchors": ["protocol:0", "protocol:1"],
+        "nodes": [
+          {
+            "id": 0,
+            "start": {"anchor": "protocol:1"},
+            "end": {"anchor": "protocol:0"}
+          }
+        ],
+        "root": {"node": 0}
+      },
+      "canonicalRaw": "10"
+    },
+    {
+      "name": "pair-11",
+      "context": "root",
+      "raw": "11",
+      "denotation": {
+        "kind": "structural",
+        "anchors": ["protocol:1"],
+        "nodes": [
+          {
+            "id": 0,
+            "start": {"anchor": "protocol:1"},
+            "end": {"anchor": "protocol:1"}
+          }
+        ],
+        "root": {"node": 0}
+      },
+      "canonicalRaw": "11"
+    }
+  ],
+  "aliases": [
+    {
+      "raw": "][",
+      "sameDenotationAs": "0",
+      "canonicalRaw": "0"
+    },
+    {
+      "raw": "[]",
+      "sameDenotationAs": "1",
+      "canonicalRaw": "1"
+    }
+  ],
+  "nonDenoting": [
+    {
+      "name": "open-open-root",
+      "context": "root",
+      "raw": "[[",
+      "kind": "raw"
+    },
+    {
+      "name": "close-close-root",
+      "context": "root",
+      "raw": "]]",
+      "kind": "raw"
+    },
+    {
+      "name": "longer-direct-sequence",
+      "context": "root",
+      "raw": "010",
+      "kind": "raw"
+    },
+    {
+      "name": "quote-one-level",
+      "context": "quote",
+      "raw": "[01]",
+      "kind": "quoted-raw",
+      "payload": "01"
+    },
+    {
+      "name": "quote-two-levels",
+      "context": "quote",
+      "raw": "[[01]]",
+      "kind": "quoted-raw",
+      "payload": "[01]"
+    },
+    {
+      "name": "relative-pair",
+      "context": "relative",
+      "raw": "01",
+      "kind": "raw"
+    }
+  ]
+}

--- a/contracts/anum_docs-v0.2/anum-pair-denotation-v0.2.json
+++ b/contracts/anum_docs-v0.2/anum-pair-denotation-v0.2.json
@@ -1,0 +1,50 @@
+{
+  "schema": "anum-pair-denotation/v0.2",
+  "status": "accepted",
+  "dependsOn": [
+    "anum-boundary-projection/v0.2",
+    "anum-denotation/v0.2"
+  ],
+  "conformanceCorpus": "contracts/anum-pair-denotation-conformance-v0.2.json",
+  "context": "root",
+  "anchors": {
+    "0": "protocol:0",
+    "1": "protocol:1"
+  },
+  "acceptedStructuralRaw": [
+    "0",
+    "1",
+    "00",
+    "01",
+    "10",
+    "11"
+  ],
+  "acceptedRootAliases": {
+    "][": "0",
+    "[]": "1"
+  },
+  "pairRule": "for exactly two direct protocol atoms ab, create one Link node from anchor(a) to anchor(b)",
+  "canonicalInverse": {
+    "anchor:protocol:0": "0",
+    "anchor:protocol:1": "1",
+    "singleNodePair": "concatenate pole atoms in start/end order",
+    "aliasesCanonicalize": true
+  },
+  "nonDenoting": {
+    "root": "any other raw carrier remains typed raw",
+    "quote": "quote projection remains typed quoted-raw",
+    "relative": "relative context remains typed raw",
+    "openOpen": "[[ remains non-denoting boundary form",
+    "closeClose": "]] remains non-denoting boundary form"
+  },
+  "effects": {
+    "mayReadMemory": false,
+    "mayMutateMemory": false,
+    "mayRealize": false,
+    "persistentLinkIdAllowed": false
+  },
+  "deferred": {
+    "recursiveBracketGrammarIssue": 95,
+    "generalDenotationIssue": 89
+  }
+}

--- a/contracts/anum_docs-v0.2/anum-pair-denotation-v0.2.json
+++ b/contracts/anum_docs-v0.2/anum-pair-denotation-v0.2.json
@@ -2,49 +2,48 @@
   "schema": "anum-pair-denotation/v0.2",
   "status": "accepted",
   "dependsOn": [
+    "mts-contract/v0.2",
     "anum-boundary-projection/v0.2",
     "anum-denotation/v0.2"
   ],
   "conformanceCorpus": "contracts/anum-pair-denotation-conformance-v0.2.json",
   "context": "root",
-  "anchors": {
+  "protocolAnchors": {
     "0": "protocol:0",
     "1": "protocol:1"
   },
-  "acceptedStructuralRaw": [
-    "0",
-    "1",
-    "00",
-    "01",
-    "10",
-    "11"
+  "rules": [
+    "root protocol value 0 denotes anchor protocol:0",
+    "root protocol value 1 denotes anchor protocol:1",
+    "exactly two direct protocol atoms ab denote one ordered Link(a,b)",
+    "root boundary aliases use their accepted projected protocol value",
+    "all other root carriers remain outside this minimal pair subset"
   ],
-  "acceptedRootAliases": {
-    "][": "0",
-    "[]": "1"
-  },
-  "pairRule": "for exactly two direct protocol atoms ab, create one Link node from anchor(a) to anchor(b)",
   "canonicalInverse": {
-    "anchor:protocol:0": "0",
-    "anchor:protocol:1": "1",
-    "singleNodePair": "concatenate pole atoms in start/end order",
-    "aliasesCanonicalize": true
+    "protocol:0": "0",
+    "protocol:1": "1",
+    "singlePair": "concatenate canonical start and end protocol atoms",
+    "sourcePreserving": false,
+    "aliases": {
+      "][": "0",
+      "[]": "1"
+    }
   },
-  "nonDenoting": {
-    "root": "any other raw carrier remains typed raw",
-    "quote": "quote projection remains typed quoted-raw",
-    "relative": "relative context remains typed raw",
-    "openOpen": "[[ remains non-denoting boundary form",
-    "closeClose": "]] remains non-denoting boundary form"
+  "outsideThisSubset": {
+    "recursiveBrackets": "contracts/anum-recursive-denotation-v0.2.json",
+    "relativeDenotation": true,
+    "openOpenBoundaryDenotation": true,
+    "closeCloseBoundaryDenotation": true,
+    "longerUnstructuredDirectSequences": true
   },
   "effects": {
     "mayReadMemory": false,
     "mayMutateMemory": false,
-    "mayRealize": false,
-    "persistentLinkIdAllowed": false
+    "mayRealize": false
   },
-  "deferred": {
-    "recursiveBracketGrammarIssue": 95,
-    "generalDenotationIssue": 89
+  "evidence": {
+    "readOnlyResearch": "docs/research/Исходные мысли МТС.md",
+    "sequenceRule": "an achislo implicitly starts at ∞; deserializing ∞ab produces a⟼b while the loaded sequence itself does not contain a⟼b",
+    "scopeDecision": "apply that rule here only where both a and b are accepted direct protocol atoms 0/1; recursive composition is owned by the recursive-denotation contract"
   }
 }

--- a/contracts/anum_docs-v0.2/anum-raw-carrier-conformance-v0.2.json
+++ b/contracts/anum_docs-v0.2/anum-raw-carrier-conformance-v0.2.json
@@ -1,0 +1,61 @@
+{
+  "schema": "anum-raw-carrier-conformance/v0.2",
+  "contract": "anum-raw-carrier/v0.2",
+  "status": "accepted",
+  "cases": [
+    {
+      "name": "empty",
+      "raw": "",
+      "expected": {"kind":"raw-carrier","raw":"","nodes":[],"root":{"role":"root"}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[],\"raw\":\"\",\"root\":{\"role\":\"root\"}}"
+    },
+    {
+      "name": "zero",
+      "raw": "0",
+      "expected": {"kind":"raw-carrier","raw":"0","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:0"}}],"root":{"node":0}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:0\"},\"id\":0,\"start\":{\"role\":\"root\"}}],\"raw\":\"0\",\"root\":{\"node\":0}}"
+    },
+    {
+      "name": "one",
+      "raw": "1",
+      "expected": {"kind":"raw-carrier","raw":"1","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:1"}}],"root":{"node":0}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:1\"},\"id\":0,\"start\":{\"role\":\"root\"}}],\"raw\":\"1\",\"root\":{\"node\":0}}"
+    },
+    {
+      "name": "pair-01",
+      "raw": "01",
+      "expected": {"kind":"raw-carrier","raw":"01","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:0"}},{"id":1,"start":{"node":0},"end":{"role":"abit:1"}}],"root":{"node":1}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:0\"},\"id\":0,\"start\":{\"role\":\"root\"}},{\"end\":{\"role\":\"abit:1\"},\"id\":1,\"start\":{\"node\":0}}],\"raw\":\"01\",\"root\":{\"node\":1}}"
+    },
+    {
+      "name": "pair-10",
+      "raw": "10",
+      "expected": {"kind":"raw-carrier","raw":"10","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:1"}},{"id":1,"start":{"node":0},"end":{"role":"abit:0"}}],"root":{"node":1}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:1\"},\"id\":0,\"start\":{\"role\":\"root\"}},{\"end\":{\"role\":\"abit:0\"},\"id\":1,\"start\":{\"node\":0}}],\"raw\":\"10\",\"root\":{\"node\":1}}"
+    },
+    {
+      "name": "boundary-link-spelling",
+      "raw": "[]",
+      "expected": {"kind":"raw-carrier","raw":"[]","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:["}},{"id":1,"start":{"node":0},"end":{"role":"abit:]"}}],"root":{"node":1}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:[\"},\"id\":0,\"start\":{\"role\":\"root\"}},{\"end\":{\"role\":\"abit:]\"},\"id\":1,\"start\":{\"node\":0}}],\"raw\":\"[]\",\"root\":{\"node\":1}}"
+    },
+    {
+      "name": "boundary-unlink-spelling",
+      "raw": "][",
+      "expected": {"kind":"raw-carrier","raw":"][","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:]"}},{"id":1,"start":{"node":0},"end":{"role":"abit:["}}],"root":{"node":1}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:]\"},\"id\":0,\"start\":{\"role\":\"root\"}},{\"end\":{\"role\":\"abit:[\"},\"id\":1,\"start\":{\"node\":0}}],\"raw\":\"][\",\"root\":{\"node\":1}}"
+    },
+    {
+      "name": "quoted-looking-raw",
+      "raw": "[01]",
+      "expected": {"kind":"raw-carrier","raw":"[01]","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:["}},{"id":1,"start":{"node":0},"end":{"role":"abit:0"}},{"id":2,"start":{"node":1},"end":{"role":"abit:1"}},{"id":3,"start":{"node":2},"end":{"role":"abit:]"}}],"root":{"node":3}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:[\"},\"id\":0,\"start\":{\"role\":\"root\"}},{\"end\":{\"role\":\"abit:0\"},\"id\":1,\"start\":{\"node\":0}},{\"end\":{\"role\":\"abit:1\"},\"id\":2,\"start\":{\"node\":1}},{\"end\":{\"role\":\"abit:]\"},\"id\":3,\"start\":{\"node\":2}}],\"raw\":\"[01]\",\"root\":{\"node\":3}}"
+    },
+    {
+      "name": "long-repeated-sequence",
+      "raw": "00110",
+      "expected": {"kind":"raw-carrier","raw":"00110","nodes":[{"id":0,"start":{"role":"root"},"end":{"role":"abit:0"}},{"id":1,"start":{"node":0},"end":{"role":"abit:0"}},{"id":2,"start":{"node":1},"end":{"role":"abit:1"}},{"id":3,"start":{"node":2},"end":{"role":"abit:1"}},{"id":4,"start":{"node":3},"end":{"role":"abit:0"}}],"root":{"node":4}},
+      "canonicalJson": "{\"kind\":\"raw-carrier\",\"nodes\":[{\"end\":{\"role\":\"abit:0\"},\"id\":0,\"start\":{\"role\":\"root\"}},{\"end\":{\"role\":\"abit:0\"},\"id\":1,\"start\":{\"node\":0}},{\"end\":{\"role\":\"abit:1\"},\"id\":2,\"start\":{\"node\":1}},{\"end\":{\"role\":\"abit:1\"},\"id\":3,\"start\":{\"node\":2}},{\"end\":{\"role\":\"abit:0\"},\"id\":4,\"start\":{\"node\":3}}],\"raw\":\"00110\",\"root\":{\"node\":4}}"
+    }
+  ]
+}

--- a/contracts/anum_docs-v0.2/anum-raw-carrier-v0.2.json
+++ b/contracts/anum_docs-v0.2/anum-raw-carrier-v0.2.json
@@ -1,0 +1,54 @@
+{
+  "schema": "anum-raw-carrier/v0.2",
+  "status": "accepted",
+  "dependsOn": [
+    "mts-contract/v0.2"
+  ],
+  "conformanceCorpus": "contracts/anum-raw-carrier-conformance-v0.2.json",
+  "purpose": "storage-neutral structural description of raw Anum transport carrier",
+  "roles": [
+    "root",
+    "abit:[",
+    "abit:]",
+    "abit:1",
+    "abit:0"
+  ],
+  "construction": {
+    "initial": "current = role:root",
+    "step": "for each raw abit x in order: node[i] = Link(current, role:abit:x); current = node[i]",
+    "root": "current after the final step, or role:root for the empty carrier"
+  },
+  "identity": {
+    "rolesAreProtocolPositionsNotGlobalObjects": true,
+    "displayLabelsAreIdentity": false,
+    "nodeIdentity": "description-local sequential position",
+    "persistentLinkIdAllowed": false,
+    "classicalGraphNodeIdentityClaimed": false
+  },
+  "separation": {
+    "rawAbitRoles": ["abit:[", "abit:]", "abit:1", "abit:0"],
+    "denotationProtocolAnchors": ["protocol:1", "protocol:0"],
+    "rawCarrierIsDenotation": false
+  },
+  "effects": {
+    "mayReadMemory": false,
+    "mayMutateMemory": false,
+    "mayRealize": false
+  },
+  "canonicalJson": {
+    "utf8": true,
+    "sortObjectKeys": true,
+    "compactSeparators": true,
+    "nodesInSequenceOrder": true
+  },
+  "explicitlyOutOfScope": [
+    "context projection",
+    "denotation",
+    "quote interpretation",
+    "recursive bracket interpretation",
+    "persistent identity",
+    "find",
+    "realize",
+    "delete"
+  ]
+}

--- a/contracts/anum_docs-v0.2/anum-recursive-denotation-conformance-v0.2.json
+++ b/contracts/anum_docs-v0.2/anum-recursive-denotation-conformance-v0.2.json
@@ -1,0 +1,135 @@
+{
+  "schema": "anum-recursive-denotation-conformance/v0.2",
+  "contract": "anum-recursive-denotation/v0.2",
+  "status": "accepted",
+  "cases": [
+    {
+      "name": "direct-pair",
+      "raw": "01",
+      "context": "root",
+      "expandedRaw": "01",
+      "expected": {"kind":"structural","anchors":["protocol:0","protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:0"},"end":{"anchor":"protocol:1"}}],"root":{"node":0}},
+      "canonicalRaw": "01"
+    },
+    {
+      "name": "nested-left",
+      "raw": "[01]1",
+      "context": "root",
+      "expandedRaw": "[01]1",
+      "expected": {"kind":"structural","anchors":["protocol:0","protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:0"},"end":{"anchor":"protocol:1"}},{"id":1,"start":{"node":0},"end":{"anchor":"protocol:1"}}],"root":{"node":1}},
+      "canonicalRaw": "[01]1"
+    },
+    {
+      "name": "nested-right",
+      "raw": "0[10]",
+      "context": "root",
+      "expandedRaw": "0[10]",
+      "expected": {"kind":"structural","anchors":["protocol:0","protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:1"},"end":{"anchor":"protocol:0"}},{"id":1,"start":{"anchor":"protocol:0"},"end":{"node":0}}],"root":{"node":1}},
+      "canonicalRaw": "0[10]"
+    },
+    {
+      "name": "nested-both",
+      "raw": "[01][10]",
+      "context": "root",
+      "expandedRaw": "[01][10]",
+      "expected": {"kind":"structural","anchors":["protocol:0","protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:0"},"end":{"anchor":"protocol:1"}},{"id":1,"start":{"anchor":"protocol:1"},"end":{"anchor":"protocol:0"}},{"id":2,"start":{"node":0},"end":{"node":1}}],"root":{"node":2}},
+      "canonicalRaw": "[01][10]"
+    },
+    {
+      "name": "deeper-left-root-open-collapse",
+      "raw": "[01]1]0",
+      "context": "root",
+      "expandedRaw": "[[01]1]0",
+      "expected": {"kind":"structural","anchors":["protocol:0","protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:0"},"end":{"anchor":"protocol:1"}},{"id":1,"start":{"node":0},"end":{"anchor":"protocol:1"}},{"id":2,"start":{"node":1},"end":{"anchor":"protocol:0"}}],"root":{"node":2}},
+      "canonicalRaw": "[01]1]0"
+    },
+    {
+      "name": "deeper-right",
+      "raw": "0[1[01]]",
+      "context": "root",
+      "expandedRaw": "0[1[01]]",
+      "expected": {"kind":"structural","anchors":["protocol:0","protocol:1"],"nodes":[{"id":0,"start":{"anchor":"protocol:0"},"end":{"anchor":"protocol:1"}},{"id":1,"start":{"anchor":"protocol:1"},"end":{"node":0}},{"id":2,"start":{"anchor":"protocol:0"},"end":{"node":1}}],"root":{"node":2}},
+      "canonicalRaw": "0[1[01]]"
+    },
+    {
+      "name": "root-link-boundary-precedence",
+      "raw": "[]",
+      "context": "root",
+      "expandedRaw": null,
+      "expected": {"kind":"structural","anchors":["protocol:1"],"nodes":[],"root":{"anchor":"protocol:1"}},
+      "canonicalRaw": "1"
+    },
+    {
+      "name": "root-unlink-boundary-precedence",
+      "raw": "][",
+      "context": "root",
+      "expandedRaw": null,
+      "expected": {"kind":"structural","anchors":["protocol:0"],"nodes":[],"root":{"anchor":"protocol:0"}},
+      "canonicalRaw": "0"
+    },
+    {
+      "name": "open-open-stays-raw",
+      "raw": "[[",
+      "context": "root",
+      "expandedRaw": null,
+      "expected": {"kind":"raw","raw":"[["},
+      "canonicalRaw": null
+    },
+    {
+      "name": "close-close-stays-raw",
+      "raw": "]]",
+      "context": "root",
+      "expandedRaw": null,
+      "expected": {"kind":"raw","raw":"]]"},
+      "canonicalRaw": null
+    },
+    {
+      "name": "noncanonical-uncollapsed-leading-opens",
+      "raw": "[[01]1]0",
+      "context": "root",
+      "expandedRaw": "[[01]1]0",
+      "expected": {"kind":"raw","raw":"[[01]1]0"},
+      "canonicalRaw": null
+    },
+    {
+      "name": "single-value-bracket-rejected",
+      "raw": "[0]1",
+      "context": "root",
+      "expandedRaw": "[0]1",
+      "expected": {"kind":"raw","raw":"[0]1"},
+      "canonicalRaw": null
+    },
+    {
+      "name": "extra-root-value-rejected",
+      "raw": "010",
+      "context": "root",
+      "expandedRaw": "010",
+      "expected": {"kind":"raw","raw":"010"},
+      "canonicalRaw": null
+    },
+    {
+      "name": "standalone-bracket-value-rejected",
+      "raw": "[01]",
+      "context": "root",
+      "expandedRaw": "[01]",
+      "expected": {"kind":"raw","raw":"[01]"},
+      "canonicalRaw": null
+    },
+    {
+      "name": "quote-context-does-not-run-recursive-grammar",
+      "raw": "[[01]1]",
+      "context": "quote",
+      "expandedRaw": null,
+      "expected": {"kind":"quoted-raw","raw":"[01]1"},
+      "canonicalRaw": null
+    },
+    {
+      "name": "relative-context-does-not-run-recursive-grammar",
+      "raw": "[01]1",
+      "context": "relative",
+      "expandedRaw": null,
+      "expected": {"kind":"raw","raw":"[01]1"},
+      "canonicalRaw": null
+    }
+  ]
+}

--- a/contracts/anum_docs-v0.2/anum-recursive-denotation-v0.2.json
+++ b/contracts/anum_docs-v0.2/anum-recursive-denotation-v0.2.json
@@ -1,0 +1,68 @@
+{
+  "schema": "anum-recursive-denotation/v0.2",
+  "status": "accepted",
+  "dependsOn": [
+    "mts-contract/v0.2",
+    "anum-raw-carrier/v0.2",
+    "anum-boundary-projection/v0.2",
+    "anum-denotation/v0.2",
+    "anum-pair-denotation/v0.2"
+  ],
+  "conformanceCorpus": "contracts/anum-recursive-denotation-conformance-v0.2.json",
+  "context": "root",
+  "grammarAfterRootOpenRestoration": {
+    "Atom": "0 | 1",
+    "Value": "Atom | '[' Pair ']'",
+    "Pair": "Value Value",
+    "Root": "Atom | Pair"
+  },
+  "semantics": {
+    "0": "Anchor(protocol:0)",
+    "1": "Anchor(protocol:1)",
+    "pair": "Link(D(start), D(end))",
+    "nodePolicy": "occurrence-preserving postorder nodes; no structural interning/global identity"
+  },
+  "specialBoundaryPrecedence": [
+    "[]",
+    "][",
+    "[[",
+    "]]"
+  ],
+  "rootOpeningCollapse": {
+    "encode": "if expanded root encoding begins with N>1 consecutive '[' characters, replace that leading run with exactly one '['",
+    "decode": "for a root candidate beginning with '[', if total bracket balance is negative, prepend exactly -balance virtual '[' characters before parsing",
+    "canonicalityVeto": "after decode, re-encode with root-opening collapse and require exact equality with input raw"
+  },
+  "contextIsolation": {
+    "root": "recursive structural grammar enabled after accepted boundary cases",
+    "quote": "existing quote projection only; recursive structural grammar disabled",
+    "relative": "raw only; recursive structural grammar disabled"
+  },
+  "inverse": {
+    "scope": "structural occurrence-tree denotations emitted by this decoder",
+    "explicitSharedNodeReferencesAccepted": false,
+    "unusedNodesAccepted": false,
+    "externalAnchorsAccepted": false,
+    "canonical": true,
+    "sourcePreserving": false
+  },
+  "effects": {
+    "mayReadMemory": false,
+    "mayMutateMemory": false,
+    "mayRealize": false
+  },
+  "challenge": {
+    "exhaustiveBinaryTreeDepth": 3,
+    "requiredProperties": [
+      "distinct occurrence trees have distinct collapsed canonical raw encodings",
+      "decode(encode(tree)) equals tree",
+      "encode(decode(raw)) equals raw for every accepted canonical vector"
+    ]
+  },
+  "unsupported": {
+    "relativeDenotation": true,
+    "contextFreeBracketMeaning": true,
+    "globalNodeIdentity": true,
+    "nonCanonicalEquivalentSpellings": true
+  }
+}

--- a/contracts/anum_docs-v0.2/mts-contract-v0.2.json
+++ b/contracts/anum_docs-v0.2/mts-contract-v0.2.json
@@ -60,10 +60,13 @@
   "anum": {
     "operations": ["serialize", "deserialize"],
     "alphabet": ["[", "]", "1", "0"],
+    "rawCarrierDescription": "contracts/anum-raw-carrier-v0.2.json",
     "rootBoundaryProjection": "contracts/anum-boundary-projection-v0.2.json",
     "denotationHandoff": "contracts/anum-denotation-v0.2.json",
     "acceptedPairDenotationSubset": "contracts/anum-pair-denotation-v0.2.json",
-    "recursiveDenotationIssue": 95,
+    "acceptedRecursiveDenotationSubset": "contracts/anum-recursive-denotation-v0.2.json",
+    "rootOpeningCollapse": "recursive root encoding collapses a leading run of opening abits to one physical '[' and restores it only through canonical decode/re-encode validation",
+    "recursiveDenotationIssue": 101,
     "generalDenotationIssue": 89
   },
   "memory": {

--- a/contracts/anum_docs-v0.2/mts-contract-v0.2.json
+++ b/contracts/anum_docs-v0.2/mts-contract-v0.2.json
@@ -59,7 +59,12 @@
   },
   "anum": {
     "operations": ["serialize", "deserialize"],
-    "alphabet": ["[", "]", "1", "0"]
+    "alphabet": ["[", "]", "1", "0"],
+    "rootBoundaryProjection": "contracts/anum-boundary-projection-v0.2.json",
+    "denotationHandoff": "contracts/anum-denotation-v0.2.json",
+    "acceptedPairDenotationSubset": "contracts/anum-pair-denotation-v0.2.json",
+    "recursiveDenotationIssue": 95,
+    "generalDenotationIssue": 89
   },
   "memory": {
     "readOperations": [

--- a/contracts/anum_docs-v0.2/provenance.json
+++ b/contracts/anum_docs-v0.2/provenance.json
@@ -1,9 +1,10 @@
 {
   "sourceRepository": "netkeep80/anum_docs",
-  "sourceCommit": "9921ce2c6c5ccf5cc62ec27daca571752e116fe9",
+  "sourceCommit": "62901cfc94831af41cf86cdc3acb1507c46c05c7",
   "contract": {
     "path": "contracts/mts-contract-v0.2.json",
-    "gitBlobSha": "a8fc7c1d565a87941dbd4c8d691ffd4887aec620"
+    "sourceCommit": "62901cfc94831af41cf86cdc3acb1507c46c05c7",
+    "gitBlobSha": "93c39e34f14fb716d850136249e4928599d75130"
   },
   "conformance": {
     "path": "contracts/mts-conformance-v0.2.json",
@@ -17,27 +18,47 @@
   },
   "anumBoundaryProjection": {
     "path": "contracts/anum-boundary-projection-v0.2.json",
-    "sourceCommit": "013c18cd2c41b0e3c5960e4bd7389a136d1958e1",
-    "gitBlobSha": "8229fc65d0c48a811b9f97e5512fcf6e350b512d"
+    "sourceCommit": "62901cfc94831af41cf86cdc3acb1507c46c05c7",
+    "gitBlobSha": "822165f7940a4ec764bb7ac59e24e875ae03fb44"
   },
   "anumDenotation": {
     "path": "contracts/anum-denotation-v0.2.json",
-    "sourceCommit": "ddf139c1900f00be896646cffaa395b8c085d144",
-    "gitBlobSha": "2c9681e2651276f70d54bac91ec1166203872812"
+    "sourceCommit": "62901cfc94831af41cf86cdc3acb1507c46c05c7",
+    "gitBlobSha": "2c0544c1b2ff57bf9c5999b50bd881622b48159d"
   },
   "anumDenotationConformance": {
     "path": "contracts/anum-denotation-conformance-v0.2.json",
-    "sourceCommit": "ddf139c1900f00be896646cffaa395b8c085d144",
+    "sourceCommit": "62901cfc94831af41cf86cdc3acb1507c46c05c7",
     "gitBlobSha": "af0740a358d40e8d70a9770387a26ef8303d5eaa"
   },
   "anumPairDenotation": {
     "path": "contracts/anum-pair-denotation-v0.2.json",
-    "sourceCommit": "9921ce2c6c5ccf5cc62ec27daca571752e116fe9",
-    "gitBlobSha": "b07d3989f8819185424782cce80759aa8310e465"
+    "sourceCommit": "62901cfc94831af41cf86cdc3acb1507c46c05c7",
+    "gitBlobSha": "d09b4e4eccd9a5f439d20086bd1004cadc05b280"
   },
   "anumPairDenotationConformance": {
     "path": "contracts/anum-pair-denotation-conformance-v0.2.json",
-    "sourceCommit": "9921ce2c6c5ccf5cc62ec27daca571752e116fe9",
-    "gitBlobSha": "0d59c92ad30b82d23e598188f64feb3644bc81a8"
+    "sourceCommit": "62901cfc94831af41cf86cdc3acb1507c46c05c7",
+    "gitBlobSha": "0d5954625267299993aa66e71c55d95172a73625"
+  },
+  "anumRawCarrier": {
+    "path": "contracts/anum-raw-carrier-v0.2.json",
+    "sourceCommit": "62901cfc94831af41cf86cdc3acb1507c46c05c7",
+    "gitBlobSha": "d5c0ddbb6c2d57967621c08551fbadd4f2cdd132"
+  },
+  "anumRawCarrierConformance": {
+    "path": "contracts/anum-raw-carrier-conformance-v0.2.json",
+    "sourceCommit": "62901cfc94831af41cf86cdc3acb1507c46c05c7",
+    "gitBlobSha": "39064ed361b4b53014f5f9fb7f026b2deba4b0f1"
+  },
+  "anumRecursiveDenotation": {
+    "path": "contracts/anum-recursive-denotation-v0.2.json",
+    "sourceCommit": "62901cfc94831af41cf86cdc3acb1507c46c05c7",
+    "gitBlobSha": "f0fc16e989c4b49c6df476393108bc7bfb41cbb4"
+  },
+  "anumRecursiveDenotationConformance": {
+    "path": "contracts/anum-recursive-denotation-conformance-v0.2.json",
+    "sourceCommit": "62901cfc94831af41cf86cdc3acb1507c46c05c7",
+    "gitBlobSha": "70375b06f2031982bd42c62c8552a2edae1be4c1"
   }
 }

--- a/contracts/anum_docs-v0.2/provenance.json
+++ b/contracts/anum_docs-v0.2/provenance.json
@@ -1,17 +1,43 @@
 {
   "sourceRepository": "netkeep80/anum_docs",
-  "sourceCommit": "294aa5e3d141e16fa93f88c0c18c4b78f8ae168c",
+  "sourceCommit": "9921ce2c6c5ccf5cc62ec27daca571752e116fe9",
   "contract": {
     "path": "contracts/mts-contract-v0.2.json",
-    "gitBlobSha": "fb414a1541f3430fa9292c0fdfd89ca07d5db8ea"
+    "gitBlobSha": "a8fc7c1d565a87941dbd4c8d691ffd4887aec620"
   },
   "conformance": {
     "path": "contracts/mts-conformance-v0.2.json",
+    "sourceCommit": "294aa5e3d141e16fa93f88c0c18c4b78f8ae168c",
     "gitBlobSha": "96303366a8808d9e67ee548b445fcdbf2233f336"
   },
   "proof": {
     "path": "contracts/mts-proof-v0.2.json",
     "sourceCommit": "d4d8e7c2291d26ea868d01dcc66f90d1c319c6e9",
     "gitBlobSha": "7c125771be689ce2c825f5fa1be4674527f15dbb"
+  },
+  "anumBoundaryProjection": {
+    "path": "contracts/anum-boundary-projection-v0.2.json",
+    "sourceCommit": "013c18cd2c41b0e3c5960e4bd7389a136d1958e1",
+    "gitBlobSha": "8229fc65d0c48a811b9f97e5512fcf6e350b512d"
+  },
+  "anumDenotation": {
+    "path": "contracts/anum-denotation-v0.2.json",
+    "sourceCommit": "ddf139c1900f00be896646cffaa395b8c085d144",
+    "gitBlobSha": "2c9681e2651276f70d54bac91ec1166203872812"
+  },
+  "anumDenotationConformance": {
+    "path": "contracts/anum-denotation-conformance-v0.2.json",
+    "sourceCommit": "ddf139c1900f00be896646cffaa395b8c085d144",
+    "gitBlobSha": "af0740a358d40e8d70a9770387a26ef8303d5eaa"
+  },
+  "anumPairDenotation": {
+    "path": "contracts/anum-pair-denotation-v0.2.json",
+    "sourceCommit": "9921ce2c6c5ccf5cc62ec27daca571752e116fe9",
+    "gitBlobSha": "b07d3989f8819185424782cce80759aa8310e465"
+  },
+  "anumPairDenotationConformance": {
+    "path": "contracts/anum-pair-denotation-conformance-v0.2.json",
+    "sourceCommit": "9921ce2c6c5ccf5cc62ec27daca571752e116fe9",
+    "gitBlobSha": "0d59c92ad30b82d23e598188f64feb3644bc81a8"
   }
 }

--- a/src/core/mtsContract.ts
+++ b/src/core/mtsContract.ts
@@ -48,10 +48,13 @@ export interface MtsContractV02 {
   anum: {
     operations: ['serialize', 'deserialize']
     alphabet: ['[', ']', '1', '0']
+    rawCarrierDescription: 'contracts/anum-raw-carrier-v0.2.json'
     rootBoundaryProjection: 'contracts/anum-boundary-projection-v0.2.json'
     denotationHandoff: 'contracts/anum-denotation-v0.2.json'
     acceptedPairDenotationSubset: 'contracts/anum-pair-denotation-v0.2.json'
-    recursiveDenotationIssue: 95
+    acceptedRecursiveDenotationSubset: 'contracts/anum-recursive-denotation-v0.2.json'
+    rootOpeningCollapse: string
+    recursiveDenotationIssue: 101
     generalDenotationIssue: 89
   }
   memory: {
@@ -211,6 +214,11 @@ export function validateMtsContractV02(value: unknown): MtsContractV02 {
     throw new TypeError('anum.alphabet must be exactly [ ] 1 0')
   }
   exact(
+    anum.rawCarrierDescription,
+    'contracts/anum-raw-carrier-v0.2.json',
+    'anum.rawCarrierDescription'
+  )
+  exact(
     anum.rootBoundaryProjection,
     'contracts/anum-boundary-projection-v0.2.json',
     'anum.rootBoundaryProjection'
@@ -225,7 +233,13 @@ export function validateMtsContractV02(value: unknown): MtsContractV02 {
     'contracts/anum-pair-denotation-v0.2.json',
     'anum.acceptedPairDenotationSubset'
   )
-  exact(anum.recursiveDenotationIssue, 95, 'anum.recursiveDenotationIssue')
+  exact(
+    anum.acceptedRecursiveDenotationSubset,
+    'contracts/anum-recursive-denotation-v0.2.json',
+    'anum.acceptedRecursiveDenotationSubset'
+  )
+  string(anum.rootOpeningCollapse, 'anum.rootOpeningCollapse')
+  exact(anum.recursiveDenotationIssue, 101, 'anum.recursiveDenotationIssue')
   exact(anum.generalDenotationIssue, 89, 'anum.generalDenotationIssue')
 
   const memory = record(root.memory, 'memory')

--- a/src/core/mtsContract.ts
+++ b/src/core/mtsContract.ts
@@ -48,6 +48,11 @@ export interface MtsContractV02 {
   anum: {
     operations: ['serialize', 'deserialize']
     alphabet: ['[', ']', '1', '0']
+    rootBoundaryProjection: 'contracts/anum-boundary-projection-v0.2.json'
+    denotationHandoff: 'contracts/anum-denotation-v0.2.json'
+    acceptedPairDenotationSubset: 'contracts/anum-pair-denotation-v0.2.json'
+    recursiveDenotationIssue: 95
+    generalDenotationIssue: 89
   }
   memory: {
     readOperations: string[]
@@ -197,10 +202,31 @@ export function validateMtsContractV02(value: unknown): MtsContractV02 {
   string(aroot.definition, 'aroot.definition')
 
   const anum = record(root.anum, 'anum')
+  const anumOperations = array(anum.operations, 'anum.operations')
+  if (JSON.stringify(anumOperations) !== JSON.stringify(['serialize', 'deserialize'])) {
+    throw new TypeError('anum.operations must be exactly serialize/deserialize')
+  }
   const alphabet = array(anum.alphabet, 'anum.alphabet')
   if (JSON.stringify(alphabet) !== JSON.stringify(['[', ']', '1', '0'])) {
     throw new TypeError('anum.alphabet must be exactly [ ] 1 0')
   }
+  exact(
+    anum.rootBoundaryProjection,
+    'contracts/anum-boundary-projection-v0.2.json',
+    'anum.rootBoundaryProjection'
+  )
+  exact(
+    anum.denotationHandoff,
+    'contracts/anum-denotation-v0.2.json',
+    'anum.denotationHandoff'
+  )
+  exact(
+    anum.acceptedPairDenotationSubset,
+    'contracts/anum-pair-denotation-v0.2.json',
+    'anum.acceptedPairDenotationSubset'
+  )
+  exact(anum.recursiveDenotationIssue, 95, 'anum.recursiveDenotationIssue')
+  exact(anum.generalDenotationIssue, 89, 'anum.generalDenotationIssue')
 
   const memory = record(root.memory, 'memory')
   exact(memory.interpretMayMaterialize, false, 'memory.interpretMayMaterialize')

--- a/tests/unit/mtsContract.test.ts
+++ b/tests/unit/mtsContract.test.ts
@@ -5,16 +5,19 @@ import { describe, expect, it } from 'vitest'
 
 import { validateMtsContractBundleV02 } from '../../src/core/mtsContract'
 
-const contractPath = resolve(
-  process.cwd(),
-  'contracts/anum_docs-v0.2/mts-contract-v0.2.json'
+const bundleRoot = resolve(process.cwd(), 'contracts/anum_docs-v0.2')
+const contractPath = resolve(bundleRoot, 'mts-contract-v0.2.json')
+const conformancePath = resolve(bundleRoot, 'mts-conformance-v0.2.json')
+const proofPath = resolve(bundleRoot, 'mts-proof-v0.2.json')
+const boundaryPath = resolve(bundleRoot, 'anum-boundary-projection-v0.2.json')
+const denotationPath = resolve(bundleRoot, 'anum-denotation-v0.2.json')
+const denotationConformancePath = resolve(bundleRoot, 'anum-denotation-conformance-v0.2.json')
+const pairDenotationPath = resolve(bundleRoot, 'anum-pair-denotation-v0.2.json')
+const pairDenotationConformancePath = resolve(
+  bundleRoot,
+  'anum-pair-denotation-conformance-v0.2.json'
 )
-const conformancePath = resolve(
-  process.cwd(),
-  'contracts/anum_docs-v0.2/mts-conformance-v0.2.json'
-)
-const proofPath = resolve(process.cwd(), 'contracts/anum_docs-v0.2/mts-proof-v0.2.json')
-const provenancePath = resolve(process.cwd(), 'contracts/anum_docs-v0.2/provenance.json')
+const provenancePath = resolve(bundleRoot, 'provenance.json')
 
 function readJson(path: string): unknown {
   return JSON.parse(readFileSync(path, 'utf8')) as unknown
@@ -28,12 +31,23 @@ function gitBlobSha(path: string): string {
     .digest('hex')
 }
 
+interface ArtifactProvenance {
+  path: string
+  sourceCommit?: string
+  gitBlobSha: string
+}
+
 interface Provenance {
   sourceRepository: string
   sourceCommit: string
-  contract: { path: string; gitBlobSha: string }
-  conformance: { path: string; gitBlobSha: string }
-  proof: { path: string; sourceCommit: string; gitBlobSha: string }
+  contract: ArtifactProvenance
+  conformance: ArtifactProvenance
+  proof: ArtifactProvenance
+  anumBoundaryProjection: ArtifactProvenance
+  anumDenotation: ArtifactProvenance
+  anumDenotationConformance: ArtifactProvenance
+  anumPairDenotation: ArtifactProvenance
+  anumPairDenotationConformance: ArtifactProvenance
 }
 
 interface ProofContractV02 {
@@ -53,8 +67,8 @@ function readProvenance(): Provenance {
   return readJson(provenancePath) as Provenance
 }
 
-describe('pinned anum_docs MTS v0.2 contract', () => {
-  it('loads as one validated contract + conformance bundle', () => {
+describe('pinned anum_docs MTS v0.2 contract bundle', () => {
+  it('loads as one validated formal contract + conformance bundle', () => {
     const bundle = validateMtsContractBundleV02(
       readJson(contractPath),
       readJson(conformancePath)
@@ -65,26 +79,56 @@ describe('pinned anum_docs MTS v0.2 contract', () => {
     expect(bundle.conformance.contract).toBe(bundle.contract.schema)
   })
 
-  it('pins the exact upstream Git blobs rather than a manually edited fork', () => {
+  it('pins the current upstream top-level contract instead of the stale #86 blob', () => {
     const provenance = readProvenance()
 
     expect(provenance.sourceRepository).toBe('netkeep80/anum_docs')
-    expect(provenance.sourceCommit).toBe('294aa5e3d141e16fa93f88c0c18c4b78f8ae168c')
+    expect(provenance.sourceCommit).toBe('9921ce2c6c5ccf5cc62ec27daca571752e116fe9')
     expect(gitBlobSha(contractPath)).toBe(provenance.contract.gitBlobSha)
-    expect(gitBlobSha(conformancePath)).toBe(provenance.conformance.gitBlobSha)
-    expect(provenance.contract.gitBlobSha).toBe('fb414a1541f3430fa9292c0fdfd89ca07d5db8ea')
-    expect(provenance.conformance.gitBlobSha).toBe('96303366a8808d9e67ee548b445fcdbf2233f336')
+    expect(provenance.contract.gitBlobSha).toBe('a8fc7c1d565a87941dbd4c8d691ffd4887aec620')
+    expect(provenance.contract.gitBlobSha).not.toBe('fb414a1541f3430fa9292c0fdfd89ca07d5db8ea')
   })
 
-  it('pins the proof contract from its newer upstream commit without rewriting old provenance', () => {
+  it('pins every referenced accepted L3 artifact by exact Git blob SHA', () => {
+    const provenance = readProvenance()
+    const artifacts: Array<[string, ArtifactProvenance, string]> = [
+      [boundaryPath, provenance.anumBoundaryProjection, '8229fc65d0c48a811b9f97e5512fcf6e350b512d'],
+      [denotationPath, provenance.anumDenotation, '2c9681e2651276f70d54bac91ec1166203872812'],
+      [
+        denotationConformancePath,
+        provenance.anumDenotationConformance,
+        'af0740a358d40e8d70a9770387a26ef8303d5eaa',
+      ],
+      [pairDenotationPath, provenance.anumPairDenotation, 'b07d3989f8819185424782cce80759aa8310e465'],
+      [
+        pairDenotationConformancePath,
+        provenance.anumPairDenotationConformance,
+        '0d59c92ad30b82d23e598188f64feb3644bc81a8',
+      ],
+    ]
+
+    for (const [path, artifact, expected] of artifacts) {
+      expect(gitBlobSha(path)).toBe(artifact.gitBlobSha)
+      expect(artifact.gitBlobSha).toBe(expected)
+      expect(artifact.sourceCommit).toMatch(/^[0-9a-f]{40}$/)
+    }
+  })
+
+  it('keeps unchanged conformance/proof artifacts pinned to their original upstream commits', () => {
     const provenance = readProvenance()
     const proof = readJson(proofPath) as ProofContractV02
 
+    expect(gitBlobSha(conformancePath)).toBe(provenance.conformance.gitBlobSha)
+    expect(provenance.conformance.gitBlobSha).toBe('96303366a8808d9e67ee548b445fcdbf2233f336')
+    expect(provenance.conformance.sourceCommit).toBe(
+      '294aa5e3d141e16fa93f88c0c18c4b78f8ae168c'
+    )
+
+    expect(gitBlobSha(proofPath)).toBe(provenance.proof.gitBlobSha)
+    expect(provenance.proof.gitBlobSha).toBe('7c125771be689ce2c825f5fa1be4674527f15dbb')
     expect(provenance.proof.sourceCommit).toBe(
       'd4d8e7c2291d26ea868d01dcc66f90d1c319c6e9'
     )
-    expect(gitBlobSha(proofPath)).toBe(provenance.proof.gitBlobSha)
-    expect(provenance.proof.gitBlobSha).toBe('7c125771be689ce2c825f5fa1be4674527f15dbb')
     expect(proof.schema).toBe('mts-proof/v0.2')
     expect(proof.status).toBe('candidate')
     expect(proof.dependsOn).toBe('mts-contract/v0.2')
@@ -94,6 +138,33 @@ describe('pinned anum_docs MTS v0.2 contract', () => {
     expect(proof.checker.mayMaterialize).toBe(false)
     expect(proof.explicitlyNotTrusted).toContain('transitivity')
     expect(proof.explicitlyNotTrusted).toContain('modus-ponens')
+  })
+
+  it('validates the upstream L3 contract graph without implementing L3 semantics locally', () => {
+    const { contract } = validateMtsContractBundleV02(
+      readJson(contractPath),
+      readJson(conformancePath)
+    )
+
+    expect(contract.anum.operations).toEqual(['serialize', 'deserialize'])
+    expect(contract.anum.alphabet).toEqual(['[', ']', '1', '0'])
+    expect(contract.anum.rootBoundaryProjection).toBe(
+      'contracts/anum-boundary-projection-v0.2.json'
+    )
+    expect(contract.anum.denotationHandoff).toBe('contracts/anum-denotation-v0.2.json')
+    expect(contract.anum.acceptedPairDenotationSubset).toBe(
+      'contracts/anum-pair-denotation-v0.2.json'
+    )
+    expect(contract.anum.recursiveDenotationIssue).toBe(95)
+    expect(contract.anum.generalDenotationIssue).toBe(89)
+
+    expect((readJson(boundaryPath) as { schema: string }).schema).toBe(
+      'anum-boundary-projection/v0.2'
+    )
+    expect((readJson(denotationPath) as { schema: string }).schema).toBe('anum-denotation/v0.2')
+    expect((readJson(pairDenotationPath) as { schema: string }).schema).toBe(
+      'anum-pair-denotation/v0.2'
+    )
   })
 
   it('treats the two context pronouns as atomic non-bracket code points', () => {

--- a/tests/unit/mtsContract.test.ts
+++ b/tests/unit/mtsContract.test.ts
@@ -17,6 +17,13 @@ const pairDenotationConformancePath = resolve(
   bundleRoot,
   'anum-pair-denotation-conformance-v0.2.json'
 )
+const rawCarrierPath = resolve(bundleRoot, 'anum-raw-carrier-v0.2.json')
+const rawCarrierConformancePath = resolve(bundleRoot, 'anum-raw-carrier-conformance-v0.2.json')
+const recursiveDenotationPath = resolve(bundleRoot, 'anum-recursive-denotation-v0.2.json')
+const recursiveDenotationConformancePath = resolve(
+  bundleRoot,
+  'anum-recursive-denotation-conformance-v0.2.json'
+)
 const provenancePath = resolve(bundleRoot, 'provenance.json')
 
 function readJson(path: string): unknown {
@@ -48,6 +55,10 @@ interface Provenance {
   anumDenotationConformance: ArtifactProvenance
   anumPairDenotation: ArtifactProvenance
   anumPairDenotationConformance: ArtifactProvenance
+  anumRawCarrier: ArtifactProvenance
+  anumRawCarrierConformance: ArtifactProvenance
+  anumRecursiveDenotation: ArtifactProvenance
+  anumRecursiveDenotationConformance: ArtifactProvenance
 }
 
 interface ProofContractV02 {
@@ -79,38 +90,54 @@ describe('pinned anum_docs MTS v0.2 contract bundle', () => {
     expect(bundle.conformance.contract).toBe(bundle.contract.schema)
   })
 
-  it('pins the current upstream top-level contract instead of the stale #86 blob', () => {
+  it('pins the current upstream top-level contract snapshot', () => {
     const provenance = readProvenance()
 
     expect(provenance.sourceRepository).toBe('netkeep80/anum_docs')
-    expect(provenance.sourceCommit).toBe('9921ce2c6c5ccf5cc62ec27daca571752e116fe9')
+    expect(provenance.sourceCommit).toBe('62901cfc94831af41cf86cdc3acb1507c46c05c7')
     expect(gitBlobSha(contractPath)).toBe(provenance.contract.gitBlobSha)
-    expect(provenance.contract.gitBlobSha).toBe('a8fc7c1d565a87941dbd4c8d691ffd4887aec620')
-    expect(provenance.contract.gitBlobSha).not.toBe('fb414a1541f3430fa9292c0fdfd89ca07d5db8ea')
+    expect(provenance.contract.gitBlobSha).toBe('93c39e34f14fb716d850136249e4928599d75130')
+    expect(provenance.contract.sourceCommit).toBe(provenance.sourceCommit)
   })
 
   it('pins every referenced accepted L3 artifact by exact Git blob SHA', () => {
     const provenance = readProvenance()
     const artifacts: Array<[string, ArtifactProvenance, string]> = [
-      [boundaryPath, provenance.anumBoundaryProjection, '8229fc65d0c48a811b9f97e5512fcf6e350b512d'],
-      [denotationPath, provenance.anumDenotation, '2c9681e2651276f70d54bac91ec1166203872812'],
+      [boundaryPath, provenance.anumBoundaryProjection, '822165f7940a4ec764bb7ac59e24e875ae03fb44'],
+      [denotationPath, provenance.anumDenotation, '2c0544c1b2ff57bf9c5999b50bd881622b48159d'],
       [
         denotationConformancePath,
         provenance.anumDenotationConformance,
         'af0740a358d40e8d70a9770387a26ef8303d5eaa',
       ],
-      [pairDenotationPath, provenance.anumPairDenotation, 'b07d3989f8819185424782cce80759aa8310e465'],
+      [pairDenotationPath, provenance.anumPairDenotation, 'd09b4e4eccd9a5f439d20086bd1004cadc05b280'],
       [
         pairDenotationConformancePath,
         provenance.anumPairDenotationConformance,
-        '0d59c92ad30b82d23e598188f64feb3644bc81a8',
+        '0d5954625267299993aa66e71c55d95172a73625',
+      ],
+      [rawCarrierPath, provenance.anumRawCarrier, 'd5c0ddbb6c2d57967621c08551fbadd4f2cdd132'],
+      [
+        rawCarrierConformancePath,
+        provenance.anumRawCarrierConformance,
+        '39064ed361b4b53014f5f9fb7f026b2deba4b0f1',
+      ],
+      [
+        recursiveDenotationPath,
+        provenance.anumRecursiveDenotation,
+        'f0fc16e989c4b49c6df476393108bc7bfb41cbb4',
+      ],
+      [
+        recursiveDenotationConformancePath,
+        provenance.anumRecursiveDenotationConformance,
+        '70375b06f2031982bd42c62c8552a2edae1be4c1',
       ],
     ]
 
     for (const [path, artifact, expected] of artifacts) {
       expect(gitBlobSha(path)).toBe(artifact.gitBlobSha)
       expect(artifact.gitBlobSha).toBe(expected)
-      expect(artifact.sourceCommit).toMatch(/^[0-9a-f]{40}$/)
+      expect(artifact.sourceCommit).toBe(provenance.sourceCommit)
     }
   })
 
@@ -148,6 +175,7 @@ describe('pinned anum_docs MTS v0.2 contract bundle', () => {
 
     expect(contract.anum.operations).toEqual(['serialize', 'deserialize'])
     expect(contract.anum.alphabet).toEqual(['[', ']', '1', '0'])
+    expect(contract.anum.rawCarrierDescription).toBe('contracts/anum-raw-carrier-v0.2.json')
     expect(contract.anum.rootBoundaryProjection).toBe(
       'contracts/anum-boundary-projection-v0.2.json'
     )
@@ -155,7 +183,11 @@ describe('pinned anum_docs MTS v0.2 contract bundle', () => {
     expect(contract.anum.acceptedPairDenotationSubset).toBe(
       'contracts/anum-pair-denotation-v0.2.json'
     )
-    expect(contract.anum.recursiveDenotationIssue).toBe(95)
+    expect(contract.anum.acceptedRecursiveDenotationSubset).toBe(
+      'contracts/anum-recursive-denotation-v0.2.json'
+    )
+    expect(contract.anum.rootOpeningCollapse).toContain('canonical decode/re-encode validation')
+    expect(contract.anum.recursiveDenotationIssue).toBe(101)
     expect(contract.anum.generalDenotationIssue).toBe(89)
 
     expect((readJson(boundaryPath) as { schema: string }).schema).toBe(
@@ -164,6 +196,10 @@ describe('pinned anum_docs MTS v0.2 contract bundle', () => {
     expect((readJson(denotationPath) as { schema: string }).schema).toBe('anum-denotation/v0.2')
     expect((readJson(pairDenotationPath) as { schema: string }).schema).toBe(
       'anum-pair-denotation/v0.2'
+    )
+    expect((readJson(rawCarrierPath) as { schema: string }).schema).toBe('anum-raw-carrier/v0.2')
+    expect((readJson(recursiveDenotationPath) as { schema: string }).schema).toBe(
+      'anum-recursive-denotation/v0.2'
     )
   })
 


### PR DESCRIPTION
Closes #125.

Восстанавливает exact upstream provenance после полного принятого L3 chain в `anum_docs` через #92/#93/#96/#100/#102.

Pinned snapshot: `netkeep80/anum_docs@62901cfc94831af41cf86cdc3acb1507c46c05c7`.

- exact current `mts-contract-v0.2.json` blob `93c39e...`;
- exact boundary projection, denotation IR+conformance, pair subset+conformance;
- exact raw-carrier contract+conformance;
- exact accepted recursive-denotation contract+conformance;
- provenance фиксирует source commit + Git blob SHA каждого vendored artifact;
- unchanged MTS conformance/proof artifacts сохраняют исходные commits/hashes;
- `mtsContract.ts` валидирует только L3 contract links/alphabet/accepted issue references, не реализует decoder/denotation semantics;
- tests пересчитывают Git blob SHA полного bundle и запрещают partial/stale repin.

Это dependency/provenance synchronization only. `aprover` остаётся application consumer; никакой второй L3 implementation не создаётся.

CI #311: lint, type-check, unit, build, Playwright — green. Branch current относительно `main`.