### PR TITLE
Показать Anum denotation v0.2 в read-only UI

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,7 @@ import ASTViewer from './components/ASTViewer.vue'
 import ErrorPanel from './components/ErrorPanel.vue'
 import LinkGraphViewer from './components/LinkGraphViewer.vue'
 import ProofReplayPanel from './components/ProofReplayPanel.vue'
+import AnumDenotationPanel from './components/AnumDenotationPanel.vue'
 import SplitPane from './components/SplitPane.vue'
 import {
   readFileContent,
@@ -65,6 +66,7 @@ const recentFiles = ref<FileMetadata[]>([])
 const showConversion = ref(false)
 const conversionSteps = ref<ConversionStep[]>([])
 const quatConversionSteps = ref<QuatConversionStep[]>([])
+const anumRawLines = ref<string[]>([])
 
 const appVersion = __APP_VERSION__
 const splitPaneRef = ref<InstanceType<typeof SplitPane> | null>(null)
@@ -130,6 +132,7 @@ const loadFile = async (file: globalThis.File) => {
     currentFileName.value = file.name
     conversionSteps.value = []
     quatConversionSteps.value = []
+    anumRawLines.value = []
     showConversion.value = false
 
     if (extension === '.astr') {
@@ -143,6 +146,7 @@ const loadFile = async (file: globalThis.File) => {
     } else if (extension === '.anum') {
       currentFileType.value = 'anum'
       const lines = content.split('\n').filter(line => line.trim() && !line.trim().startsWith('//'))
+      anumRawLines.value = lines.map(line => line.trim())
       if (lines.length) {
         quatConversionSteps.value = visualizeQuatConversion(lines[0].trim())
         showConversion.value = true
@@ -175,6 +179,7 @@ const handleNewFile = () => {
   showConversion.value = false
   conversionSteps.value = []
   quatConversionSteps.value = []
+  anumRawLines.value = []
   input.value = CANONICAL_ROOT
 }
 
@@ -329,6 +334,10 @@ onUnmounted(() => {
         <code>{{ step.formal }}</code>
       </div>
     </div>
+    <AnumDenotationPanel
+      v-if="showConversion && currentFileType === 'anum' && anumRawLines.length"
+      :raw-lines="anumRawLines"
+    />
 
     <ErrorPanel :error="error" />
 

--- a/src/components/AnumDenotationPanel.vue
+++ b/src/components/AnumDenotationPanel.vue
@@ -1,0 +1,252 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import {
+  canonicalAnum,
+  denotateAnum,
+  type AnumDenotationContext,
+  type DenotationRef,
+} from '../core/anumDenotation'
+
+const props = defineProps<{
+  rawLines: string[]
+}>()
+
+const context = ref<AnumDenotationContext>('root')
+
+const formatRef = (ref: DenotationRef): string =>
+  'anchor' in ref ? `anchor:${ref.anchor}` : `node:${ref.node}`
+
+const entries = computed(() =>
+  props.rawLines.map((raw, index) => {
+    try {
+      const value = denotateAnum(raw, context.value)
+      let canonicalRaw: string | null = null
+      let inverseError: string | null = null
+
+      if (value.kind === 'structural') {
+        try {
+          canonicalRaw = canonicalAnum(value)
+        } catch (cause) {
+          inverseError = cause instanceof Error ? cause.message : 'Canonical inverse unavailable'
+        }
+      }
+
+      return { index, raw, value, canonicalRaw, inverseError, error: null as string | null }
+    } catch (cause) {
+      return {
+        index,
+        raw,
+        value: null,
+        canonicalRaw: null,
+        inverseError: null,
+        error: cause instanceof Error ? cause.message : 'Denotation failed',
+      }
+    }
+  })
+)
+</script>
+
+<template>
+  <section class="anum-denotation-panel" aria-label="Anum denotation v0.2">
+    <header class="denotation-header">
+      <div>
+        <strong>Anum denotation v0.2</strong>
+        <span class="boundary">read-only L3 consumer</span>
+      </div>
+      <label class="context-control">
+        Context
+        <select v-model="context" aria-label="Anum denotation context">
+          <option value="root">root</option>
+          <option value="quote">quote</option>
+          <option value="relative">relative</option>
+        </select>
+      </label>
+    </header>
+
+    <div class="denotation-content">
+      <div v-if="entries.length === 0" class="empty">No Anum source lines</div>
+
+      <article v-for="entry in entries" :key="`${entry.index}:${entry.raw}`" class="entry">
+        <div class="entry-heading">
+          <span>line {{ entry.index + 1 }}</span>
+          <code class="source">{{ entry.raw }}</code>
+          <span v-if="entry.value" class="kind">{{ entry.value.kind }}</span>
+        </div>
+
+        <div v-if="entry.error" class="error" role="alert">{{ entry.error }}</div>
+
+        <template v-else-if="entry.value?.kind === 'structural'">
+          <dl class="summary">
+            <dt>anchors</dt>
+            <dd><code>{{ entry.value.anchors.join(', ') || 'none' }}</code></dd>
+            <dt>root</dt>
+            <dd><code>{{ formatRef(entry.value.root) }}</code></dd>
+            <dt>canonicalRaw</dt>
+            <dd>
+              <code v-if="entry.canonicalRaw !== null">{{ entry.canonicalRaw }}</code>
+              <span v-else class="muted">not defined for this general IR value</span>
+            </dd>
+          </dl>
+
+          <div v-if="entry.inverseError" class="inverse-note">
+            {{ entry.inverseError }}
+          </div>
+
+          <table v-if="entry.value.nodes.length" class="nodes">
+            <thead>
+              <tr><th>id</th><th>start</th><th>end</th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="node in entry.value.nodes" :key="node.id">
+                <td><code>{{ node.id }}</code></td>
+                <td><code>{{ formatRef(node.start) }}</code></td>
+                <td><code>{{ formatRef(node.end) }}</code></td>
+              </tr>
+            </tbody>
+          </table>
+          <div v-else class="muted">No structural nodes; root is an anchor.</div>
+        </template>
+
+        <dl v-else-if="entry.value" class="summary">
+          <dt>payload</dt>
+          <dd><code>{{ entry.value.raw }}</code></dd>
+        </dl>
+      </article>
+
+      <footer class="veto-note">
+        Presentation only — no MemoryView, realize, delete or materialization action.
+      </footer>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.anum-denotation-panel {
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--panel-bg);
+  overflow: hidden;
+}
+
+.denotation-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--accent-color);
+  font-size: 0.8rem;
+}
+
+.denotation-header > div {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.boundary,
+.muted,
+.inverse-note,
+.veto-note {
+  color: #64748b;
+  font-size: 0.75rem;
+}
+
+.context-control {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #94a3b8;
+}
+
+.context-control select {
+  background: var(--bg-color);
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  padding: 0.2rem 0.35rem;
+}
+
+.denotation-content {
+  padding: 0.65rem;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.entry {
+  padding: 0.55rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.entry + .entry {
+  margin-top: 0.55rem;
+}
+
+.entry-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 0.76rem;
+}
+
+.source {
+  color: #c4b5fd;
+}
+
+.kind {
+  margin-left: auto;
+  color: #94a3b8;
+}
+
+.summary {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 0.25rem 0.7rem;
+  margin: 0.55rem 0 0;
+  font-size: 0.75rem;
+}
+
+.summary dt {
+  color: #64748b;
+}
+
+.summary dd {
+  margin: 0;
+  min-width: 0;
+}
+
+.nodes {
+  width: 100%;
+  margin-top: 0.55rem;
+  border-collapse: collapse;
+  font-size: 0.73rem;
+}
+
+.nodes th,
+.nodes td {
+  padding: 0.25rem 0.4rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.error {
+  margin-top: 0.5rem;
+  color: var(--error-color);
+  font-size: 0.75rem;
+}
+
+.inverse-note {
+  margin-top: 0.4rem;
+}
+
+.empty {
+  color: #64748b;
+  font-size: 0.8rem;
+}
+
+.veto-note {
+  margin-top: 0.65rem;
+}
+</style>

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -141,6 +141,29 @@ test.describe('aprover canonical MTS v0.2 UI', () => {
     await expect(page.locator('.toolbar-btn[title*="Результаты"]')).toHaveCount(0)
   })
 
+  test('shows read-only Anum denotation for an opened .anum file', async ({ page }) => {
+    const chooserPromise = page.waitForEvent('filechooser')
+    await page.locator('.toolbar-btn[title*="Открыть"]').click()
+    const chooser = await chooserPromise
+    await chooser.setFiles({
+      name: 'sample.anum',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('01\n[01]1\n'),
+    })
+
+    const panel = page.getByLabel('Anum denotation v0.2')
+    await expect(panel).toBeVisible()
+    await expect(panel.locator('.entry')).toHaveCount(2)
+    await expect(panel).toContainText('structural')
+    await expect(panel).toContainText('canonicalRaw')
+    await expect(panel).toContainText('[01]1')
+
+    await panel.getByLabel('Anum denotation context').selectOption('quote')
+    await expect(panel.locator('.kind')).toHaveCount(2)
+    await expect(panel.locator('.kind').first()).toHaveText('quoted-raw')
+    await expect(panel.locator('button')).toHaveCount(0)
+  })
+
   test('creates a new canonical document', async ({ page }) => {
     const editor = page.locator('.code-input')
     await editor.fill('custom')

--- a/tests/unit/AnumDenotationPanel.test.ts
+++ b/tests/unit/AnumDenotationPanel.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import AnumDenotationPanel from '../../src/components/AnumDenotationPanel.vue'
+
+describe('AnumDenotationPanel', () => {
+  it('renders structural root denotation and canonical inverse', () => {
+    const wrapper = mount(AnumDenotationPanel, { props: { rawLines: ['01'] } })
+
+    expect(wrapper.text()).toContain('Anum denotation v0.2')
+    expect(wrapper.text()).toContain('structural')
+    expect(wrapper.text()).toContain('protocol:0')
+    expect(wrapper.text()).toContain('protocol:1')
+    expect(wrapper.text()).toContain('node:0')
+    expect(wrapper.text()).toContain('canonicalRaw')
+    expect(wrapper.text()).toContain('01')
+  })
+
+  it('renders nested recursive nodes in postorder', () => {
+    const wrapper = mount(AnumDenotationPanel, { props: { rawLines: ['[01]1'] } })
+    const rows = wrapper.findAll('tbody tr')
+
+    expect(rows).toHaveLength(2)
+    expect(rows[0].text()).toContain('0')
+    expect(rows[1].text()).toContain('1')
+    expect(wrapper.text()).toContain('[01]1')
+  })
+
+  it('switches to quote and relative context through the same core consumer', async () => {
+    const wrapper = mount(AnumDenotationPanel, { props: { rawLines: ['[01]'] } })
+    const select = wrapper.get('select')
+
+    await select.setValue('quote')
+    expect(wrapper.text()).toContain('quoted-raw')
+    expect(wrapper.text()).toContain('01')
+
+    await select.setValue('relative')
+    expect(wrapper.text()).toContain('raw')
+    expect(wrapper.text()).toContain('[01]')
+  })
+
+  it('renders multiple raw lines independently', () => {
+    const wrapper = mount(AnumDenotationPanel, {
+      props: { rawLines: ['0', '01', '[['] },
+    })
+
+    expect(wrapper.findAll('.entry')).toHaveLength(3)
+    expect(wrapper.text()).toContain('line 1')
+    expect(wrapper.text()).toContain('line 2')
+    expect(wrapper.text()).toContain('line 3')
+    expect(wrapper.text()).toContain('raw')
+  })
+
+  it('contains no L4 mutation controls', () => {
+    const wrapper = mount(AnumDenotationPanel, { props: { rawLines: ['01'] } })
+
+    expect(wrapper.findAll('button')).toHaveLength(0)
+    expect(wrapper.text()).toContain('Presentation only')
+    expect(wrapper.text()).toContain('no MemoryView')
+  })
+})


### PR DESCRIPTION
Closes #131.

Добавляет только application presentation поверх смерженного canonical `denotateAnum()` consumer.

- новый `AnumDenotationPanel.vue`;
- context selector `root|quote|relative`;
- каждая содержательная `.anum` строка denotate-ится отдельно;
- structural view: anchors, postorder nodes, root, `canonicalRaw` когда recursive inverse определён;
- raw/quoted-raw показывают retained payload;
- inverse failure не ломает общий denotation result;
- App хранит raw `.anum` lines отдельно от lossless AbitLit/MTL presentation;
- panel включён в существующий conversion view;
- component tests покрывают structural, nested, context switch, multiple lines и отсутствие mutation buttons.

Veto: компонент не импортирует MemoryView и не содержит realize/delete/materialize actions. Draft до полного CI и проверки текущей базы.