### PR TITLE
Исправить склеивание формул через перевод строки

### DIFF
--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -232,12 +232,20 @@ export class Parser {
     return left
   }
 
-  /** Каноническое соположение: a{b,c}, {}b, {}{}, [][], ... */
+  /**
+   * Каноническое соположение внутри одной строки: a{b,c}, {}b, {}{}, [][], ...
+   *
+   * В файловом/editor workflow aprover перевод строки остаётся границей формул.
+   * Это application-boundary: сам L2 AST не получает отдельного newline-оператора.
+   */
   private parseSequence(): ASTNode {
     const first = this.parsePref()
     const items: ASTNode[] = [first]
 
-    while (FORM_STARTS.has(this.current().type)) {
+    while (
+      FORM_STARTS.has(this.current().type) &&
+      this.current().loc.start.line === items[items.length - 1].loc!.end.line
+    ) {
       items.push(this.parsePref())
     }
 

--- a/tests/e2e/root-newline-regression.spec.ts
+++ b/tests/e2e/root-newline-regression.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test'
+
+test('канонический многострочный корень не склеивается соположением', async ({ page }) => {
+  await page.goto('/')
+
+  const source = await page.locator('.code-input').inputValue()
+  expect(source).toContain('∞ : {◁ = ∞, ▷ = ∞}')
+  expect(source).toContain('(=) : {♀◁ = ♀▷, ◁♂ = ▷♂}')
+
+  await expect(page.locator('.error-panel')).toHaveCount(0)
+  await expect(page.locator('.app-footer')).toContainText('10 statements parsed')
+  await expect(page.locator('.tree-root')).toBeVisible()
+})

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from 'vitest'
 import { LexerError } from '../../src/core/lexer'
-import { ParseError, parseExpr } from '../../src/core/parser'
+import { ParseError, parse, parseExpr } from '../../src/core/parser'
 import { toMtsSource } from '../../src/core/mtsSource'
 
 describe('Parser', () => {
@@ -51,6 +51,29 @@ describe('Parser', () => {
     expect(toMtsSource(parseExpr('{x,y}'))).toBe('{x, y}')
     expect(toMtsSource(parseExpr('{y,x}'))).toBe('{y, x}')
     expect(toMtsSource(parseExpr('{x,x}'))).toBe('{x, x}')
+  })
+
+  it('parses juxtaposition inside one line', () => {
+    expect(toMtsSource(parseExpr('a{b,c}'))).toBe('a{b, c}')
+    expect(toMtsSource(parseExpr('{}b'))).toBe('{}b')
+    expect(toMtsSource(parseExpr('{}{}'))).toBe('{}{}')
+    expect(toMtsSource(parseExpr('[][]'))).toBe('[][]')
+  })
+
+  it('keeps a newline as an application-level statement boundary', () => {
+    const file = parse('a : {x = y}\nb : {y = x}')
+    expect(file.statements).toHaveLength(2)
+    expect(toMtsSource(file.statements[0].expr)).toBe('a : {x = y}')
+    expect(toMtsSource(file.statements[1].expr)).toBe('b : {y = x}')
+  })
+
+  it('does not glue canonical root definitions across lines', () => {
+    const file = parse('∞ : {◁ = ∞, ▷ = ∞}\n(=) : {♀◁ = ♀▷, ◁♂ = ▷♂}')
+    expect(file.statements).toHaveLength(2)
+    expect(file.statements.map(statement => statement.expr.type)).toEqual([
+      'Definition',
+      'Definition',
+    ])
   })
 
   it('distinguishes round literals from judgments and link forms', () => {


### PR DESCRIPTION
Closes #135.

Исправляет регрессию опубликованного приложения после добавления соположения форм.

- соположение (`a{b,c}`, `{}b`, `{}{}`, `[][]`) продолжает работать внутри одной строки;
- перевод строки снова является границей формул в файловом/editor workflow aprover;
- добавлены regression tests на две соседние формулы и две корневые definitions без `.`;
- нормативную семантику МТС не меняет: это только application parsing boundary.

После зелёного полного CI будет смержено сразу.