### PR TITLE
Исполнить pinned Anum denotation v0.2 в TypeScript

### DIFF
--- a/src/core/anumDenotation.ts
+++ b/src/core/anumDenotation.ts
@@ -11,7 +11,8 @@ import { cleanQuatAnum, validateQuatAnum } from './quatAnum'
 export type AnumDenotationContext = 'root' | 'quote' | 'relative'
 export type ProtocolAnchor = 'protocol:0' | 'protocol:1'
 
-export type DenotationRef = { anchor: ProtocolAnchor } | { node: number }
+/** Base anum-denotation/v0.2 anchors are opaque non-empty strings. */
+export type DenotationRef = { anchor: string } | { node: number }
 
 export interface DenotationNode {
   id: number
@@ -21,7 +22,7 @@ export interface DenotationNode {
 
 export interface StructuralAnumDenotation {
   kind: 'structural'
-  anchors: ProtocolAnchor[]
+  anchors: string[]
   nodes: DenotationNode[]
   root: DenotationRef
 }
@@ -66,8 +67,10 @@ function anchorForAtom(atom: '0' | '1'): ProtocolAnchor {
   return atom === '0' ? 'protocol:0' : 'protocol:1'
 }
 
-function atomForAnchor(anchor: ProtocolAnchor): '0' | '1' {
-  return anchor === 'protocol:0' ? '0' : '1'
+function atomForAnchor(anchor: string): '0' | '1' {
+  if (anchor === 'protocol:0') return '0'
+  if (anchor === 'protocol:1') return '1'
+  throw new Error('Recursive denotation endpoint must be protocol:0 or protocol:1')
 }
 
 function anchorDenotation(anchor: ProtocolAnchor): StructuralAnumDenotation {
@@ -77,7 +80,7 @@ function anchorDenotation(anchor: ProtocolAnchor): StructuralAnumDenotation {
 function pairDenotation(start: ProtocolAnchor, end: ProtocolAnchor): StructuralAnumDenotation {
   return {
     kind: 'structural',
-    anchors: [...new Set<ProtocolAnchor>([start, end])].sort(),
+    anchors: [...new Set([start, end])].sort(),
     nodes: [{ id: 0, start: { anchor: start }, end: { anchor: end } }],
     root: { node: 0 },
   }
@@ -85,9 +88,8 @@ function pairDenotation(start: ProtocolAnchor, end: ProtocolAnchor): StructuralA
 
 function denotatePairSubset(raw: string, context: AnumDenotationContext): AnumDenotation {
   if (context === 'quote') {
-    const quoted = raw.length >= 2 && raw.startsWith('[') && raw.endsWith(']')
-      ? raw.slice(1, -1)
-      : raw
+    const quoted =
+      raw.length >= 2 && raw.startsWith('[') && raw.endsWith(']') ? raw.slice(1, -1) : raw
     return { kind: 'quoted-raw', raw: quoted }
   }
 
@@ -125,12 +127,93 @@ export function denotateAnum(
   }
 }
 
-/** Canonical inverse for structural occurrence trees in the accepted v0.2 subset. */
+/** Validate the general storage-neutral anum-denotation/v0.2 IR. */
+export function validateAnumDenotation(value: AnumDenotation): void {
+  if (value.kind === 'raw' || value.kind === 'quoted-raw') {
+    if (typeof value.raw !== 'string') throw new Error('Raw Anum denotation requires a string payload')
+    return
+  }
+
+  if (!Array.isArray(value.anchors) || !value.anchors.every(anchor => typeof anchor === 'string')) {
+    throw new Error('Structural denotation anchors must be a string list')
+  }
+  if ([...value.anchors].sort().some((anchor, index) => anchor !== value.anchors[index])) {
+    throw new Error('Denotation anchors must be sorted')
+  }
+  if (new Set(value.anchors).size !== value.anchors.length) {
+    throw new Error('Denotation anchors must be unique')
+  }
+  if (value.anchors.some(anchor => anchor.length === 0)) {
+    throw new Error('Denotation anchor keys must be non-empty')
+  }
+
+  const anchors = new Set(value.anchors)
+  value.nodes.forEach((node, expectedId) => {
+    if (!Number.isInteger(node.id) || node.id !== expectedId) {
+      throw new Error('Denotation node ids must be contiguous and ordered')
+    }
+    validateRef(node.start, anchors, expectedId)
+    validateRef(node.end, anchors, expectedId)
+  })
+  validateRef(value.root, anchors, value.nodes.length)
+}
+
+/** Deterministic compact JSON required by anum-denotation/v0.2. */
+export function canonicalDenotationJson(value: AnumDenotation): string {
+  validateAnumDenotation(value)
+  const payload =
+    value.kind === 'structural'
+      ? {
+          kind: value.kind,
+          anchors: value.anchors,
+          nodes: value.nodes.map(node => ({ id: node.id, start: node.start, end: node.end })),
+          root: value.root,
+        }
+      : { kind: value.kind, raw: value.raw }
+  return JSON.stringify(sortJsonKeys(payload))
+}
+
+/** Canonical inverse for structural occurrence trees in the accepted recursive subset. */
 export function canonicalAnum(value: AnumDenotation): string {
   if (value.kind !== 'structural') {
     throw new Error('Only structural Anum denotations have a canonical inverse')
   }
+  validateAnumDenotation(value)
   return canonicalTreeRaw(treeFromStructural(value))
+}
+
+function validateRef(ref: DenotationRef, anchors: Set<string>, availableNodes: number): void {
+  if (!ref || typeof ref !== 'object') throw new Error('Denotation reference must be an object')
+
+  const keys = Object.keys(ref)
+  if (keys.length !== 1) {
+    throw new Error('Denotation reference must contain exactly one anchor or node')
+  }
+
+  if ('anchor' in ref) {
+    if (typeof ref.anchor !== 'string') throw new Error('Anchor reference must contain a string key')
+    if (!anchors.has(ref.anchor)) {
+      throw new Error(`Denotation reference uses undeclared anchor: ${ref.anchor}`)
+    }
+    return
+  }
+
+  if (!('node' in ref) || !Number.isInteger(ref.node)) {
+    throw new Error('Node reference must contain an integer node id')
+  }
+  if (ref.node < 0 || ref.node >= availableNodes) {
+    throw new Error('Denotation node reference must target an earlier node')
+  }
+}
+
+function sortJsonKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJsonKeys)
+  if (value === null || typeof value !== 'object') return value
+
+  const input = value as Record<string, unknown>
+  const sorted: Record<string, unknown> = {}
+  for (const key of Object.keys(input).sort()) sorted[key] = sortJsonKeys(input[key])
+  return sorted
 }
 
 function atomTree(atom: '0' | '1'): AtomTree {
@@ -143,18 +226,18 @@ function linkTree(start: RecursiveAnumTree, end: RecursiveAnumTree): LinkTree {
 
 function decodeRecursiveTree(raw: string): RecursiveAnumTree {
   if (raw === '[]' || raw === '][' || raw === '[[' || raw === ']]') {
-    throw new RecursiveDecodeError('special boundary form is outside recursive grammar')
+    throw new RecursiveDecodeError('Special boundary form is outside recursive grammar')
   }
   if (raw === '0' || raw === '1') return atomTree(raw)
-  if (!raw) throw new RecursiveDecodeError('empty raw carrier has no recursive denotation')
+  if (!raw) throw new RecursiveDecodeError('Empty raw carrier has no recursive denotation')
 
   const expanded = restoreCollapsedRootOpens(raw)
   const parsed = parseRoot(expanded)
   if (parsed.position !== expanded.length) {
-    throw new RecursiveDecodeError('recursive Anum carrier has trailing values or brackets')
+    throw new RecursiveDecodeError('Recursive Anum carrier has trailing values or brackets')
   }
   if (canonicalTreeRaw(parsed.tree) !== raw) {
-    throw new RecursiveDecodeError('recursive Anum carrier is not canonical')
+    throw new RecursiveDecodeError('Recursive Anum carrier is not canonical')
   }
   return parsed.tree
 }
@@ -185,20 +268,20 @@ function parseRoot(raw: string): { tree: RecursiveAnumTree; position: number } {
 }
 
 function parseValue(raw: string, position: number): { tree: RecursiveAnumTree; position: number } {
-  if (position >= raw.length) throw new RecursiveDecodeError('recursive Anum value is missing')
+  if (position >= raw.length) throw new RecursiveDecodeError('Recursive Anum value is missing')
 
   const current = raw[position]
   if (current === '0' || current === '1') {
     return { tree: atomTree(current), position: position + 1 }
   }
   if (current !== '[') {
-    throw new RecursiveDecodeError("recursive Anum value must start with atom or '['")
+    throw new RecursiveDecodeError("Recursive Anum value must start with atom or '['")
   }
 
   const start = parseValue(raw, position + 1)
   const end = parseValue(raw, start.position)
   if (end.position >= raw.length || raw[end.position] !== ']') {
-    throw new RecursiveDecodeError('recursive bracket value must close after exactly one pair')
+    throw new RecursiveDecodeError('Recursive bracket value must close after exactly one pair')
   }
   return { tree: linkTree(start.tree, end.tree), position: end.position + 1 }
 }
@@ -241,24 +324,14 @@ function treeToDenotation(tree: RecursiveAnumTree): StructuralAnumDenotation {
 
 function treeFromStructural(value: StructuralAnumDenotation): RecursiveAnumTree {
   const visited = new Set<number>()
-  const usedAnchors = new Set<ProtocolAnchor>()
-
-  value.nodes.forEach((node, index) => {
-    if (node.id !== index) throw new Error('Structural denotation node ids must be dense postorder indices')
-  })
+  const usedAnchors = new Set<string>()
 
   const visit = (ref: DenotationRef): RecursiveAnumTree => {
     if ('anchor' in ref) {
-      if (ref.anchor !== 'protocol:0' && ref.anchor !== 'protocol:1') {
-        throw new Error('Recursive denotation endpoint must be protocol:0 or protocol:1')
-      }
       usedAnchors.add(ref.anchor)
       return atomTree(atomForAnchor(ref.anchor))
     }
 
-    if (!Number.isInteger(ref.node) || ref.node < 0 || ref.node >= value.nodes.length) {
-      throw new Error('Recursive denotation node reference is out of range')
-    }
     if (visited.has(ref.node)) {
       throw new Error('Explicit shared node references are outside occurrence-tree subset')
     }
@@ -273,7 +346,7 @@ function treeFromStructural(value: StructuralAnumDenotation): RecursiveAnumTree 
     throw new Error('Recursive denotation contains unused structural nodes')
   }
 
-  const declared = new Set<ProtocolAnchor>(value.anchors)
+  const declared = new Set(value.anchors)
   if (declared.size !== usedAnchors.size || [...declared].some(anchor => !usedAnchors.has(anchor))) {
     throw new Error('Recursive denotation contains unused or missing anchors')
   }

--- a/src/core/anumDenotation.ts
+++ b/src/core/anumDenotation.ts
@@ -1,0 +1,295 @@
+/**
+ * Storage-neutral Anum L3 denotation consumer.
+ *
+ * Normative behavior is defined by the vendored anum_docs v0.2 contracts and
+ * conformance corpora. This module intentionally has no MemoryView dependency
+ * and performs no realization/materialization.
+ */
+
+import { cleanQuatAnum, validateQuatAnum } from './quatAnum'
+
+export type AnumDenotationContext = 'root' | 'quote' | 'relative'
+export type ProtocolAnchor = 'protocol:0' | 'protocol:1'
+
+export type DenotationRef = { anchor: ProtocolAnchor } | { node: number }
+
+export interface DenotationNode {
+  id: number
+  start: DenotationRef
+  end: DenotationRef
+}
+
+export interface StructuralAnumDenotation {
+  kind: 'structural'
+  anchors: ProtocolAnchor[]
+  nodes: DenotationNode[]
+  root: DenotationRef
+}
+
+export interface RawAnumDenotation {
+  kind: 'raw'
+  raw: string
+}
+
+export interface QuotedRawAnumDenotation {
+  kind: 'quoted-raw'
+  raw: string
+}
+
+export type AnumDenotation =
+  | StructuralAnumDenotation
+  | RawAnumDenotation
+  | QuotedRawAnumDenotation
+
+interface AtomTree {
+  kind: 'atom'
+  atom: '0' | '1'
+}
+
+interface LinkTree {
+  kind: 'link'
+  start: RecursiveAnumTree
+  end: RecursiveAnumTree
+}
+
+type RecursiveAnumTree = AtomTree | LinkTree
+
+class RecursiveDecodeError extends Error {}
+
+function normalizeRaw(raw: string): string {
+  const validation = validateQuatAnum(raw)
+  if (!validation.valid) {
+    throw new Error(validation.error ?? 'Invalid Anum raw carrier')
+  }
+  return cleanQuatAnum(raw)
+}
+
+function anchorForAtom(atom: '0' | '1'): ProtocolAnchor {
+  return atom === '0' ? 'protocol:0' : 'protocol:1'
+}
+
+function atomForAnchor(anchor: ProtocolAnchor): '0' | '1' {
+  return anchor === 'protocol:0' ? '0' : '1'
+}
+
+function anchorDenotation(anchor: ProtocolAnchor): StructuralAnumDenotation {
+  return {
+    kind: 'structural',
+    anchors: [anchor],
+    nodes: [],
+    root: { anchor },
+  }
+}
+
+function pairDenotation(start: ProtocolAnchor, end: ProtocolAnchor): StructuralAnumDenotation {
+  return {
+    kind: 'structural',
+    anchors: [...new Set<ProtocolAnchor>([start, end])].sort(),
+    nodes: [{ id: 0, start: { anchor: start }, end: { anchor: end } }],
+    root: { node: 0 },
+  }
+}
+
+function denotatePairSubset(raw: string, context: AnumDenotationContext): AnumDenotation {
+  if (context === 'quote') {
+    const quoted = raw.length >= 2 && raw.startsWith('[') && raw.endsWith(']')
+      ? raw.slice(1, -1)
+      : raw
+    return { kind: 'quoted-raw', raw: quoted }
+  }
+
+  if (context === 'relative') return { kind: 'raw', raw }
+
+  if (raw === '0' || raw === '][') return anchorDenotation('protocol:0')
+  if (raw === '1' || raw === '[]') return anchorDenotation('protocol:1')
+
+  if (raw.length === 2 && /^[01]{2}$/.test(raw)) {
+    const start = anchorForAtom(raw[0] as '0' | '1')
+    const end = anchorForAtom(raw[1] as '0' | '1')
+    return pairDenotation(start, end)
+  }
+
+  return { kind: 'raw', raw }
+}
+
+/** Execute the accepted pair + recursive v0.2 denotation observable behavior. */
+export function denotateAnum(
+  source: string,
+  context: AnumDenotationContext = 'root'
+): AnumDenotation {
+  const raw = normalizeRaw(source)
+  const base = denotatePairSubset(raw, context)
+
+  if (context !== 'root' || base.kind === 'structural') return base
+  if (raw === '[[' || raw === ']]') return base
+
+  try {
+    return treeToDenotation(decodeRecursiveTree(raw))
+  } catch (error) {
+    if (error instanceof RecursiveDecodeError) return base
+    throw error
+  }
+}
+
+/** Canonical inverse for structural occurrence trees in the accepted v0.2 subset. */
+export function canonicalAnum(value: AnumDenotation): string {
+  if (value.kind !== 'structural') {
+    throw new Error('Only structural Anum denotations have a canonical inverse')
+  }
+  return canonicalTreeRaw(treeFromStructural(value))
+}
+
+function atomTree(atom: '0' | '1'): AtomTree {
+  return { kind: 'atom', atom }
+}
+
+function linkTree(start: RecursiveAnumTree, end: RecursiveAnumTree): LinkTree {
+  return { kind: 'link', start, end }
+}
+
+function decodeRecursiveTree(raw: string): RecursiveAnumTree {
+  if (raw === '[]' || raw === '][' || raw === '[[' || raw === ']]') {
+    throw new RecursiveDecodeError('special boundary form is outside recursive grammar')
+  }
+  if (raw === '0' || raw === '1') return atomTree(raw)
+  if (!raw) throw new RecursiveDecodeError('empty raw carrier has no recursive denotation')
+
+  const expanded = restoreCollapsedRootOpens(raw)
+  const parsed = parseRoot(expanded)
+  if (parsed.position !== expanded.length) {
+    throw new RecursiveDecodeError('recursive Anum carrier has trailing values or brackets')
+  }
+  if (canonicalTreeRaw(parsed.tree) !== raw) {
+    throw new RecursiveDecodeError('recursive Anum carrier is not canonical')
+  }
+  return parsed.tree
+}
+
+function restoreCollapsedRootOpens(raw: string): string {
+  if (!raw.startsWith('[')) return raw
+
+  let balance = 0
+  for (const char of raw) {
+    if (char === '[') balance++
+    else if (char === ']') balance--
+  }
+  return balance < 0 ? '['.repeat(-balance) + raw : raw
+}
+
+function collapseRootOpens(expanded: string): string {
+  let count = 0
+  while (count < expanded.length && expanded[count] === '[') count++
+  return count <= 1 ? expanded : '[' + expanded.slice(count)
+}
+
+function parseRoot(raw: string): { tree: RecursiveAnumTree; position: number } {
+  if (raw === '0' || raw === '1') return { tree: atomTree(raw), position: 1 }
+
+  const start = parseValue(raw, 0)
+  const end = parseValue(raw, start.position)
+  return { tree: linkTree(start.tree, end.tree), position: end.position }
+}
+
+function parseValue(raw: string, position: number): { tree: RecursiveAnumTree; position: number } {
+  if (position >= raw.length) throw new RecursiveDecodeError('recursive Anum value is missing')
+
+  const current = raw[position]
+  if (current === '0' || current === '1') {
+    return { tree: atomTree(current), position: position + 1 }
+  }
+  if (current !== '[') {
+    throw new RecursiveDecodeError("recursive Anum value must start with atom or '['")
+  }
+
+  const start = parseValue(raw, position + 1)
+  const end = parseValue(raw, start.position)
+  if (end.position >= raw.length || raw[end.position] !== ']') {
+    throw new RecursiveDecodeError('recursive bracket value must close after exactly one pair')
+  }
+  return { tree: linkTree(start.tree, end.tree), position: end.position + 1 }
+}
+
+function encodePairExpanded(tree: LinkTree): string {
+  return encodeValueExpanded(tree.start) + encodeValueExpanded(tree.end)
+}
+
+function encodeValueExpanded(tree: RecursiveAnumTree): string {
+  if (tree.kind === 'atom') return tree.atom
+  return '[' + encodePairExpanded(tree) + ']'
+}
+
+function canonicalTreeRaw(tree: RecursiveAnumTree): string {
+  if (tree.kind === 'atom') return tree.atom
+  return collapseRootOpens(encodePairExpanded(tree))
+}
+
+function treeToDenotation(tree: RecursiveAnumTree): StructuralAnumDenotation {
+  const nodes: DenotationNode[] = []
+  const anchors = new Set<ProtocolAnchor>()
+
+  const emit = (item: RecursiveAnumTree): DenotationRef => {
+    if (item.kind === 'atom') {
+      const anchor = anchorForAtom(item.atom)
+      anchors.add(anchor)
+      return { anchor }
+    }
+
+    const start = emit(item.start)
+    const end = emit(item.end)
+    const id = nodes.length
+    nodes.push({ id, start, end })
+    return { node: id }
+  }
+
+  return {
+    kind: 'structural',
+    anchors: [...anchors].sort(),
+    nodes,
+    root: emit(tree),
+  }
+}
+
+function treeFromStructural(value: StructuralAnumDenotation): RecursiveAnumTree {
+  const visited = new Set<number>()
+  const usedAnchors = new Set<ProtocolAnchor>()
+
+  value.nodes.forEach((node, index) => {
+    if (node.id !== index) throw new Error('Structural denotation node ids must be dense postorder indices')
+  })
+
+  const visit = (ref: DenotationRef): RecursiveAnumTree => {
+    if ('anchor' in ref) {
+      if (ref.anchor !== 'protocol:0' && ref.anchor !== 'protocol:1') {
+        throw new Error('Recursive denotation endpoint must be protocol:0 or protocol:1')
+      }
+      usedAnchors.add(ref.anchor)
+      return atomTree(atomForAnchor(ref.anchor))
+    }
+
+    if (!Number.isInteger(ref.node) || ref.node < 0 || ref.node >= value.nodes.length) {
+      throw new Error('Recursive denotation node reference is out of range')
+    }
+    if (visited.has(ref.node)) {
+      throw new Error('Explicit shared node references are outside occurrence-tree subset')
+    }
+
+    visited.add(ref.node)
+    const node = value.nodes[ref.node]
+    return linkTree(visit(node.start), visit(node.end))
+  }
+
+  const tree = visit(value.root)
+  if (visited.size !== value.nodes.length) {
+    throw new Error('Recursive denotation contains unused structural nodes')
+  }
+
+  const declared = new Set<ProtocolAnchor>(value.anchors)
+  if (
+    declared.size !== usedAnchors.size ||
+    [...declared].some(anchor => !usedAnchors.has(anchor))
+  ) {
+    throw new Error('Recursive denotation contains unused or missing anchors')
+  }
+
+  return tree
+}

--- a/src/core/anumDenotation.ts
+++ b/src/core/anumDenotation.ts
@@ -58,9 +58,7 @@ class RecursiveDecodeError extends Error {}
 
 function normalizeRaw(raw: string): string {
   const validation = validateQuatAnum(raw)
-  if (!validation.valid) {
-    throw new Error(validation.error ?? 'Invalid Anum raw carrier')
-  }
+  if (!validation.valid) throw new Error(validation.error ?? 'Invalid Anum raw carrier')
   return cleanQuatAnum(raw)
 }
 
@@ -73,12 +71,7 @@ function atomForAnchor(anchor: ProtocolAnchor): '0' | '1' {
 }
 
 function anchorDenotation(anchor: ProtocolAnchor): StructuralAnumDenotation {
-  return {
-    kind: 'structural',
-    anchors: [anchor],
-    nodes: [],
-    root: { anchor },
-  }
+  return { kind: 'structural', anchors: [anchor], nodes: [], root: { anchor } }
 }
 
 function pairDenotation(start: ProtocolAnchor, end: ProtocolAnchor): StructuralAnumDenotation {
@@ -104,15 +97,16 @@ function denotatePairSubset(raw: string, context: AnumDenotationContext): AnumDe
   if (raw === '1' || raw === '[]') return anchorDenotation('protocol:1')
 
   if (raw.length === 2 && /^[01]{2}$/.test(raw)) {
-    const start = anchorForAtom(raw[0] as '0' | '1')
-    const end = anchorForAtom(raw[1] as '0' | '1')
-    return pairDenotation(start, end)
+    return pairDenotation(
+      anchorForAtom(raw[0] as '0' | '1'),
+      anchorForAtom(raw[1] as '0' | '1')
+    )
   }
 
   return { kind: 'raw', raw }
 }
 
-/** Execute the accepted pair + recursive v0.2 denotation observable behavior. */
+/** Execute the accepted pair + recursive v0.2 observable denotation behavior. */
 export function denotateAnum(
   source: string,
   context: AnumDenotationContext = 'root'
@@ -241,12 +235,8 @@ function treeToDenotation(tree: RecursiveAnumTree): StructuralAnumDenotation {
     return { node: id }
   }
 
-  return {
-    kind: 'structural',
-    anchors: [...anchors].sort(),
-    nodes,
-    root: emit(tree),
-  }
+  const root = emit(tree)
+  return { kind: 'structural', anchors: [...anchors].sort(), nodes, root }
 }
 
 function treeFromStructural(value: StructuralAnumDenotation): RecursiveAnumTree {
@@ -284,10 +274,7 @@ function treeFromStructural(value: StructuralAnumDenotation): RecursiveAnumTree 
   }
 
   const declared = new Set<ProtocolAnchor>(value.anchors)
-  if (
-    declared.size !== usedAnchors.size ||
-    [...declared].some(anchor => !usedAnchors.has(anchor))
-  ) {
+  if (declared.size !== usedAnchors.size || [...declared].some(anchor => !usedAnchors.has(anchor))) {
     throw new Error('Recursive denotation contains unused or missing anchors')
   }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -190,7 +190,12 @@ export type {
   QuotedRawAnumDenotation,
   AnumDenotation,
 } from './anumDenotation'
-export { denotateAnum, canonicalAnum } from './anumDenotation'
+export {
+  denotateAnum,
+  validateAnumDenotation,
+  canonicalDenotationJson,
+  canonicalAnum,
+} from './anumDenotation'
 
 export type { FileMetadata, SupportedExtension } from './fileIO'
 export {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -180,6 +180,18 @@ export {
   isQuatAnumContent,
 } from './quatAnum'
 
+export type {
+  AnumDenotationContext,
+  ProtocolAnchor,
+  DenotationRef,
+  DenotationNode,
+  StructuralAnumDenotation,
+  RawAnumDenotation,
+  QuotedRawAnumDenotation,
+  AnumDenotation,
+} from './anumDenotation'
+export { denotateAnum, canonicalAnum } from './anumDenotation'
+
 export type { FileMetadata, SupportedExtension } from './fileIO'
 export {
   SUPPORTED_EXTENSIONS,

--- a/tests/unit/anumDenotation.test.ts
+++ b/tests/unit/anumDenotation.test.ts
@@ -104,7 +104,7 @@ describe('canonical Anum inverse vetoes', () => {
     expect(() => canonicalAnum(value)).toThrow(/shared node references/i)
   })
 
-  it('rejects unused nodes and mismatched anchor declarations', () => {
+  it('rejects unused nodes and invalid or unused anchor declarations', () => {
     const unusedNode: StructuralAnumDenotation = {
       kind: 'structural',
       anchors: ['protocol:0', 'protocol:1'],
@@ -136,7 +136,15 @@ describe('canonical Anum inverse vetoes', () => {
       ],
       root: { node: 0 },
     }
-    expect(() => canonicalAnum(missingAnchor)).toThrow(/unused or missing anchors/i)
+    expect(() => canonicalAnum(missingAnchor)).toThrow(/undeclared anchor/i)
+
+    const unusedAnchor: StructuralAnumDenotation = {
+      kind: 'structural',
+      anchors: ['protocol:0', 'protocol:1'],
+      nodes: [],
+      root: { anchor: 'protocol:0' },
+    }
+    expect(() => canonicalAnum(unusedAnchor)).toThrow(/unused or missing anchors/i)
   })
 
   it('rejects external anchors even when supplied through untyped data', () => {

--- a/tests/unit/anumDenotation.test.ts
+++ b/tests/unit/anumDenotation.test.ts
@@ -1,0 +1,152 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  canonicalAnum,
+  denotateAnum,
+  type AnumDenotation,
+  type AnumDenotationContext,
+  type StructuralAnumDenotation,
+} from '../../src/core/anumDenotation'
+
+interface DenotationCase {
+  name: string
+  raw: string
+  context: AnumDenotationContext
+  expected: AnumDenotation
+  canonicalRaw: string | null
+}
+
+interface ConformanceCorpus {
+  schema: string
+  contract: string
+  status: string
+  cases: DenotationCase[]
+}
+
+function loadCorpus(filename: string): ConformanceCorpus {
+  return JSON.parse(
+    readFileSync(resolve(process.cwd(), `contracts/anum_docs-v0.2/${filename}`), 'utf8')
+  ) as ConformanceCorpus
+}
+
+const pairCorpus = loadCorpus('anum-pair-denotation-conformance-v0.2.json')
+const recursiveCorpus = loadCorpus('anum-recursive-denotation-conformance-v0.2.json')
+
+function runCorpus(corpus: ConformanceCorpus): void {
+  for (const testCase of corpus.cases) {
+    it(testCase.name, () => {
+      const actual = denotateAnum(testCase.raw, testCase.context)
+      expect(actual).toEqual(testCase.expected)
+
+      if (testCase.canonicalRaw !== null) {
+        expect(actual.kind).toBe('structural')
+        expect(canonicalAnum(actual)).toBe(testCase.canonicalRaw)
+      } else {
+        expect(() => canonicalAnum(actual)).toThrow()
+      }
+    })
+  }
+}
+
+describe('Anum pair-denotation v0.2 upstream conformance', () => {
+  it('uses the accepted pinned corpus', () => {
+    expect(pairCorpus.schema).toBe('anum-pair-denotation-conformance/v0.2')
+    expect(pairCorpus.contract).toBe('anum-pair-denotation/v0.2')
+    expect(pairCorpus.status).toBe('accepted')
+  })
+
+  runCorpus(pairCorpus)
+})
+
+describe('Anum recursive-denotation v0.2 upstream conformance', () => {
+  it('uses the accepted pinned corpus', () => {
+    expect(recursiveCorpus.schema).toBe('anum-recursive-denotation-conformance/v0.2')
+    expect(recursiveCorpus.contract).toBe('anum-recursive-denotation/v0.2')
+    expect(recursiveCorpus.status).toBe('accepted')
+  })
+
+  runCorpus(recursiveCorpus)
+
+  it('keeps the noncanonical uncollapsed root spelling raw', () => {
+    expect(denotateAnum('[[01]1]0', 'root')).toEqual({ kind: 'raw', raw: '[[01]1]0' })
+  })
+
+  it('accepts the collapsed canonical root and round-trips it exactly', () => {
+    const value = denotateAnum('[01]1]0', 'root')
+    expect(value.kind).toBe('structural')
+    expect(canonicalAnum(value)).toBe('[01]1]0')
+  })
+
+  it('does not run root recursive grammar in quote or relative context', () => {
+    expect(denotateAnum('[[01]1]', 'quote')).toEqual({ kind: 'quoted-raw', raw: '[01]1' })
+    expect(denotateAnum('[01]1', 'relative')).toEqual({ kind: 'raw', raw: '[01]1' })
+  })
+})
+
+describe('canonical Anum inverse vetoes', () => {
+  it('rejects shared structural node references', () => {
+    const value: StructuralAnumDenotation = {
+      kind: 'structural',
+      anchors: ['protocol:0', 'protocol:1'],
+      nodes: [
+        {
+          id: 0,
+          start: { anchor: 'protocol:0' },
+          end: { anchor: 'protocol:1' },
+        },
+        { id: 1, start: { node: 0 }, end: { node: 0 } },
+      ],
+      root: { node: 1 },
+    }
+
+    expect(() => canonicalAnum(value)).toThrow(/shared node references/i)
+  })
+
+  it('rejects unused nodes and mismatched anchor declarations', () => {
+    const unusedNode: StructuralAnumDenotation = {
+      kind: 'structural',
+      anchors: ['protocol:0', 'protocol:1'],
+      nodes: [
+        {
+          id: 0,
+          start: { anchor: 'protocol:0' },
+          end: { anchor: 'protocol:1' },
+        },
+        {
+          id: 1,
+          start: { anchor: 'protocol:1' },
+          end: { anchor: 'protocol:0' },
+        },
+      ],
+      root: { node: 0 },
+    }
+    expect(() => canonicalAnum(unusedNode)).toThrow(/unused structural nodes/i)
+
+    const missingAnchor: StructuralAnumDenotation = {
+      kind: 'structural',
+      anchors: ['protocol:0'],
+      nodes: [
+        {
+          id: 0,
+          start: { anchor: 'protocol:0' },
+          end: { anchor: 'protocol:1' },
+        },
+      ],
+      root: { node: 0 },
+    }
+    expect(() => canonicalAnum(missingAnchor)).toThrow(/unused or missing anchors/i)
+  })
+
+  it('rejects external anchors even when supplied through untyped data', () => {
+    const external = {
+      kind: 'structural',
+      anchors: ['protocol:x'],
+      nodes: [],
+      root: { anchor: 'protocol:x' },
+    } as unknown as StructuralAnumDenotation
+
+    expect(() => canonicalAnum(external)).toThrow(/protocol:0 or protocol:1/i)
+  })
+})

--- a/tests/unit/anumDenotationContract.test.ts
+++ b/tests/unit/anumDenotationContract.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  canonicalDenotationJson,
+  validateAnumDenotation,
+  type AnumDenotation,
+} from '../../src/core/anumDenotation'
+
+interface BaseCase {
+  name: string
+  value: AnumDenotation
+  canonicalJson: string
+}
+
+interface BaseCorpus {
+  schema: string
+  contract: string
+  status: string
+  cases: BaseCase[]
+}
+
+function loadCorpus(): BaseCorpus {
+  const path = resolve(
+    process.cwd(),
+    'contracts/anum_docs-v0.2/anum-denotation-conformance-v0.2.json'
+  )
+  return JSON.parse(readFileSync(path, 'utf8')) as BaseCorpus
+}
+
+describe('Anum denotation v0.2 base IR contract', () => {
+  const corpus = loadCorpus()
+
+  it('uses the accepted pinned base corpus', () => {
+    expect(corpus.schema).toBe('anum-denotation-conformance/v0.2')
+    expect(corpus.contract).toBe('anum-denotation/v0.2')
+    expect(corpus.status).toBe('accepted')
+  })
+
+  for (const testCase of corpus.cases) {
+    it(`validates and canonicalizes ${testCase.name}`, () => {
+      expect(() => validateAnumDenotation(testCase.value)).not.toThrow()
+      expect(canonicalDenotationJson(testCase.value)).toBe(testCase.canonicalJson)
+    })
+  }
+
+  it('allows opaque anchors and explicit sharing in the general IR', () => {
+    const shared: AnumDenotation = {
+      kind: 'structural',
+      anchors: ['a', 'b'],
+      nodes: [
+        { id: 0, start: { anchor: 'a' }, end: { anchor: 'b' } },
+        { id: 1, start: { node: 0 }, end: { node: 0 } },
+      ],
+      root: { node: 1 },
+    }
+    expect(() => validateAnumDenotation(shared)).not.toThrow()
+  })
+
+  it('rejects undeclared anchors', () => {
+    const value = {
+      kind: 'structural',
+      anchors: ['a'],
+      nodes: [],
+      root: { anchor: 'b' },
+    } as AnumDenotation
+    expect(() => validateAnumDenotation(value)).toThrow(/undeclared anchor/i)
+  })
+
+  it('rejects forward node references', () => {
+    const value = {
+      kind: 'structural',
+      anchors: ['a'],
+      nodes: [
+        { id: 0, start: { node: 1 }, end: { anchor: 'a' } },
+        { id: 1, start: { anchor: 'a' }, end: { anchor: 'a' } },
+      ],
+      root: { node: 1 },
+    } as AnumDenotation
+    expect(() => validateAnumDenotation(value)).toThrow(/earlier node/i)
+  })
+
+  it('rejects non-contiguous node ids', () => {
+    const value = {
+      kind: 'structural',
+      anchors: ['a'],
+      nodes: [{ id: 1, start: { anchor: 'a' }, end: { anchor: 'a' } }],
+      root: { node: 0 },
+    } as AnumDenotation
+    expect(() => validateAnumDenotation(value)).toThrow(/contiguous and ordered/i)
+  })
+
+  it('rejects mixed reference shapes from untyped data', () => {
+    const value = {
+      kind: 'structural',
+      anchors: ['a'],
+      nodes: [],
+      root: { anchor: 'a', node: 0 },
+    } as unknown as AnumDenotation
+    expect(() => validateAnumDenotation(value)).toThrow(/exactly one anchor or node/i)
+  })
+
+  it('rejects unsorted, duplicate, or empty anchor declarations', () => {
+    const withAnchors = (anchors: string[]): AnumDenotation => ({
+      kind: 'structural',
+      anchors,
+      nodes: [],
+      root: { anchor: anchors[0] ?? '' },
+    })
+
+    expect(() => validateAnumDenotation(withAnchors(['b', 'a']))).toThrow(/sorted/i)
+    expect(() => validateAnumDenotation(withAnchors(['a', 'a']))).toThrow(/unique/i)
+    expect(() => validateAnumDenotation(withAnchors(['']))).toThrow(/non-empty/i)
+  })
+})


### PR DESCRIPTION
Closes #129.

Добавляет один TypeScript consumer accepted Anum L3 contracts из vendored `anum_docs`, без новой normative semantics и без L4 effects.

## Base storage-neutral IR

- `validateAnumDenotation()` исполняет invariants `anum-denotation/v0.2`;
- general IR сохраняет **opaque string anchors** и явный node sharing;
- проверяются sorted/unique/non-empty anchors, contiguous node ids, exact ref shape и topology `node ref -> только более ранний node`;
- `canonicalDenotationJson()` напрямую проходит `anum-denotation-conformance-v0.2.json` и воспроизводит upstream deterministic compact JSON.

## Pair + recursive producer consumer

- `denotateAnum(raw, context)` исполняет pair/boundary subset и root recursive subset;
- quote снимает ровно одну внешнюю envelope, relative остаётся raw;
- special boundary precedence сохраняется;
- recursive root-opening restore/collapse и exact canonicality veto реализованы по pinned v0.2 observable behavior;
- generated structural IR occurrence-preserving/postorder и использует только `protocol:0/1` anchors;
- unit suite напрямую исполняет `anum-pair-denotation-conformance-v0.2.json` и `anum-recursive-denotation-conformance-v0.2.json`.

## Recursive canonical inverse

`canonicalAnum()` намеренно уже general IR contract: inverse определён только для accepted recursive occurrence-tree subset. Он отвергает shared/unused nodes, undeclared/unused anchors и external non-protocol anchors.

## Architecture boundary

- нет `MemoryView` dependency;
- нет `realize`/materialization/delete;
- raw carrier и denotation остаются разными стадиями;
- нет второго parser-а/versioned local semantics;
- normative behavior остаётся в pinned upstream contracts/corpora;
- UI integration и L4 realization вынесены в отдельные следующие slices.

Draft до полного CI и проверки `behind_by=0`; merge только с expected-head guard.