### PR TITLE
Потребить принятую семантику плоских пучков МТС v0.2

### DIFF
--- a/contracts/anum_docs-v0.2/mts-contract-v0.2.json
+++ b/contracts/anum_docs-v0.2/mts-contract-v0.2.json
@@ -55,6 +55,26 @@
     },
     "aroot": {
       "definition": "∞ : {◁ = ∞, ▷ = ∞}"
+    },
+    "valueBundle": {
+      "contract": "contracts/mts-value-bundle-v0.2.json",
+      "conformanceCorpus": "contracts/mts-value-bundle-conformance-v0.2.json",
+      "surface": "{...}",
+      "staticRoles": [
+        "ConstraintBundle",
+        "ValueBundle"
+      ],
+      "runtimeRoleGuessing": false,
+      "valueScope": "flat-only",
+      "semanticIdentity": "extensional-set-of-resolved-link-identities",
+      "sourceOccurrenceProvenance": true,
+      "crossKindSingletonCoercion": false,
+      "nestedValueBundle": false,
+      "bundleValuedDefinition": false,
+      "scalarOperatorLifting": false,
+      "expansionReadOnly": true,
+      "interpretMayRealize": false,
+      "interpretMayDelete": false
     }
   },
   "anum": {
@@ -75,7 +95,10 @@
       "poles",
       "findLink",
       "findStartProjection",
-      "findEndProjection"
+      "findEndProjection",
+      "outgoing",
+      "incoming",
+      "allLinks"
     ],
     "effectOperations": ["realize", "delete"],
     "interpretMayMaterialize": false

--- a/contracts/anum_docs-v0.2/mts-value-bundle-conformance-v0.2.json
+++ b/contracts/anum_docs-v0.2/mts-value-bundle-conformance-v0.2.json
@@ -4,46 +4,208 @@
   "contract": "mts-value-bundle/v0.2",
   "accepted": true,
   "elaboration": [
-    {"id":"constraint-nonempty","source":"{x = y, y != z}","expectedRole":"ConstraintBundle"},
-    {"id":"value-nonempty","source":"{x, y}","expectedRole":"ValueBundle"},
-    {"id":"empty-constraint-entry","source":"{}","context":"constraint-entry","expectedRole":"ConstraintBundle"},
-    {"id":"empty-value-form-position","source":"{} = x","bundlePath":[0],"expectedRole":"ValueBundle"},
-    {"id":"empty-definition-default","source":"x : {}","bundlePath":[1],"expectedRole":"ConstraintBundle"}
+    {
+      "id": "constraint-nonempty",
+      "source": "{x = y, y != z}",
+      "expectedRole": "ConstraintBundle"
+    },
+    {
+      "id": "value-nonempty",
+      "source": "{x, y}",
+      "expectedRole": "ValueBundle"
+    },
+    {
+      "id": "empty-constraint-entry",
+      "source": "{}",
+      "context": "constraint-entry",
+      "expectedRole": "ConstraintBundle"
+    },
+    {
+      "id": "empty-value-form-position",
+      "source": "{} = x",
+      "bundlePath": [0],
+      "expectedRole": "ValueBundle"
+    },
+    {
+      "id": "empty-definition-default",
+      "source": "x : {}",
+      "bundlePath": [1],
+      "expectedRole": "ConstraintBundle"
+    }
   ],
   "staticRejections": [
-    {"id":"mixed-role","source":"{x, y = z}","error":"mixed-bundle-role-evidence"},
-    {"id":"ambiguous-empty","source":"{{}}","error":"ambiguous-empty-bundle-role"},
-    {"id":"nested-value","source":"{{x, y}} = z","error":"nested-value-bundle-not-supported"},
-    {"id":"value-at-constraint-entry","source":"{x, y}","context":"constraint-entry","error":"bundle-role-mismatch"},
-    {"id":"bundle-valued-definition-deferred","source":"b : {x, y}","error":"bundle-valued-definition-deferred"},
-    {"id":"bundle-explicit-link-pole-deferred","source":"{x, y} ⟼ z","error":"bundle-not-supported-in-scalar-operator"},
-    {"id":"bundle-projection-deferred","source":"♀{x, y}","error":"bundle-not-supported-in-scalar-operator"},
-    {"id":"bundle-inversion-deferred","source":"¬{x, y}","error":"bundle-not-supported-in-scalar-operator"},
-    {"id":"bundle-expansion-as-explicit-link-pole-deferred","source":"a{b, c} ⟼ z","error":"bundle-not-supported-in-scalar-operator"}
+    {
+      "id": "mixed-role",
+      "source": "{x, y = z}",
+      "error": "mixed-bundle-role-evidence"
+    },
+    {
+      "id": "ambiguous-empty",
+      "source": "{{}}",
+      "error": "ambiguous-empty-bundle-role"
+    },
+    {
+      "id": "nested-value",
+      "source": "{{x, y}} = z",
+      "error": "nested-value-bundle-not-supported"
+    },
+    {
+      "id": "value-at-constraint-entry",
+      "source": "{x, y}",
+      "context": "constraint-entry",
+      "error": "bundle-role-mismatch"
+    },
+    {
+      "id": "bundle-valued-definition-deferred",
+      "source": "b : {x, y}",
+      "error": "bundle-valued-definition-deferred"
+    },
+    {
+      "id": "bundle-explicit-link-pole-deferred",
+      "source": "{x, y} ⟼ z",
+      "error": "bundle-not-supported-in-scalar-operator"
+    },
+    {
+      "id": "bundle-projection-deferred",
+      "source": "♀{x, y}",
+      "error": "bundle-not-supported-in-scalar-operator"
+    },
+    {
+      "id": "bundle-inversion-deferred",
+      "source": "¬{x, y}",
+      "error": "bundle-not-supported-in-scalar-operator"
+    },
+    {
+      "id": "bundle-expansion-as-explicit-link-pole-deferred",
+      "source": "a{b, c} ⟼ z",
+      "error": "bundle-not-supported-in-scalar-operator"
+    }
   ],
   "valueEquality": [
-    {"id":"order-insensitive","left":"{a, b}","right":"{b, a}","symbols":{"a":10,"b":20},"leftHoles":{},"rightHoles":{},"leftSet":[10,20],"rightSet":[10,20],"equal":true},
-    {"id":"resolved-duplicate-idempotence","left":"{a, a}","right":"{a}","symbols":{"a":10},"leftHoles":{},"rightHoles":{},"leftSet":[10],"rightSet":[10],"equal":true},
-    {"id":"anonymous-different-bindings","left":"{[], []}","right":"{[]}","symbols":{},"leftHoles":{"0":10,"1":20},"rightHoles":{"0":10},"leftSet":[10,20],"rightSet":[10],"equal":false},
-    {"id":"anonymous-same-bindings","left":"{[], []}","right":"{[]}","symbols":{},"leftHoles":{"0":10,"1":10},"rightHoles":{"0":10},"leftSet":[10],"rightSet":[10],"equal":true},
-    {"id":"different-sets","left":"{a, b}","right":"{a}","symbols":{"a":10,"b":20},"leftHoles":{},"rightHoles":{},"leftSet":[10,20],"rightSet":[10],"equal":false}
+    {
+      "id": "order-insensitive",
+      "left": "{a, b}",
+      "right": "{b, a}",
+      "symbols": {"a": 10, "b": 20},
+      "leftHoles": {},
+      "rightHoles": {},
+      "leftSet": [10, 20],
+      "rightSet": [10, 20],
+      "equal": true
+    },
+    {
+      "id": "resolved-duplicate-idempotence",
+      "left": "{a, a}",
+      "right": "{a}",
+      "symbols": {"a": 10},
+      "leftHoles": {},
+      "rightHoles": {},
+      "leftSet": [10],
+      "rightSet": [10],
+      "equal": true
+    },
+    {
+      "id": "anonymous-different-bindings",
+      "left": "{[], []}",
+      "right": "{[]}",
+      "symbols": {},
+      "leftHoles": {"0": 10, "1": 20},
+      "rightHoles": {"0": 10},
+      "leftSet": [10, 20],
+      "rightSet": [10],
+      "equal": false
+    },
+    {
+      "id": "anonymous-same-bindings",
+      "left": "{[], []}",
+      "right": "{[]}",
+      "symbols": {},
+      "leftHoles": {"0": 10, "1": 10},
+      "rightHoles": {"0": 10},
+      "leftSet": [10],
+      "rightSet": [10],
+      "equal": true
+    },
+    {
+      "id": "different-sets",
+      "left": "{a, b}",
+      "right": "{a}",
+      "symbols": {"a": 10, "b": 20},
+      "leftHoles": {},
+      "rightHoles": {},
+      "leftSet": [10, 20],
+      "rightSet": [10],
+      "equal": false
+    }
   ],
   "crossKindComparison": [
-    {"id":"singleton-bundle-vs-scalar","bundle":"{a}","scalar":"a","symbols":{"a":10},"bundleSet":[10],"scalarIdentity":10,"equal":false,"notEqual":true},
-    {"id":"empty-bundle-vs-scalar","bundle":"{}","scalar":"a","symbols":{"a":10},"bundleSet":[],"scalarIdentity":10,"equal":false,"notEqual":true,"context":"form-required"}
+    {
+      "id": "singleton-bundle-vs-scalar",
+      "bundle": "{a}",
+      "scalar": "a",
+      "symbols": {"a": 10},
+      "bundleSet": [10],
+      "scalarIdentity": 10,
+      "equal": false,
+      "notEqual": true
+    },
+    {
+      "id": "empty-bundle-vs-scalar",
+      "bundle": "{}",
+      "scalar": "a",
+      "symbols": {"a": 10},
+      "bundleSet": [],
+      "scalarIdentity": 10,
+      "equal": false,
+      "notEqual": true,
+      "context": "form-required"
+    }
   ],
   "expansionMemory": {
-    "links": {"0":[0,0],"1":[0,1],"2":[1,0],"3":[1,1]},
-    "symbols": {"a":0,"b":1,"c":0,"d":1,"e":2}
+    "links": {
+      "0": [0, 0],
+      "1": [0, 1],
+      "2": [1, 0],
+      "3": [1, 1]
+    },
+    "symbols": {"a": 0, "b": 1, "c": 0, "d": 1, "e": 2}
   },
   "expansion": [
-    {"id":"single-to-bundle","source":"a{c, d}","expectedLinks":[0,1]},
-    {"id":"bundle-to-single","source":"{a, b}d","expectedLinks":[1,3]},
-    {"id":"cartesian-existing","source":"{a, b}{c, d}","expectedLinks":[0,1,2,3]},
-    {"id":"outgoing-wildcard","source":"a{}","expectedLinks":[0,1]},
-    {"id":"incoming-wildcard","source":"{}d","expectedLinks":[1,3]},
-    {"id":"all-links-wildcard","source":"{}{}","expectedLinks":[0,1,2,3]},
-    {"id":"missing-pair-no-realize","source":"a{e}","expectedLinks":[]}
+    {
+      "id": "single-to-bundle",
+      "source": "a{c, d}",
+      "expectedLinks": [0, 1]
+    },
+    {
+      "id": "bundle-to-single",
+      "source": "{a, b}d",
+      "expectedLinks": [1, 3]
+    },
+    {
+      "id": "cartesian-existing",
+      "source": "{a, b}{c, d}",
+      "expectedLinks": [0, 1, 2, 3]
+    },
+    {
+      "id": "outgoing-wildcard",
+      "source": "a{}",
+      "expectedLinks": [0, 1]
+    },
+    {
+      "id": "incoming-wildcard",
+      "source": "{}d",
+      "expectedLinks": [1, 3]
+    },
+    {
+      "id": "all-links-wildcard",
+      "source": "{}{}",
+      "expectedLinks": [0, 1, 2, 3]
+    },
+    {
+      "id": "missing-pair-no-realize",
+      "source": "a{e}",
+      "expectedLinks": []
+    }
   ],
   "veto": {
     "rootDefinitionsChanged": false,

--- a/contracts/anum_docs-v0.2/mts-value-bundle-conformance-v0.2.json
+++ b/contracts/anum_docs-v0.2/mts-value-bundle-conformance-v0.2.json
@@ -1,0 +1,59 @@
+{
+  "schema": "mts-value-bundle-conformance/v0.2",
+  "status": "accepted",
+  "contract": "mts-value-bundle/v0.2",
+  "accepted": true,
+  "elaboration": [
+    {"id":"constraint-nonempty","source":"{x = y, y != z}","expectedRole":"ConstraintBundle"},
+    {"id":"value-nonempty","source":"{x, y}","expectedRole":"ValueBundle"},
+    {"id":"empty-constraint-entry","source":"{}","context":"constraint-entry","expectedRole":"ConstraintBundle"},
+    {"id":"empty-value-form-position","source":"{} = x","bundlePath":[0],"expectedRole":"ValueBundle"},
+    {"id":"empty-definition-default","source":"x : {}","bundlePath":[1],"expectedRole":"ConstraintBundle"}
+  ],
+  "staticRejections": [
+    {"id":"mixed-role","source":"{x, y = z}","error":"mixed-bundle-role-evidence"},
+    {"id":"ambiguous-empty","source":"{{}}","error":"ambiguous-empty-bundle-role"},
+    {"id":"nested-value","source":"{{x, y}} = z","error":"nested-value-bundle-not-supported"},
+    {"id":"value-at-constraint-entry","source":"{x, y}","context":"constraint-entry","error":"bundle-role-mismatch"},
+    {"id":"bundle-valued-definition-deferred","source":"b : {x, y}","error":"bundle-valued-definition-deferred"},
+    {"id":"bundle-explicit-link-pole-deferred","source":"{x, y} ⟼ z","error":"bundle-not-supported-in-scalar-operator"},
+    {"id":"bundle-projection-deferred","source":"♀{x, y}","error":"bundle-not-supported-in-scalar-operator"},
+    {"id":"bundle-inversion-deferred","source":"¬{x, y}","error":"bundle-not-supported-in-scalar-operator"},
+    {"id":"bundle-expansion-as-explicit-link-pole-deferred","source":"a{b, c} ⟼ z","error":"bundle-not-supported-in-scalar-operator"}
+  ],
+  "valueEquality": [
+    {"id":"order-insensitive","left":"{a, b}","right":"{b, a}","symbols":{"a":10,"b":20},"leftHoles":{},"rightHoles":{},"leftSet":[10,20],"rightSet":[10,20],"equal":true},
+    {"id":"resolved-duplicate-idempotence","left":"{a, a}","right":"{a}","symbols":{"a":10},"leftHoles":{},"rightHoles":{},"leftSet":[10],"rightSet":[10],"equal":true},
+    {"id":"anonymous-different-bindings","left":"{[], []}","right":"{[]}","symbols":{},"leftHoles":{"0":10,"1":20},"rightHoles":{"0":10},"leftSet":[10,20],"rightSet":[10],"equal":false},
+    {"id":"anonymous-same-bindings","left":"{[], []}","right":"{[]}","symbols":{},"leftHoles":{"0":10,"1":10},"rightHoles":{"0":10},"leftSet":[10],"rightSet":[10],"equal":true},
+    {"id":"different-sets","left":"{a, b}","right":"{a}","symbols":{"a":10,"b":20},"leftHoles":{},"rightHoles":{},"leftSet":[10,20],"rightSet":[10],"equal":false}
+  ],
+  "crossKindComparison": [
+    {"id":"singleton-bundle-vs-scalar","bundle":"{a}","scalar":"a","symbols":{"a":10},"bundleSet":[10],"scalarIdentity":10,"equal":false,"notEqual":true},
+    {"id":"empty-bundle-vs-scalar","bundle":"{}","scalar":"a","symbols":{"a":10},"bundleSet":[],"scalarIdentity":10,"equal":false,"notEqual":true,"context":"form-required"}
+  ],
+  "expansionMemory": {
+    "links": {"0":[0,0],"1":[0,1],"2":[1,0],"3":[1,1]},
+    "symbols": {"a":0,"b":1,"c":0,"d":1,"e":2}
+  },
+  "expansion": [
+    {"id":"single-to-bundle","source":"a{c, d}","expectedLinks":[0,1]},
+    {"id":"bundle-to-single","source":"{a, b}d","expectedLinks":[1,3]},
+    {"id":"cartesian-existing","source":"{a, b}{c, d}","expectedLinks":[0,1,2,3]},
+    {"id":"outgoing-wildcard","source":"a{}","expectedLinks":[0,1]},
+    {"id":"incoming-wildcard","source":"{}d","expectedLinks":[1,3]},
+    {"id":"all-links-wildcard","source":"{}{}","expectedLinks":[0,1,2,3]},
+    {"id":"missing-pair-no-realize","source":"a{e}","expectedLinks":[]}
+  ],
+  "veto": {
+    "rootDefinitionsChanged": false,
+    "constraintBundleBehaviorChanged": false,
+    "deduplicateSourceOccurrences": false,
+    "nestedValueBundleAccepted": false,
+    "bundleValuedDefinitionAccepted": false,
+    "scalarOperatorLiftingAccepted": false,
+    "interpretMayRealize": false,
+    "interpretMayDelete": false,
+    "globalRewrite": false
+  }
+}

--- a/contracts/anum_docs-v0.2/mts-value-bundle-v0.2.json
+++ b/contracts/anum_docs-v0.2/mts-value-bundle-v0.2.json
@@ -47,16 +47,46 @@
       "definitionRhs": "existing scalar Form or ConstraintBundle only; ValueBundle deferred"
     },
     "rules": [
-      {"when": "all non-empty direct items are Judgments", "result": "ConstraintBundle"},
-      {"when": "all non-empty direct items are non-bundle Forms in a value-capable context", "result": "ValueBundle"},
-      {"when": "direct items mix Judgment and Form evidence", "result": "static-error:mixed-bundle-role-evidence"},
-      {"when": "empty {} occurs in a statically value-capable position", "result": "ValueBundle"},
-      {"when": "empty {} is the constraint interpretation entry expression", "result": "ConstraintBundle"},
-      {"when": "empty {} is a definition RHS", "result": "ConstraintBundle"},
-      {"when": "non-empty ValueBundle is a definition RHS", "result": "static-error:bundle-valued-definition-deferred"},
-      {"when": "ValueBundle appears under scalar-only ⟼/♀/♂/¬ operand position", "result": "static-error:bundle-not-supported-in-scalar-operator"},
-      {"when": "empty {} has no static role context", "result": "static-error:ambiguous-empty-bundle-role"},
-      {"when": "a ValueBundle directly contains another ValueBundle/CurlySyntax item", "result": "static-error:nested-value-bundle-not-supported"}
+      {
+        "when": "all non-empty direct items are Judgments",
+        "result": "ConstraintBundle"
+      },
+      {
+        "when": "all non-empty direct items are non-bundle Forms in a value-capable context",
+        "result": "ValueBundle"
+      },
+      {
+        "when": "direct items mix Judgment and Form evidence",
+        "result": "static-error:mixed-bundle-role-evidence"
+      },
+      {
+        "when": "empty {} occurs in a statically value-capable position",
+        "result": "ValueBundle"
+      },
+      {
+        "when": "empty {} is the constraint interpretation entry expression",
+        "result": "ConstraintBundle"
+      },
+      {
+        "when": "empty {} is a definition RHS",
+        "result": "ConstraintBundle"
+      },
+      {
+        "when": "non-empty ValueBundle is a definition RHS",
+        "result": "static-error:bundle-valued-definition-deferred"
+      },
+      {
+        "when": "ValueBundle appears under scalar-only ⟼/♀/♂/¬ operand position",
+        "result": "static-error:bundle-not-supported-in-scalar-operator"
+      },
+      {
+        "when": "empty {} has no static role context",
+        "result": "static-error:ambiguous-empty-bundle-role"
+      },
+      {
+        "when": "a ValueBundle directly contains another ValueBundle/CurlySyntax item",
+        "result": "static-error:nested-value-bundle-not-supported"
+      }
     ],
     "rootRegression": {
       "currentTenDefinitionsMustElaborateIdentically": true,
@@ -64,8 +94,15 @@
     }
   },
   "runtimeValueModel": {
-    "scalar": {"kind": "link", "identity": "resolved L1 LinkRef"},
-    "bundle": {"kind": "bundle", "identity": "extensional set of unique resolved L1 LinkRefs", "occurrenceProvenanceSeparate": true},
+    "scalar": {
+      "kind": "link",
+      "identity": "resolved L1 LinkRef"
+    },
+    "bundle": {
+      "kind": "bundle",
+      "identity": "extensional set of unique resolved L1 LinkRefs",
+      "occurrenceProvenanceSeparate": true
+    },
     "crossKindEquality": false,
     "crossKindInequality": true,
     "globalRewrite": false,
@@ -119,7 +156,11 @@
     "expansionIsCommand": false
   },
   "deferred": {
-    "nestedValueBundleSemantics": ["first-class nested collection", "flatten/union", "other construction"],
+    "nestedValueBundleSemantics": [
+      "first-class nested collection",
+      "flatten/union",
+      "other construction"
+    ],
     "bundleValuedDefinitions": "requires a tagged value environment/binding contract",
     "bundleProjectionOrInversion": "requires an explicit lifting rule or rejection in a later version",
     "bundleAsExplicitLinkFormPole": "requires a separate lifting decision; current expansion uses juxtaposition only",

--- a/contracts/anum_docs-v0.2/mts-value-bundle-v0.2.json
+++ b/contracts/anum_docs-v0.2/mts-value-bundle-v0.2.json
@@ -1,0 +1,144 @@
+{
+  "schema": "mts-value-bundle/v0.2",
+  "status": "accepted",
+  "accepted": true,
+  "acceptedContractLinkAllowed": true,
+  "dependsOn": [
+    "mts-contract/v0.2",
+    "mts-bundle-decision/v0.2",
+    "mts-bundle-elaboration-challenge/v0.2",
+    "mts-bundle-algebra-challenge/v0.2",
+    "mts-bundle-expansion-challenge/v0.2"
+  ],
+  "scope": {
+    "valueBundle": "flat only",
+    "constraintBundle": "existing accepted behavior unchanged",
+    "nestedValueBundle": "rejected/deferred",
+    "bundleValuedDefinition": "rejected/deferred",
+    "scalarOperatorLifting": "rejected/deferred",
+    "materialization": "out-of-scope",
+    "persistentStorage": "out-of-scope"
+  },
+  "syntax": {
+    "glyph": "{...}",
+    "surfaceNode": "CurlySyntax",
+    "surfaceNodeIsSemanticType": false,
+    "sourceOrderPreserved": true,
+    "sourceMultiplicityPreserved": true,
+    "sourceOccurrencePathsPreserved": true
+  },
+  "elaboration": {
+    "phase": "static-before-interpretation",
+    "runtimeRoleGuessing": false,
+    "outputs": [
+      "ConstraintBundle",
+      "ValueBundle"
+    ],
+    "operatorDomains": {
+      "constraintEntry": "ConstraintBundle or existing Judgment semantics",
+      "standaloneValueEntry": "flat ValueBundle allowed when value context is explicit",
+      "equalityOperands": "LinkValue or flat ValueBundle",
+      "inequalityOperands": "LinkValue or flat ValueBundle",
+      "sequenceWithBundleOperand": "bundle expansion query",
+      "linkFormOperands": "scalar LinkValue only",
+      "projectionOperand": "scalar LinkValue only",
+      "inversionOperand": "scalar LinkValue only",
+      "definitionTarget": "scalar LinkValue form only",
+      "definitionRhs": "existing scalar Form or ConstraintBundle only; ValueBundle deferred"
+    },
+    "rules": [
+      {"when": "all non-empty direct items are Judgments", "result": "ConstraintBundle"},
+      {"when": "all non-empty direct items are non-bundle Forms in a value-capable context", "result": "ValueBundle"},
+      {"when": "direct items mix Judgment and Form evidence", "result": "static-error:mixed-bundle-role-evidence"},
+      {"when": "empty {} occurs in a statically value-capable position", "result": "ValueBundle"},
+      {"when": "empty {} is the constraint interpretation entry expression", "result": "ConstraintBundle"},
+      {"when": "empty {} is a definition RHS", "result": "ConstraintBundle"},
+      {"when": "non-empty ValueBundle is a definition RHS", "result": "static-error:bundle-valued-definition-deferred"},
+      {"when": "ValueBundle appears under scalar-only ⟼/♀/♂/¬ operand position", "result": "static-error:bundle-not-supported-in-scalar-operator"},
+      {"when": "empty {} has no static role context", "result": "static-error:ambiguous-empty-bundle-role"},
+      {"when": "a ValueBundle directly contains another ValueBundle/CurlySyntax item", "result": "static-error:nested-value-bundle-not-supported"}
+    ],
+    "rootRegression": {
+      "currentTenDefinitionsMustElaborateIdentically": true,
+      "valueBundleMayAppearInCurrentRoot": false
+    }
+  },
+  "runtimeValueModel": {
+    "scalar": {"kind": "link", "identity": "resolved L1 LinkRef"},
+    "bundle": {"kind": "bundle", "identity": "extensional set of unique resolved L1 LinkRefs", "occurrenceProvenanceSeparate": true},
+    "crossKindEquality": false,
+    "crossKindInequality": true,
+    "globalRewrite": false,
+    "equality": "local contextual value comparison"
+  },
+  "elementResolution": {
+    "eachOccurrenceResolvedIndependently": true,
+    "deduplicateBeforeResolution": false,
+    "anonymousSquareIdentity": "ast-occurrence-path",
+    "unresolvedAnonymousOccurrence": "evaluation-unresolved/failure; never choose an arbitrary LinkRef",
+    "resolvedOccurrenceTraceRequired": true,
+    "semanticSetBuiltAfterResolution": true,
+    "semanticOrderRelevant": false,
+    "semanticDuplicateCountRelevant": false
+  },
+  "flatValueAlgebra": {
+    "idempotentAfterResolution": true,
+    "commutativeAfterResolution": true,
+    "sourceOrderStillObservableAsProvenance": true,
+    "sourceDuplicateOccurrencesStillObservableAsProvenance": true,
+    "historicalAnonymousClaim": {
+      "source": "{[], []} = {[]}",
+      "unconditional": false,
+      "conditional": "true only when independently resolved identity sets are equal"
+    }
+  },
+  "expansionQuery": {
+    "trigger": "Sequence/juxtaposition with exactly two endpoints and at least one statically elaborated ValueBundle operand",
+    "result": "flat ValueBundle of existing Link identities",
+    "readOnly": true,
+    "endpointDomains": {
+      "scalar": "singleton resolved identity",
+      "nonEmptyBundle": "resolved extensional identity set",
+      "emptyBundle": "wildcard only in expansion endpoint position"
+    },
+    "operations": {
+      "scalarToEmpty": "all existing outgoing links",
+      "emptyToScalar": "all existing incoming links",
+      "emptyToEmpty": "all existing links in selected memory view",
+      "constrainedToConstrained": "existing exact links whose ordered poles belong to the two endpoint domains"
+    },
+    "missingPair": "omit",
+    "implicitRealize": false,
+    "implicitDelete": false
+  },
+  "effects": {
+    "interpretMayReadMemory": true,
+    "interpretMayRealize": false,
+    "interpretMayDelete": false,
+    "bundleLiteralIsCommand": false,
+    "expansionIsCommand": false
+  },
+  "deferred": {
+    "nestedValueBundleSemantics": ["first-class nested collection", "flatten/union", "other construction"],
+    "bundleValuedDefinitions": "requires a tagged value environment/binding contract",
+    "bundleProjectionOrInversion": "requires an explicit lifting rule or rejection in a later version",
+    "bundleAsExplicitLinkFormPole": "requires a separate lifting decision; current expansion uses juxtaposition only",
+    "syntheticMissingLinkForms": "not part of current contract",
+    "explicitBundleMaterialization": "separate L4 operation if ever needed"
+  },
+  "acceptanceEvidence": {
+    "decision": "contracts/mts-bundle-decision-v0.2.json",
+    "staticElaborationChallenge": "contracts/mts-bundle-elaboration-challenge-v0.2.json",
+    "resolvedIdentityAlgebraChallenge": "contracts/mts-bundle-algebra-challenge-v0.2.json",
+    "readOnlyExpansionChallenge": "contracts/mts-bundle-expansion-challenge-v0.2.json",
+    "referenceCore": "core/mtc_value_bundle.py",
+    "conformanceCorpus": "contracts/mts-value-bundle-conformance-v0.2.json",
+    "rootRegression": "tests/mtc_formulas.mtc",
+    "constraintBundleRegression": "tests/test_mtc_value_bundle_reference.py"
+  },
+  "downstream": {
+    "aproverRepinRequired": true,
+    "consumerMustExecuteConformance": true,
+    "compatibilityImplementationAllowed": false
+  }
+}

--- a/contracts/anum_docs-v0.2/provenance.json
+++ b/contracts/anum_docs-v0.2/provenance.json
@@ -1,10 +1,10 @@
 {
   "sourceRepository": "netkeep80/anum_docs",
-  "sourceCommit": "62901cfc94831af41cf86cdc3acb1507c46c05c7",
+  "sourceCommit": "9278ee3a86af8df7d39ee6bf4ff0b3e14943bd7a",
   "contract": {
     "path": "contracts/mts-contract-v0.2.json",
-    "sourceCommit": "62901cfc94831af41cf86cdc3acb1507c46c05c7",
-    "gitBlobSha": "93c39e34f14fb716d850136249e4928599d75130"
+    "sourceCommit": "9278ee3a86af8df7d39ee6bf4ff0b3e14943bd7a",
+    "gitBlobSha": "d7101f0277ffd9c072648bd821021cf08c0e9df4"
   },
   "conformance": {
     "path": "contracts/mts-conformance-v0.2.json",
@@ -15,6 +15,16 @@
     "path": "contracts/mts-proof-v0.2.json",
     "sourceCommit": "d4d8e7c2291d26ea868d01dcc66f90d1c319c6e9",
     "gitBlobSha": "7c125771be689ce2c825f5fa1be4674527f15dbb"
+  },
+  "valueBundle": {
+    "path": "contracts/mts-value-bundle-v0.2.json",
+    "sourceCommit": "9278ee3a86af8df7d39ee6bf4ff0b3e14943bd7a",
+    "gitBlobSha": "6f6991945adf23aace7da7b3c535a279b751b88a"
+  },
+  "valueBundleConformance": {
+    "path": "contracts/mts-value-bundle-conformance-v0.2.json",
+    "sourceCommit": "9278ee3a86af8df7d39ee6bf4ff0b3e14943bd7a",
+    "gitBlobSha": "ca5a3624f4cf1ab880686807d10d45afbf697670"
   },
   "anumBoundaryProjection": {
     "path": "contracts/anum-boundary-projection-v0.2.json",

--- a/src/core/ast.ts
+++ b/src/core/ast.ts
@@ -56,10 +56,16 @@ export interface NotExpr extends ASTNode {
   operand: ASTNode
 }
 
-/** Bundle syntax { A, B, C }. No value/set algebra is implied by this AST node. */
+/** Фигурная запись { A, B, C }; семантическая роль определяется отдельно. */
 export interface SetExpr extends ASTNode {
   type: 'Set'
   elements: ASTNode[]
+}
+
+/** Каноническое соположение двух и более форм, например a{b,c} или {}{}. */
+export interface SequenceExpr extends ASTNode {
+  type: 'Sequence'
+  items: ASTNode[]
 }
 
 export interface InfinityExpr extends ASTNode {
@@ -146,6 +152,9 @@ export function isNotExpr(node: ASTNode): node is NotExpr {
 export function isSetExpr(node: ASTNode): node is SetExpr {
   return node.type === 'Set'
 }
+export function isSequenceExpr(node: ASTNode): node is SequenceExpr {
+  return node.type === 'Sequence'
+}
 export function isInfinityExpr(node: ASTNode): node is InfinityExpr {
   return node.type === 'Infinity'
 }
@@ -193,6 +202,8 @@ export function astToString(node: ASTNode): string {
       return `¬${astToString((node as NotExpr).operand)}`
     case 'Set':
       return `{${(node as SetExpr).elements.map(astToString).join(', ')}}`
+    case 'Sequence':
+      return (node as SequenceExpr).items.map(astToString).join('')
     case 'Infinity':
       return '∞'
     case 'Num':

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,9 +1,9 @@
 /**
- * aprover public core API.
+ * Публичное ядро aprover.
  *
- * `anum_docs` is the normative source for MTS theory/contracts. This package
- * exposes the canonical parser/runtime plus the pinned mts-proof/v0.2 replay
- * checker; legacy proof and grammar semantics are intentionally not public.
+ * `anum_docs` остаётся нормативным источником теории и контрактов МТС. Здесь
+ * публикуются только единый parser/runtime, принятые consumers и replay-checker;
+ * старые совместимые грамматики и отдельная теория приложения отсутствуют.
  */
 
 export type {
@@ -17,6 +17,7 @@ export type {
   FemaleExpr,
   NotExpr,
   SetExpr,
+  SequenceExpr,
   InfinityExpr,
   NumExpr,
   IdentExpr,
@@ -39,6 +40,7 @@ export {
   isFemaleExpr,
   isNotExpr,
   isSetExpr,
+  isSequenceExpr,
   isInfinityExpr,
   isNumExpr,
   isIdentExpr,
@@ -95,6 +97,28 @@ export { InterpretationError, resolveContextPronoun, interpretConstraints } from
 
 export type { DistinguishedLink } from './memoryView'
 export { ExplicitMemoryView } from './memoryView'
+
+export type {
+  BundleRole,
+  ExpectedBundleRole,
+  BundleRoleAt,
+  BundleElaboration,
+  ResolvedOccurrence,
+  LinkValue,
+  BundleValue,
+  MtsValue,
+  FormResolver,
+  BundleQueryMemory,
+} from './valueBundle'
+export {
+  BundleElaborationError,
+  BundleEvaluationError,
+  elaborateBundles,
+  evaluateFlatValueBundle,
+  valuesEqual,
+  expandBundleQuery,
+  resolveCorpusForm,
+} from './valueBundle'
 
 export type { InterpretationSessionConfig } from './interpretationSession'
 export { InterpretationSession } from './interpretationSession'

--- a/src/core/linkGraph.ts
+++ b/src/core/linkGraph.ts
@@ -1,8 +1,9 @@
 /**
- * Occurrence-preserving link graph projection for МТС.
+ * Проекция AST МТС в граф с сохранением отдельных вхождений.
  *
- * Display labels are presentation only. Equal labels remain distinct graph
- * occurrences unless a canonical runtime explicitly supplies shared identity.
+ * Видимые подписи служат только отображению. Одинаковые подписи остаются
+ * разными вхождениями, пока каноническое исполнение явно не задаст общую
+ * семантическую сущность.
  */
 
 import type { ASTNode } from './ast'
@@ -15,6 +16,7 @@ import {
   isFemaleExpr,
   isNotExpr,
   isSetExpr,
+  isSequenceExpr,
   isInfinityExpr,
   isNumExpr,
   isIdentExpr,
@@ -24,7 +26,13 @@ import {
 import { astToString } from './ast'
 import { escapeLabel } from './utils'
 
-export type LinkGraphNodeType = 'link-center' | 'atom' | 'operator' | 'unary' | 'set'
+export type LinkGraphNodeType =
+  | 'link-center'
+  | 'atom'
+  | 'operator'
+  | 'unary'
+  | 'set'
+  | 'sequence'
 
 export interface LinkGraphNode {
   id: string
@@ -135,13 +143,7 @@ function projectNode(node: ASTNode, state: GraphBuilderState): string {
   }
 
   if (isNotExpr(node)) {
-    const centerId = createNode(
-      state,
-      'not',
-      `¬${getNodeLabel(node.operand)}`,
-      'unary',
-      node
-    )
+    const centerId = createNode(state, 'not', `¬${getNodeLabel(node.operand)}`, 'unary', node)
     const operandId = projectNode(node.operand, state)
     addEdge(state, operandId, centerId, 'relation', '¬')
     return centerId
@@ -176,10 +178,19 @@ function projectNode(node: ASTNode, state: GraphBuilderState): string {
 
   if (isSetExpr(node)) {
     const centerId = createNode(state, 'set', '{…}', 'set', node)
-    for (const element of node.elements) {
+    node.elements.forEach((element, index) => {
       const elementId = projectNode(element, state)
-      addEdge(state, centerId, elementId, 'member')
-    }
+      addEdge(state, centerId, elementId, 'member', String(index))
+    })
+    return centerId
+  }
+
+  if (isSequenceExpr(node)) {
+    const centerId = createNode(state, 'sequence', 'соположение', 'sequence', node)
+    node.items.forEach((item, index) => {
+      const itemId = projectNode(item, state)
+      addEdge(state, centerId, itemId, 'member', String(index))
+    })
     return centerId
   }
 
@@ -249,6 +260,7 @@ export function linkGraphToDOT(graph: LinkGraph, title?: string): string {
     operator: 'shape=diamond, style=filled, fillcolor="#fff3e0"',
     unary: 'shape=ellipse, style=filled, fillcolor="#f3e5f5"',
     set: 'shape=box, style=filled, fillcolor="#e8eaf6"',
+    sequence: 'shape=box, style="filled,rounded", fillcolor="#f5f5f5"',
   }
 
   for (const node of graph.nodes) {

--- a/src/core/memoryView.ts
+++ b/src/core/memoryView.ts
@@ -11,12 +11,11 @@ function pairKey(start: LinkRef, end: LinkRef): string {
 }
 
 /**
- * Immutable application adapter for the read-only memory surface consumed by
- * canonical MTS v0.2 interpretation.
+ * Неизменяемое представление уже различённых связей приложения.
  *
- * Construction is the explicit boundary where already-distinguished links are
- * supplied by the application/storage layer. Interpretation itself receives no
- * mutation API and therefore cannot realize missing links or projections.
+ * Это граница, на которой приложение предоставляет существующие связи ядру
+ * МТС. Интерпретация получает только операции чтения и не может создавать или
+ * удалять связи.
  */
 export class ExplicitMemoryView implements MemoryView {
   private readonly linksById: ReadonlyMap<LinkRef, readonly [LinkRef, LinkRef]>
@@ -88,6 +87,27 @@ export class ExplicitMemoryView implements MemoryView {
 
   findEndProjection(form: LinkRef): LinkRef | undefined {
     return this.endProjections.get(form)
+  }
+
+  /** Все существующие связи с данным первым полюсом. */
+  outgoing(start: LinkRef): readonly LinkRef[] {
+    return [...this.linksById.entries()]
+      .filter(([, poles]) => poles[0] === start)
+      .map(([link]) => link)
+      .sort((left, right) => left - right)
+  }
+
+  /** Все существующие связи с данным вторым полюсом. */
+  incoming(end: LinkRef): readonly LinkRef[] {
+    return [...this.linksById.entries()]
+      .filter(([, poles]) => poles[1] === end)
+      .map(([link]) => link)
+      .sort((left, right) => left - right)
+  }
+
+  /** Все существующие связи в каноническом порядке идентификаторов. */
+  allLinks(): readonly LinkRef[] {
+    return [...this.linksById.keys()].sort((left, right) => left - right)
   }
 
   /** Deterministic copy useful for diagnostics and non-mutation assertions. */

--- a/src/core/memoryView.ts
+++ b/src/core/memoryView.ts
@@ -10,18 +10,22 @@ function pairKey(start: LinkRef, end: LinkRef): string {
   return `${start}:${end}`
 }
 
+type ProjectionIndexValue = LinkRef | null
+
 /**
  * Неизменяемое представление уже различённых связей приложения.
  *
  * Это граница, на которой приложение предоставляет существующие связи ядру
  * МТС. Интерпретация получает только операции чтения и не может создавать или
- * удалять связи.
+ * удалять связи. Проекционные индексы могут быть неоднозначны; такая
+ * неоднозначность становится ошибкой только при запросе соответствующей
+ * проекции и не запрещает хранить саму сеть связей.
  */
 export class ExplicitMemoryView implements MemoryView {
   private readonly linksById: ReadonlyMap<LinkRef, readonly [LinkRef, LinkRef]>
   private readonly linksByPoles: ReadonlyMap<string, LinkRef>
-  private readonly startProjections: ReadonlyMap<LinkRef, LinkRef>
-  private readonly endProjections: ReadonlyMap<LinkRef, LinkRef>
+  private readonly startProjections: ReadonlyMap<LinkRef, ProjectionIndexValue>
+  private readonly endProjections: ReadonlyMap<LinkRef, ProjectionIndexValue>
 
   constructor(links: readonly DistinguishedLink[]) {
     const byId = new Map<LinkRef, readonly [LinkRef, LinkRef]>()
@@ -44,24 +48,20 @@ export class ExplicitMemoryView implements MemoryView {
       byPoles.set(key, link.id)
     }
 
-    const startProjections = new Map<LinkRef, LinkRef>()
-    const endProjections = new Map<LinkRef, LinkRef>()
+    const startProjections = new Map<LinkRef, ProjectionIndexValue>()
+    const endProjections = new Map<LinkRef, ProjectionIndexValue>()
 
     for (const [link, poles] of byId) {
       const [start, end] = poles
       if (start === link) {
         const existing = startProjections.get(end)
-        if (existing !== undefined && existing !== link) {
-          throw new Error(`Ambiguous start projection for form ${end}`)
-        }
-        startProjections.set(end, link)
+        if (existing === undefined) startProjections.set(end, link)
+        else if (existing !== link) startProjections.set(end, null)
       }
       if (end === link) {
         const existing = endProjections.get(start)
-        if (existing !== undefined && existing !== link) {
-          throw new Error(`Ambiguous end projection for form ${start}`)
-        }
-        endProjections.set(start, link)
+        if (existing === undefined) endProjections.set(start, link)
+        else if (existing !== link) endProjections.set(start, null)
       }
     }
 
@@ -82,11 +82,15 @@ export class ExplicitMemoryView implements MemoryView {
   }
 
   findStartProjection(form: LinkRef): LinkRef | undefined {
-    return this.startProjections.get(form)
+    const projection = this.startProjections.get(form)
+    if (projection === null) throw new Error(`Ambiguous start projection for form ${form}`)
+    return projection
   }
 
   findEndProjection(form: LinkRef): LinkRef | undefined {
-    return this.endProjections.get(form)
+    const projection = this.endProjections.get(form)
+    if (projection === null) throw new Error(`Ambiguous end projection for form ${form}`)
+    return projection
   }
 
   /** Все существующие связи с данным первым полюсом. */
@@ -110,7 +114,7 @@ export class ExplicitMemoryView implements MemoryView {
     return [...this.linksById.keys()].sort((left, right) => left - right)
   }
 
-  /** Deterministic copy useful for diagnostics and non-mutation assertions. */
+  /** Детерминированная копия для диагностики и проверки отсутствия мутаций. */
   entries(): readonly (readonly [LinkRef, readonly [LinkRef, LinkRef]])[] {
     return [...this.linksById.entries()]
       .sort(([left], [right]) => left - right)

--- a/src/core/mtsContract.ts
+++ b/src/core/mtsContract.ts
@@ -3,6 +3,24 @@ export interface MtsContextRole {
   role: 'start' | 'end'
 }
 
+export interface MtsValueBundleContractRefV02 {
+  contract: 'contracts/mts-value-bundle-v0.2.json'
+  conformanceCorpus: 'contracts/mts-value-bundle-conformance-v0.2.json'
+  surface: '{...}'
+  staticRoles: ['ConstraintBundle', 'ValueBundle']
+  runtimeRoleGuessing: false
+  valueScope: 'flat-only'
+  semanticIdentity: 'extensional-set-of-resolved-link-identities'
+  sourceOccurrenceProvenance: true
+  crossKindSingletonCoercion: false
+  nestedValueBundle: false
+  bundleValuedDefinition: false
+  scalarOperatorLifting: false
+  expansionReadOnly: true
+  interpretMayRealize: false
+  interpretMayDelete: false
+}
+
 export interface MtsContractV02 {
   schema: 'mts-contract/v0.2'
   status: 'accepted'
@@ -44,6 +62,7 @@ export interface MtsContractV02 {
     aroot: {
       definition: string
     }
+    valueBundle: MtsValueBundleContractRefV02
   }
   anum: {
     operations: ['serialize', 'deserialize']
@@ -137,6 +156,13 @@ function string(value: unknown, name: string): string {
   return value
 }
 
+function exactArray(actual: unknown, expected: readonly unknown[], name: string): void {
+  const values = array(actual, name)
+  if (JSON.stringify(values) !== JSON.stringify(expected)) {
+    throw new TypeError(`${name} must be exactly ${JSON.stringify(expected)}`)
+  }
+}
+
 function validateContextRole(value: unknown, index: number): MtsContextRole {
   const role = record(value, `formalNotation.context.roles[${index}]`)
   const source = string(role.source, `context role ${index} source`)
@@ -150,6 +176,34 @@ function validateContextRole(value: unknown, index: number): MtsContextRole {
     throw new TypeError(`context role ${index} must be start or end`)
   }
   return { source, role: role.role }
+}
+
+function validateValueBundleRef(value: unknown): MtsValueBundleContractRefV02 {
+  const bundle = record(value, 'formalNotation.valueBundle')
+  exact(bundle.contract, 'contracts/mts-value-bundle-v0.2.json', 'valueBundle.contract')
+  exact(
+    bundle.conformanceCorpus,
+    'contracts/mts-value-bundle-conformance-v0.2.json',
+    'valueBundle.conformanceCorpus'
+  )
+  exact(bundle.surface, '{...}', 'valueBundle.surface')
+  exactArray(bundle.staticRoles, ['ConstraintBundle', 'ValueBundle'], 'valueBundle.staticRoles')
+  exact(bundle.runtimeRoleGuessing, false, 'valueBundle.runtimeRoleGuessing')
+  exact(bundle.valueScope, 'flat-only', 'valueBundle.valueScope')
+  exact(
+    bundle.semanticIdentity,
+    'extensional-set-of-resolved-link-identities',
+    'valueBundle.semanticIdentity'
+  )
+  exact(bundle.sourceOccurrenceProvenance, true, 'valueBundle.sourceOccurrenceProvenance')
+  exact(bundle.crossKindSingletonCoercion, false, 'valueBundle.crossKindSingletonCoercion')
+  exact(bundle.nestedValueBundle, false, 'valueBundle.nestedValueBundle')
+  exact(bundle.bundleValuedDefinition, false, 'valueBundle.bundleValuedDefinition')
+  exact(bundle.scalarOperatorLifting, false, 'valueBundle.scalarOperatorLifting')
+  exact(bundle.expansionReadOnly, true, 'valueBundle.expansionReadOnly')
+  exact(bundle.interpretMayRealize, false, 'valueBundle.interpretMayRealize')
+  exact(bundle.interpretMayDelete, false, 'valueBundle.interpretMayDelete')
+  return value as MtsValueBundleContractRefV02
 }
 
 export function validateMtsContractV02(value: unknown): MtsContractV02 {
@@ -203,16 +257,11 @@ export function validateMtsContractV02(value: unknown): MtsContractV02 {
 
   const aroot = record(formalNotation.aroot, 'formalNotation.aroot')
   string(aroot.definition, 'aroot.definition')
+  validateValueBundleRef(formalNotation.valueBundle)
 
   const anum = record(root.anum, 'anum')
-  const anumOperations = array(anum.operations, 'anum.operations')
-  if (JSON.stringify(anumOperations) !== JSON.stringify(['serialize', 'deserialize'])) {
-    throw new TypeError('anum.operations must be exactly serialize/deserialize')
-  }
-  const alphabet = array(anum.alphabet, 'anum.alphabet')
-  if (JSON.stringify(alphabet) !== JSON.stringify(['[', ']', '1', '0'])) {
-    throw new TypeError('anum.alphabet must be exactly [ ] 1 0')
-  }
+  exactArray(anum.operations, ['serialize', 'deserialize'], 'anum.operations')
+  exactArray(anum.alphabet, ['[', ']', '1', '0'], 'anum.alphabet')
   exact(
     anum.rawCarrierDescription,
     'contracts/anum-raw-carrier-v0.2.json',
@@ -243,6 +292,21 @@ export function validateMtsContractV02(value: unknown): MtsContractV02 {
   exact(anum.generalDenotationIssue, 89, 'anum.generalDenotationIssue')
 
   const memory = record(root.memory, 'memory')
+  exactArray(
+    memory.readOperations,
+    [
+      'find',
+      'poles',
+      'findLink',
+      'findStartProjection',
+      'findEndProjection',
+      'outgoing',
+      'incoming',
+      'allLinks',
+    ],
+    'memory.readOperations'
+  )
+  exactArray(memory.effectOperations, ['realize', 'delete'], 'memory.effectOperations')
   exact(memory.interpretMayMaterialize, false, 'memory.interpretMayMaterialize')
 
   const integration = record(root.integration, 'integration')

--- a/src/core/mtsSource.ts
+++ b/src/core/mtsSource.ts
@@ -8,6 +8,7 @@ import type {
   FemaleExpr,
   NotExpr,
   SetExpr,
+  SequenceExpr,
   NumExpr,
   IdentExpr,
   AbitLitExpr,
@@ -22,9 +23,10 @@ const PRECEDENCE = {
   definition: 1,
   equality: 2,
   link: 3,
-  prefix: 4,
-  postfix: 5,
-  atom: 6,
+  sequence: 4,
+  prefix: 5,
+  postfix: 6,
+  atom: 7,
 } as const
 
 function render(node: ASTNode, parentPrecedence = 0, rightOfLeftAssociative = false): string {
@@ -54,6 +56,12 @@ function render(node: ASTNode, parentPrecedence = 0, rightOfLeftAssociative = fa
       const link = node as LinkExpr
       text = `${render(link.left, PRECEDENCE.link)} ⟼ ${render(link.right, PRECEDENCE.link, true)}`
       precedence = PRECEDENCE.link
+      break
+    }
+    case 'Sequence': {
+      const sequence = node as SequenceExpr
+      text = sequence.items.map(item => render(item, PRECEDENCE.sequence)).join('')
+      precedence = PRECEDENCE.sequence
       break
     }
     case 'Not': {
@@ -134,11 +142,11 @@ function render(node: ASTNode, parentPrecedence = 0, rightOfLeftAssociative = fa
 }
 
 /**
- * Serialize one canonical MTS v0.2 AST expression back to formal source.
+ * Преобразует одно каноническое выражение AST МТС v0.2 обратно в исходную запись.
  *
- * This is a syntax formatter only. It preserves explicit Round/Square forms,
- * canonical projection fixity (`♀F`, `F♂`) and bundle order; it does not
- * normalize or interpret the expression.
+ * Это только форматирование синтаксиса: явные круглые/квадратные формы,
+ * фиксация проекций (`♀F`, `F♂`), порядок пучков и соположение сохраняются;
+ * интерпретация или дополнительная нормализация здесь не выполняются.
  */
 export function toMtsSource(node: ASTNode): string {
   return render(node)

--- a/src/core/normalizer.ts
+++ b/src/core/normalizer.ts
@@ -1,11 +1,9 @@
 /**
- * Structural normalizer for the canonical МТС AST consumed from anum_docs.
+ * Структурный нормализатор канонического AST МТС из anum_docs.
  *
- * The parser preserves explicit L2 containers for round-trip/visual identity.
- * Normalization only follows accepted structural rules: non-empty round
- * grouping is transparent and child nodes are normalized recursively. It does
- * not invent inversion algebra, bundle algebra, power expansion or NotLink
- * desugaring that are absent from the upstream MTS v0.2 contract.
+ * Parser сохраняет явные контейнеры. Нормализация следует только принятым
+ * структурным правилам и не добавляет самостоятельную алгебру инверсии,
+ * пучков или старые prover-era преобразования.
  */
 
 import type { ASTNode, DefExpr, Statement, File } from './ast'
@@ -18,6 +16,7 @@ import {
   isFemaleExpr,
   isNotExpr,
   isSetExpr,
+  isSequenceExpr,
   isInfinityExpr,
   isNumExpr,
   isIdentExpr,
@@ -140,6 +139,7 @@ function containsIdent(node: ASTNode, name: string, guarded: boolean): boolean {
     return containsIdent(node.operand, name, guarded)
   }
   if (isSetExpr(node)) return node.elements.some(el => containsIdent(el, name, guarded))
+  if (isSequenceExpr(node)) return node.items.some(item => containsIdent(item, name, guarded))
   if (isDefExpr(node)) {
     return containsIdent(node.name, name, guarded) || containsIdent(node.form, name, guarded)
   }
@@ -162,8 +162,6 @@ function checkGuardedRecursion(def: DefExpr): void {
 
 function normalizeNode(node: ASTNode, options: NormalizerOptions): ASTNode {
   if (isRoundExpr(node)) {
-    // Empty () is a genuine formal atom. Non-empty round grouping is
-    // transparent to semantic matching in the upstream interpreter.
     return node.content === null ? node : normalizeNode(node.content, options)
   }
   if (isSquareExpr(node)) {
@@ -204,6 +202,9 @@ function normalizeNode(node: ASTNode, options: NormalizerOptions): ASTNode {
   if (isSetExpr(node)) {
     return { ...node, elements: node.elements.map(el => normalizeNode(el, options)) }
   }
+  if (isSequenceExpr(node)) {
+    return { ...node, items: node.items.map(item => normalizeNode(item, options)) }
+  }
   return node
 }
 
@@ -240,7 +241,7 @@ export function normalizeFile(file: File, options: Partial<NormalizerOptions> = 
   }
 }
 
-/** Syntax/structure key, not an additional semantic equality relation. */
+/** Структурный ключ синтаксиса, а не дополнительное семантическое равенство. */
 export function toCanonicalString(node: ASTNode): string {
   if (isRoundExpr(node)) {
     return node.content === null ? '()' : `(${toCanonicalString(node.content)})`
@@ -260,6 +261,7 @@ export function toCanonicalString(node: ASTNode): string {
   if (isFemaleExpr(node)) return `♀${toCanonicalString(node.operand)}`
   if (isNotExpr(node)) return `¬${toCanonicalString(node.operand)}`
   if (isSetExpr(node)) return `{${node.elements.map(toCanonicalString).join(',')}}`
+  if (isSequenceExpr(node)) return node.items.map(toCanonicalString).join('')
   if (isInfinityExpr(node)) return '∞'
   if (isNumExpr(node)) return String(node.value)
   if (isIdentExpr(node)) return node.name

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -1,9 +1,8 @@
 /**
- * Parser for the canonical МТС formal notation consumed from anum_docs.
+ * Единственный parser канонической формальной нотации МТС из anum_docs.
  *
- * This is the single aprover parser. Projection fixity follows МТС v0.2:
- * `♀F` is start projection and `F♂` is end projection. Compatibility grammar
- * (`->`, binary `↛`, power, bare `!`) is intentionally absent.
+ * Фиксация проекций v0.2: `♀F` — проекция начала, `F♂` — проекция конца.
+ * Старая совместимая грамматика (`->`, binary `↛`, power, bare `!`) отсутствует.
  */
 
 import type { Token, TokenType } from './lexer'
@@ -20,6 +19,7 @@ import type {
   FemaleExpr,
   NotExpr,
   SetExpr,
+  SequenceExpr,
   InfinityExpr,
   NumExpr,
   IdentExpr,
@@ -56,6 +56,25 @@ const ROUND_LITERALS = new Set<TokenType>([
   'DEFINE',
   'LBRACKET',
   'RBRACKET',
+])
+
+/** Токены, с которых может начинаться следующая форма в соположении. */
+const FORM_STARTS = new Set<TokenType>([
+  'INFINITY',
+  'ZERO',
+  'ONE',
+  'CONTEXT_START',
+  'CONTEXT_END',
+  'CONTEXT_UP',
+  'ID',
+  'NAT',
+  'ABIT_LIT',
+  'STRING_LIT',
+  'LBRACE',
+  'LPAREN',
+  'LBRACKET',
+  'NOT',
+  'FEMALE',
 ])
 
 export class Parser {
@@ -195,12 +214,13 @@ export class Parser {
     return this.parseChain()
   }
 
+  /** `⟼` имеет меньший приоритет, чем соположение форм. */
   private parseChain(): ASTNode {
-    let left = this.parsePref()
+    let left = this.parseSequence()
 
     while (this.check('ARROW')) {
       this.advance()
-      const right = this.parsePref()
+      const right = this.parseSequence()
       left = {
         type: 'Link',
         left,
@@ -212,7 +232,25 @@ export class Parser {
     return left
   }
 
-  /** Canonical prefix operators: inversion `¬` and start projection `♀`. */
+  /** Каноническое соположение: a{b,c}, {}b, {}{}, [][], ... */
+  private parseSequence(): ASTNode {
+    const first = this.parsePref()
+    const items: ASTNode[] = [first]
+
+    while (FORM_STARTS.has(this.current().type)) {
+      items.push(this.parsePref())
+    }
+
+    if (items.length === 1) return first
+    const last = items[items.length - 1]
+    return {
+      type: 'Sequence',
+      items,
+      loc: this.mergeLoc(first.loc!, last.loc!),
+    } as SequenceExpr
+  }
+
+  /** Канонические префиксные операторы: инверсия `¬` и проекция начала `♀`. */
   private parsePref(): ASTNode {
     const prefixes: { type: 'NOT' | 'FEMALE'; loc: SourceLocation }[] = []
 
@@ -244,7 +282,7 @@ export class Parser {
     return node
   }
 
-  /** Canonical postfix operator: end projection `F♂`. */
+  /** Канонический постфиксный оператор: проекция конца `F♂`. */
   private parsePost(): ASTNode {
     let node = this.parseAtom()
 

--- a/src/core/valueBundle.ts
+++ b/src/core/valueBundle.ts
@@ -1,0 +1,375 @@
+import type {
+  ASTNode,
+  SetExpr,
+  SequenceExpr,
+  SquareExpr,
+} from './ast'
+import type { LinkRef, OccurrencePath } from './interpreter'
+
+export type BundleRole = 'ConstraintBundle' | 'ValueBundle'
+export type ExpectedBundleRole = 'none' | 'constraint' | 'value' | 'scalar' | 'definition-rhs'
+
+export interface BundleRoleAt {
+  readonly path: OccurrencePath
+  readonly role: BundleRole
+}
+
+export interface BundleElaboration {
+  readonly roles: readonly BundleRoleAt[]
+}
+
+export interface ResolvedOccurrence {
+  readonly path: OccurrencePath
+  readonly link: LinkRef
+}
+
+export interface LinkValue {
+  readonly kind: 'link'
+  readonly identity: LinkRef
+}
+
+export interface BundleValue {
+  readonly kind: 'bundle'
+  readonly identities: readonly LinkRef[]
+  readonly occurrences: readonly ResolvedOccurrence[]
+}
+
+export type MtsValue = LinkValue | BundleValue
+export type FormResolver = (form: ASTNode, path: OccurrencePath) => LinkRef
+
+/** Минимальная read-only поверхность L4 для раскрытия пучков. */
+export interface BundleQueryMemory {
+  findLink(start: LinkRef, end: LinkRef): LinkRef | undefined
+  outgoing(start: LinkRef): readonly LinkRef[]
+  incoming(end: LinkRef): readonly LinkRef[]
+  allLinks(): readonly LinkRef[]
+}
+
+export class BundleElaborationError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly path: OccurrencePath
+  ) {
+    super(`${code} at [${path.join(',')}]`)
+    this.name = 'BundleElaborationError'
+  }
+}
+
+export class BundleEvaluationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'BundleEvaluationError'
+  }
+}
+
+function isJudgment(node: ASTNode): boolean {
+  return node.type === 'Equality' || node.type === 'Inequality'
+}
+
+function isForm(node: ASTNode): boolean {
+  return !['Definition', 'Equality', 'Inequality', 'Statement', 'File'].includes(node.type)
+}
+
+function roleAt(elaboration: BundleElaboration, path: OccurrencePath): BundleRole | undefined {
+  return elaboration.roles.find(item => samePath(item.path, path))?.role
+}
+
+function samePath(left: OccurrencePath, right: OccurrencePath): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index])
+}
+
+function evidence(bundle: SetExpr): 'constraint' | 'value' | 'mixed' | undefined {
+  const found = new Set<'constraint' | 'value'>()
+  for (const item of bundle.elements) {
+    if (item.type === 'Set') {
+      const child = evidence(item as SetExpr)
+      if (child === 'mixed') return 'mixed'
+      if (child !== undefined) found.add(child)
+    } else if (isJudgment(item)) {
+      found.add('constraint')
+    } else if (isForm(item)) {
+      found.add('value')
+    } else {
+      throw new BundleElaborationError('unsupported-bundle-item', [])
+    }
+  }
+  if (found.size > 1) return 'mixed'
+  return [...found][0]
+}
+
+function containsBundle(node: ASTNode): boolean {
+  if (node.type === 'Set') return true
+  if (node.type === 'Sequence') {
+    return (node as SequenceExpr).items.some(containsBundle)
+  }
+  if (node.type === 'Link' || node.type === 'Equality' || node.type === 'Inequality') {
+    const binary = node as ASTNode & { left: ASTNode; right: ASTNode }
+    return containsBundle(binary.left) || containsBundle(binary.right)
+  }
+  if (node.type === 'Male' || node.type === 'Female' || node.type === 'Not') {
+    return containsBundle((node as ASTNode & { operand: ASTNode }).operand)
+  }
+  if (node.type === 'Round') {
+    const content = (node as ASTNode & { content: ASTNode | null }).content
+    return content !== null && containsBundle(content)
+  }
+  return false
+}
+
+function elaborateSet(
+  bundle: SetExpr,
+  path: OccurrencePath,
+  expected: ExpectedBundleRole,
+  roles: BundleRoleAt[]
+): void {
+  const intrinsic = evidence(bundle)
+  if (intrinsic === 'mixed') {
+    throw new BundleElaborationError('mixed-bundle-role-evidence', path)
+  }
+  if (expected === 'scalar') {
+    throw new BundleElaborationError('bundle-not-supported-in-scalar-operator', path)
+  }
+
+  let role: BundleRole
+  if (expected === 'definition-rhs') {
+    if (intrinsic === 'value') {
+      throw new BundleElaborationError('bundle-valued-definition-deferred', path)
+    }
+    role = 'ConstraintBundle'
+  } else if (expected === 'constraint') {
+    if (intrinsic === 'value') throw new BundleElaborationError('bundle-role-mismatch', path)
+    role = 'ConstraintBundle'
+  } else if (expected === 'value') {
+    if (intrinsic === 'constraint') throw new BundleElaborationError('bundle-role-mismatch', path)
+    role = 'ValueBundle'
+  } else if (intrinsic === 'constraint') {
+    role = 'ConstraintBundle'
+  } else if (intrinsic === 'value') {
+    role = 'ValueBundle'
+  } else {
+    throw new BundleElaborationError('ambiguous-empty-bundle-role', path)
+  }
+
+  if (role === 'ValueBundle' && bundle.elements.some(item => item.type === 'Set')) {
+    throw new BundleElaborationError('nested-value-bundle-not-supported', path)
+  }
+
+  roles.push({ path: [...path], role })
+  const childExpected: ExpectedBundleRole = role === 'ConstraintBundle' ? 'constraint' : 'scalar'
+  bundle.elements.forEach((item, index) => {
+    elaborateExpression(item, [...path, index], childExpected, roles)
+  })
+}
+
+function elaborateExpression(
+  node: ASTNode,
+  path: OccurrencePath,
+  expected: ExpectedBundleRole,
+  roles: BundleRoleAt[]
+): void {
+  if (node.type === 'Set') {
+    elaborateSet(node as SetExpr, path, expected, roles)
+    return
+  }
+
+  if (node.type === 'Definition') {
+    if (expected === 'scalar' || expected === 'value' || expected === 'constraint') {
+      throw new BundleElaborationError('expression-role-mismatch', path)
+    }
+    const definition = node as ASTNode & { name: ASTNode; form: ASTNode }
+    elaborateExpression(definition.name, [...path, 0], 'scalar', roles)
+    elaborateExpression(definition.form, [...path, 1], 'definition-rhs', roles)
+    return
+  }
+
+  if (node.type === 'Equality' || node.type === 'Inequality') {
+    if (expected === 'scalar') throw new BundleElaborationError('expression-role-mismatch', path)
+    const judgment = node as ASTNode & { left: ASTNode; right: ASTNode }
+    elaborateExpression(judgment.left, [...path, 0], 'value', roles)
+    elaborateExpression(judgment.right, [...path, 1], 'value', roles)
+    return
+  }
+
+  if (node.type === 'Sequence') {
+    if (expected === 'constraint') throw new BundleElaborationError('expression-role-mismatch', path)
+    if (expected === 'scalar' && containsBundle(node)) {
+      throw new BundleElaborationError('bundle-not-supported-in-scalar-operator', path)
+    }
+    if (expected === 'definition-rhs' && containsBundle(node)) {
+      throw new BundleElaborationError('bundle-valued-definition-deferred', path)
+    }
+    ;(node as SequenceExpr).items.forEach((item, index) => {
+      elaborateExpression(item, [...path, index], 'value', roles)
+    })
+    return
+  }
+
+  if (node.type === 'Link') {
+    if (expected === 'constraint') throw new BundleElaborationError('expression-role-mismatch', path)
+    const link = node as ASTNode & { left: ASTNode; right: ASTNode }
+    elaborateExpression(link.left, [...path, 0], 'scalar', roles)
+    elaborateExpression(link.right, [...path, 1], 'scalar', roles)
+    return
+  }
+
+  if (node.type === 'Male' || node.type === 'Female' || node.type === 'Not') {
+    if (expected === 'constraint') throw new BundleElaborationError('expression-role-mismatch', path)
+    elaborateExpression((node as ASTNode & { operand: ASTNode }).operand, [...path, 0], 'scalar', roles)
+    return
+  }
+
+  if (node.type === 'Round') {
+    if (expected === 'constraint') throw new BundleElaborationError('expression-role-mismatch', path)
+    const content = (node as ASTNode & { content: ASTNode | null }).content
+    if (content !== null) elaborateExpression(content, [...path, 0], expected, roles)
+    return
+  }
+
+  if (node.type === 'Square') {
+    if (expected === 'constraint') throw new BundleElaborationError('expression-role-mismatch', path)
+    return
+  }
+
+  if (isForm(node)) {
+    if (expected === 'constraint') throw new BundleElaborationError('expression-role-mismatch', path)
+    return
+  }
+
+  if (isJudgment(node)) {
+    if (expected !== 'constraint') throw new BundleElaborationError('expression-role-mismatch', path)
+    return
+  }
+
+  throw new BundleElaborationError('unsupported-expression', path)
+}
+
+/** Статически определяет роли фигурных записей, не читая память. */
+export function elaborateBundles(
+  expression: ASTNode,
+  entry: ExpectedBundleRole = 'none'
+): BundleElaboration {
+  const roles: BundleRoleAt[] = []
+  elaborateExpression(expression, [], entry, roles)
+  return { roles }
+}
+
+/** Разрешает каждый элемент плоского пучка независимо, затем убирает повторы по LinkRef. */
+export function evaluateFlatValueBundle(
+  bundle: SetExpr,
+  path: OccurrencePath,
+  elaboration: BundleElaboration,
+  resolveForm: FormResolver
+): BundleValue {
+  if (roleAt(elaboration, path) !== 'ValueBundle') {
+    throw new BundleEvaluationError(`bundle at [${path.join(',')}] is not a ValueBundle`)
+  }
+
+  const occurrences: ResolvedOccurrence[] = []
+  bundle.elements.forEach((item, index) => {
+    if (item.type === 'Set') {
+      throw new BundleEvaluationError('nested ValueBundle is not supported in v0.2')
+    }
+    if (!isForm(item) || isJudgment(item)) {
+      throw new BundleEvaluationError('ValueBundle item must be a form')
+    }
+    const itemPath = [...path, index]
+    occurrences.push({ path: itemPath, link: resolveForm(item, itemPath) })
+  })
+
+  return {
+    kind: 'bundle',
+    identities: [...new Set(occurrences.map(item => item.link))].sort((a, b) => a - b),
+    occurrences,
+  }
+}
+
+/** Локальное сравнение значений разных видов без приведения одиночного пучка к связи. */
+export function valuesEqual(left: MtsValue, right: MtsValue): boolean {
+  if (left.kind !== right.kind) return false
+  if (left.kind === 'link' && right.kind === 'link') return left.identity === right.identity
+  if (left.kind === 'bundle' && right.kind === 'bundle') {
+    return (
+      left.identities.length === right.identities.length &&
+      left.identities.every((value, index) => value === right.identities[index])
+    )
+  }
+  return false
+}
+
+function endpointDomain(
+  expression: ASTNode,
+  path: OccurrencePath,
+  elaboration: BundleElaboration,
+  resolveForm: FormResolver
+): ReadonlySet<LinkRef> | null {
+  if (expression.type === 'Set') {
+    const value = evaluateFlatValueBundle(expression as SetExpr, path, elaboration, resolveForm)
+    return value.identities.length === 0 ? null : new Set(value.identities)
+  }
+  return new Set([resolveForm(expression, path)])
+}
+
+/** Выполняет двухполюсное раскрытие как чистый запрос к существующим связям. */
+export function expandBundleQuery(
+  sequence: SequenceExpr,
+  path: OccurrencePath,
+  elaboration: BundleElaboration,
+  resolveForm: FormResolver,
+  memory: BundleQueryMemory
+): BundleValue {
+  if (sequence.items.length !== 2) {
+    throw new BundleEvaluationError('bundle expansion requires exactly two endpoints in v0.2')
+  }
+
+  const [leftExpression, rightExpression] = sequence.items
+  if (leftExpression.type !== 'Set' && rightExpression.type !== 'Set') {
+    throw new BundleEvaluationError('bundle expansion requires at least one ValueBundle operand')
+  }
+
+  const left = endpointDomain(leftExpression, [...path, 0], elaboration, resolveForm)
+  const right = endpointDomain(rightExpression, [...path, 1], elaboration, resolveForm)
+  const identities = new Set<LinkRef>()
+
+  if (left === null && right === null) {
+    memory.allLinks().forEach(link => identities.add(link))
+  } else if (left === null) {
+    right!.forEach(end => memory.incoming(end).forEach(link => identities.add(link)))
+  } else if (right === null) {
+    left.forEach(start => memory.outgoing(start).forEach(link => identities.add(link)))
+  } else {
+    left.forEach(start => {
+      right.forEach(end => {
+        const found = memory.findLink(start, end)
+        if (found !== undefined) identities.add(found)
+      })
+    })
+  }
+
+  return {
+    kind: 'bundle',
+    identities: [...identities].sort((a, b) => a - b),
+    occurrences: [],
+  }
+}
+
+/** Удобный разрешатель для тестов/простых consumers пучка. */
+export function resolveCorpusForm(
+  form: ASTNode,
+  path: OccurrencePath,
+  symbols: Readonly<Record<string, LinkRef>>,
+  holes: Readonly<Record<string, LinkRef>>
+): LinkRef {
+  if (form.type === 'Identifier') {
+    const name = (form as ASTNode & { name: string }).name
+    const value = symbols[name]
+    if (value === undefined) throw new BundleEvaluationError(`unbound symbol ${name}`)
+    return value
+  }
+  if (form.type === 'Square' && (form as SquareExpr).content === null) {
+    const key = path.join('.')
+    const value = holes[key]
+    if (value === undefined) throw new BundleEvaluationError(`unbound anonymous occurrence ${key}`)
+    return value
+  }
+  throw new BundleEvaluationError(`unsupported resolved form ${form.type}`)
+}

--- a/tests/unit/memoryView.test.ts
+++ b/tests/unit/memoryView.test.ts
@@ -42,6 +42,21 @@ describe('ExplicitMemoryView', () => {
     ).toThrow('Ambiguous canonical Link identity')
   })
 
+  it('allows a general link network and reports projection ambiguity only on projection read', () => {
+    const memory = new ExplicitMemoryView([
+      { id: 0, start: 0, end: 0 },
+      { id: 1, start: 0, end: 1 },
+      { id: 2, start: 1, end: 0 },
+      { id: 3, start: 1, end: 1 },
+    ])
+
+    expect(memory.findLink(0, 1)).toBe(1)
+    expect(memory.outgoing(0)).toEqual([0, 1])
+    expect(memory.incoming(1)).toEqual([1, 3])
+    expect(memory.allLinks()).toEqual([0, 1, 2, 3])
+    expect(() => memory.findEndProjection(0)).toThrow('Ambiguous end projection for form 0')
+  })
+
   it('throws when poles are requested for an unknown link', () => {
     const memory = new ExplicitMemoryView([])
     expect(() => memory.poles(999)).toThrow('Unknown memory link 999')

--- a/tests/unit/mtsContract.test.ts
+++ b/tests/unit/mtsContract.test.ts
@@ -9,6 +9,8 @@ const bundleRoot = resolve(process.cwd(), 'contracts/anum_docs-v0.2')
 const contractPath = resolve(bundleRoot, 'mts-contract-v0.2.json')
 const conformancePath = resolve(bundleRoot, 'mts-conformance-v0.2.json')
 const proofPath = resolve(bundleRoot, 'mts-proof-v0.2.json')
+const valueBundlePath = resolve(bundleRoot, 'mts-value-bundle-v0.2.json')
+const valueBundleConformancePath = resolve(bundleRoot, 'mts-value-bundle-conformance-v0.2.json')
 const boundaryPath = resolve(bundleRoot, 'anum-boundary-projection-v0.2.json')
 const denotationPath = resolve(bundleRoot, 'anum-denotation-v0.2.json')
 const denotationConformancePath = resolve(bundleRoot, 'anum-denotation-conformance-v0.2.json')
@@ -50,6 +52,8 @@ interface Provenance {
   contract: ArtifactProvenance
   conformance: ArtifactProvenance
   proof: ArtifactProvenance
+  valueBundle: ArtifactProvenance
+  valueBundleConformance: ArtifactProvenance
   anumBoundaryProjection: ArtifactProvenance
   anumDenotation: ArtifactProvenance
   anumDenotationConformance: ArtifactProvenance
@@ -78,8 +82,8 @@ function readProvenance(): Provenance {
   return readJson(provenancePath) as Provenance
 }
 
-describe('pinned anum_docs MTS v0.2 contract bundle', () => {
-  it('loads as one validated formal contract + conformance bundle', () => {
+describe('закреплённый набор контрактов МТС v0.2 из anum_docs', () => {
+  it('загружает единый основной контракт и корпус соответствия', () => {
     const bundle = validateMtsContractBundleV02(
       readJson(contractPath),
       readJson(conformancePath)
@@ -90,18 +94,35 @@ describe('pinned anum_docs MTS v0.2 contract bundle', () => {
     expect(bundle.conformance.contract).toBe(bundle.contract.schema)
   })
 
-  it('pins the current upstream top-level contract snapshot', () => {
+  it('закрепляет текущий верхний снимок anum_docs после принятия пучков', () => {
     const provenance = readProvenance()
 
     expect(provenance.sourceRepository).toBe('netkeep80/anum_docs')
-    expect(provenance.sourceCommit).toBe('62901cfc94831af41cf86cdc3acb1507c46c05c7')
+    expect(provenance.sourceCommit).toBe('9278ee3a86af8df7d39ee6bf4ff0b3e14943bd7a')
     expect(gitBlobSha(contractPath)).toBe(provenance.contract.gitBlobSha)
-    expect(provenance.contract.gitBlobSha).toBe('93c39e34f14fb716d850136249e4928599d75130')
+    expect(provenance.contract.gitBlobSha).toBe('d7101f0277ffd9c072648bd821021cf08c0e9df4')
     expect(provenance.contract.sourceCommit).toBe(provenance.sourceCommit)
   })
 
-  it('pins every referenced accepted L3 artifact by exact Git blob SHA', () => {
+  it('закрепляет принятые пучки значений байт-в-байт', () => {
     const provenance = readProvenance()
+
+    expect(gitBlobSha(valueBundlePath)).toBe('6f6991945adf23aace7da7b3c535a279b751b88a')
+    expect(gitBlobSha(valueBundlePath)).toBe(provenance.valueBundle.gitBlobSha)
+    expect(provenance.valueBundle.sourceCommit).toBe(provenance.sourceCommit)
+
+    expect(gitBlobSha(valueBundleConformancePath)).toBe(
+      'ca5a3624f4cf1ab880686807d10d45afbf697670'
+    )
+    expect(gitBlobSha(valueBundleConformancePath)).toBe(
+      provenance.valueBundleConformance.gitBlobSha
+    )
+    expect(provenance.valueBundleConformance.sourceCommit).toBe(provenance.sourceCommit)
+  })
+
+  it('сохраняет точное происхождение неизменённых L3-артефактов', () => {
+    const provenance = readProvenance()
+    const l3Origin = '62901cfc94831af41cf86cdc3acb1507c46c05c7'
     const artifacts: Array<[string, ArtifactProvenance, string]> = [
       [boundaryPath, provenance.anumBoundaryProjection, '822165f7940a4ec764bb7ac59e24e875ae03fb44'],
       [denotationPath, provenance.anumDenotation, '2c0544c1b2ff57bf9c5999b50bd881622b48159d'],
@@ -137,11 +158,11 @@ describe('pinned anum_docs MTS v0.2 contract bundle', () => {
     for (const [path, artifact, expected] of artifacts) {
       expect(gitBlobSha(path)).toBe(artifact.gitBlobSha)
       expect(artifact.gitBlobSha).toBe(expected)
-      expect(artifact.sourceCommit).toBe(provenance.sourceCommit)
+      expect(artifact.sourceCommit).toBe(l3Origin)
     }
   })
 
-  it('keeps unchanged conformance/proof artifacts pinned to their original upstream commits', () => {
+  it('сохраняет неизменные общий корпус и proof-контракт на их исходных commit', () => {
     const provenance = readProvenance()
     const proof = readJson(proofPath) as ProofContractV02
 
@@ -167,7 +188,7 @@ describe('pinned anum_docs MTS v0.2 contract bundle', () => {
     expect(proof.explicitlyNotTrusted).toContain('modus-ponens')
   })
 
-  it('validates the upstream L3 contract graph without implementing L3 semantics locally', () => {
+  it('проверяет ссылки верхнего контракта, не дублируя L3-семантику', () => {
     const { contract } = validateMtsContractBundleV02(
       readJson(contractPath),
       readJson(conformancePath)
@@ -186,24 +207,25 @@ describe('pinned anum_docs MTS v0.2 contract bundle', () => {
     expect(contract.anum.acceptedRecursiveDenotationSubset).toBe(
       'contracts/anum-recursive-denotation-v0.2.json'
     )
-    expect(contract.anum.rootOpeningCollapse).toContain('canonical decode/re-encode validation')
-    expect(contract.anum.recursiveDenotationIssue).toBe(101)
-    expect(contract.anum.generalDenotationIssue).toBe(89)
+
+    expect(contract.formalNotation.valueBundle.contract).toBe(
+      'contracts/mts-value-bundle-v0.2.json'
+    )
+    expect(contract.formalNotation.valueBundle.conformanceCorpus).toBe(
+      'contracts/mts-value-bundle-conformance-v0.2.json'
+    )
+    expect(contract.formalNotation.valueBundle.runtimeRoleGuessing).toBe(false)
+    expect(contract.formalNotation.valueBundle.valueScope).toBe('flat-only')
+    expect(contract.formalNotation.valueBundle.expansionReadOnly).toBe(true)
 
     expect((readJson(boundaryPath) as { schema: string }).schema).toBe(
       'anum-boundary-projection/v0.2'
     )
-    expect((readJson(denotationPath) as { schema: string }).schema).toBe('anum-denotation/v0.2')
-    expect((readJson(pairDenotationPath) as { schema: string }).schema).toBe(
-      'anum-pair-denotation/v0.2'
-    )
-    expect((readJson(rawCarrierPath) as { schema: string }).schema).toBe('anum-raw-carrier/v0.2')
-    expect((readJson(recursiveDenotationPath) as { schema: string }).schema).toBe(
-      'anum-recursive-denotation/v0.2'
-    )
+    expect((readJson(valueBundlePath) as { schema: string; status: string }).status).toBe('accepted')
+    expect((readJson(valueBundleConformancePath) as { accepted: boolean }).accepted).toBe(true)
   })
 
-  it('treats the two context pronouns as atomic non-bracket code points', () => {
+  it('сохраняет два атомарных контекстных местоимения вне квадратных скобок', () => {
     const { contract } = validateMtsContractBundleV02(
       readJson(contractPath),
       readJson(conformancePath)
@@ -217,11 +239,9 @@ describe('pinned anum_docs MTS v0.2 contract bundle', () => {
       { source: '▷', role: 'end' },
     ])
     expect(context.ancestor.operator).toBe('↑')
-    expect(context.roles.every(role => [...role.source].length === 1)).toBe(true)
-    expect(context.roles.some(role => /[\[\]]/.test(role.source))).toBe(false)
   })
 
-  it('forbids display labels from becoming semantic identity', () => {
+  it('не превращает видимую подпись в семантическое тождество', () => {
     const { contract } = validateMtsContractBundleV02(
       readJson(contractPath),
       readJson(conformancePath)
@@ -233,7 +253,7 @@ describe('pinned anum_docs MTS v0.2 contract bundle', () => {
     expect(contract.integration.requiredRuntimeIdentities).toContain('LinkRef')
   })
 
-  it('keeps interpretation read-only and realization explicit', () => {
+  it('оставляет интерпретацию только читающей, а изменение памяти явным', () => {
     const { contract } = validateMtsContractBundleV02(
       readJson(contractPath),
       readJson(conformancePath)
@@ -242,10 +262,19 @@ describe('pinned anum_docs MTS v0.2 contract bundle', () => {
     expect(contract.formalNotation.operations.interpret.effect).toBe('none')
     expect(contract.memory.interpretMayMaterialize).toBe(false)
     expect(contract.memory.effectOperations).toEqual(['realize', 'delete'])
-    expect(contract.memory.readOperations).toContain('poles')
+    expect(contract.memory.readOperations).toEqual([
+      'find',
+      'poles',
+      'findLink',
+      'findStartProjection',
+      'findEndProjection',
+      'outgoing',
+      'incoming',
+      'allLinks',
+    ])
   })
 
-  it('contains executable vectors for lexing, canonicalization and interpretation', () => {
+  it('содержит исполнимые случаи лексики, канонизации и интерпретации', () => {
     const { conformance } = validateMtsContractBundleV02(
       readJson(contractPath),
       readJson(conformancePath)
@@ -254,14 +283,5 @@ describe('pinned anum_docs MTS v0.2 contract bundle', () => {
     expect(conformance.lexing.length).toBeGreaterThan(0)
     expect(conformance.canonicalization.length).toBeGreaterThan(0)
     expect(conformance.interpretation.length).toBeGreaterThan(0)
-
-    const bracketCase = conformance.lexing.find(
-      item => item.id === 'atomic-pronouns-do-not-overload-brackets'
-    )
-    expect(bracketCase).toEqual({
-      id: 'atomic-pronouns-do-not-overload-brackets',
-      source: '◁[]▷',
-      tokens: ['context-start', 'lbracket', 'rbracket', 'context-end'],
-    })
   })
 })

--- a/tests/unit/mtsValueBundle.test.ts
+++ b/tests/unit/mtsValueBundle.test.ts
@@ -1,0 +1,218 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import type { ASTNode, SetExpr, SequenceExpr } from '../../src/core/ast'
+import { parseExpr } from '../../src/core/parser'
+import { ExplicitMemoryView } from '../../src/core/memoryView'
+import {
+  BundleElaborationError,
+  elaborateBundles,
+  evaluateFlatValueBundle,
+  expandBundleQuery,
+  resolveCorpusForm,
+  valuesEqual,
+  type BundleValue,
+  type ExpectedBundleRole,
+  type LinkValue,
+} from '../../src/core/valueBundle'
+
+interface ElaborationCase {
+  id: string
+  source: string
+  context?: string
+  bundlePath?: number[]
+  expectedRole: 'ConstraintBundle' | 'ValueBundle'
+}
+
+interface RejectionCase {
+  id: string
+  source: string
+  context?: string
+  error: string
+}
+
+interface EqualityCase {
+  id: string
+  left: string
+  right: string
+  symbols: Record<string, number>
+  leftHoles: Record<string, number>
+  rightHoles: Record<string, number>
+  leftSet: number[]
+  rightSet: number[]
+  equal: boolean
+}
+
+interface CrossKindCase {
+  id: string
+  bundle: string
+  scalar: string
+  symbols: Record<string, number>
+  bundleSet: number[]
+  scalarIdentity: number
+  equal: boolean
+  notEqual: boolean
+  context?: string
+}
+
+interface ExpansionCase {
+  id: string
+  source: string
+  expectedLinks: number[]
+}
+
+interface Corpus {
+  schema: string
+  status: string
+  contract: string
+  accepted: boolean
+  elaboration: ElaborationCase[]
+  staticRejections: RejectionCase[]
+  valueEquality: EqualityCase[]
+  crossKindComparison: CrossKindCase[]
+  expansionMemory: {
+    links: Record<string, [number, number]>
+    symbols: Record<string, number>
+  }
+  expansion: ExpansionCase[]
+  veto: Record<string, boolean>
+}
+
+const corpus = JSON.parse(
+  readFileSync(
+    resolve(process.cwd(), 'contracts/anum_docs-v0.2/mts-value-bundle-conformance-v0.2.json'),
+    'utf8'
+  )
+) as Corpus
+
+function entryFor(context?: string): ExpectedBundleRole {
+  if (context === 'constraint-entry') return 'constraint'
+  if (context === 'form-required' || context === 'value-entry') return 'value'
+  return 'none'
+}
+
+function samePath(left: readonly number[], right: readonly number[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index])
+}
+
+function setValue(
+  source: string,
+  symbols: Record<string, number>,
+  holes: Record<string, number>
+): BundleValue {
+  const ast = parseExpr(source)
+  expect(ast.type).toBe('Set')
+  const set = ast as SetExpr
+  const elaboration = elaborateBundles(set, set.elements.length === 0 ? 'value' : 'none')
+  return evaluateFlatValueBundle(set, [], elaboration, (form, path) =>
+    resolveCorpusForm(form, path, symbols, holes)
+  )
+}
+
+describe('принятый корпус плоских пучков МТС v0.2', () => {
+  it('потребляет именно принятый upstream-корпус', () => {
+    expect(corpus.schema).toBe('mts-value-bundle-conformance/v0.2')
+    expect(corpus.contract).toBe('mts-value-bundle/v0.2')
+    expect(corpus.status).toBe('accepted')
+    expect(corpus.accepted).toBe(true)
+  })
+
+  for (const testCase of corpus.elaboration) {
+    it(`уточняет роль: ${testCase.id}`, () => {
+      const ast = parseExpr(testCase.source)
+      const elaboration = elaborateBundles(ast, entryFor(testCase.context))
+      const path = testCase.bundlePath ?? []
+      const actual = elaboration.roles.find(item => samePath(item.path, path))
+      expect(actual?.role).toBe(testCase.expectedRole)
+    })
+  }
+
+  for (const testCase of corpus.staticRejections) {
+    it(`статически отвергает: ${testCase.id}`, () => {
+      const ast = parseExpr(testCase.source)
+      try {
+        elaborateBundles(ast, entryFor(testCase.context))
+        throw new Error('ожидалась статическая ошибка пучка')
+      } catch (error) {
+        expect(error).toBeInstanceOf(BundleElaborationError)
+        expect((error as BundleElaborationError).code).toBe(testCase.error)
+      }
+    })
+  }
+
+  for (const testCase of corpus.valueEquality) {
+    it(`сравнивает после разрешения: ${testCase.id}`, () => {
+      const left = setValue(testCase.left, testCase.symbols, testCase.leftHoles)
+      const right = setValue(testCase.right, testCase.symbols, testCase.rightHoles)
+
+      expect(left.identities).toEqual(testCase.leftSet)
+      expect(right.identities).toEqual(testCase.rightSet)
+      expect(valuesEqual(left, right)).toBe(testCase.equal)
+    })
+  }
+
+  for (const testCase of corpus.crossKindComparison) {
+    it(`не смешивает пучок и одиночную связь: ${testCase.id}`, () => {
+      const bundle = setValue(testCase.bundle, testCase.symbols, {})
+      const scalar: LinkValue = { kind: 'link', identity: testCase.scalarIdentity }
+      expect(bundle.identities).toEqual(testCase.bundleSet)
+      expect(valuesEqual(bundle, scalar)).toBe(testCase.equal)
+      expect(!valuesEqual(bundle, scalar)).toBe(testCase.notEqual)
+    })
+  }
+
+  it('выполняет всё раскрытие только через существующие связи', () => {
+    const links = Object.entries(corpus.expansionMemory.links).map(([id, poles]) => ({
+      id: Number(id),
+      start: poles[0],
+      end: poles[1],
+    }))
+    const memory = new ExplicitMemoryView(links)
+    const before = memory.entries()
+
+    for (const testCase of corpus.expansion) {
+      const ast = parseExpr(testCase.source)
+      expect(ast.type).toBe('Sequence')
+      const sequence = ast as SequenceExpr
+      const elaboration = elaborateBundles(sequence)
+      const value = expandBundleQuery(
+        sequence,
+        [],
+        elaboration,
+        (form: ASTNode, path) =>
+          resolveCorpusForm(form, path, corpus.expansionMemory.symbols, {}),
+        memory
+      )
+      expect(value.identities, testCase.id).toEqual(testCase.expectedLinks)
+      expect(memory.entries(), `${testCase.id}: память должна остаться неизменной`).toEqual(before)
+    }
+  })
+
+  it('сохраняет запреты на скрытые расширения семантики', () => {
+    expect(corpus.veto.rootDefinitionsChanged).toBe(false)
+    expect(corpus.veto.constraintBundleBehaviorChanged).toBe(false)
+    expect(corpus.veto.deduplicateSourceOccurrences).toBe(false)
+    expect(corpus.veto.nestedValueBundleAccepted).toBe(false)
+    expect(corpus.veto.bundleValuedDefinitionAccepted).toBe(false)
+    expect(corpus.veto.scalarOperatorLiftingAccepted).toBe(false)
+    expect(corpus.veto.interpretMayRealize).toBe(false)
+    expect(corpus.veto.interpretMayDelete).toBe(false)
+    expect(corpus.veto.globalRewrite).toBe(false)
+  })
+})
+
+describe('соположение в единственном parser МТС', () => {
+  it('разбирает двухполюсные формы раскрытия как Sequence', () => {
+    expect(parseExpr('a{b,c}').type).toBe('Sequence')
+    expect(parseExpr('{a,b}c').type).toBe('Sequence')
+    expect(parseExpr('{a,b}{c,d}').type).toBe('Sequence')
+    expect(parseExpr('{}{}').type).toBe('Sequence')
+  })
+
+  it('даёт соположению больший приоритет, чем ⟼', () => {
+    const ast = parseExpr('a{b,c} ⟼ z') as ASTNode & { left: ASTNode }
+    expect(ast.type).toBe('Link')
+    expect(ast.left.type).toBe('Sequence')
+  })
+})


### PR DESCRIPTION
Closes #133.

Синхронизирует `aprover` с нормативным `anum_docs@9278ee3a86af8df7d39ee6bf4ff0b3e14943bd7a` после принятия плоских пучков значений МТС v0.2.

## Что входит

- точный pin основного `mts-contract/v0.2` и двух новых контрактов пучков с Git blob provenance;
- каноническое соположение/последовательность добавлено в единственный AST/parser, без второго parser;
- фигурная запись статически различается как пучок условий или пучок значений;
- плоский пучок сравнивается по множеству разрешённых связей после независимого разрешения вхождений;
- одиночная связь и пучок остаются разными видами значения;
- `a{}`, `{}b`, `{}{}` и ограниченное декартово раскрытие работают только как чтение существующих связей;
- `ExplicitMemoryView` получает read-only `outgoing`, `incoming`, `allLinks`;
- upstream корпус `mts-value-bundle-conformance/v0.2` исполняется напрямую TypeScript consumer-ом.

## Что не входит

- вложенные пучки значений;
- непустой пучок в правой части `:`;
- пучок как явный полюс `⟼`;
- распространение `♀/♂/¬` на пучок;
- создание или удаление связей;
- локальная теория, отличающаяся от `anum_docs`.

Теоретическое изложение остаётся в `anum_docs`; здесь только машинный consumer и приложение.