### PR TITLE
Публиковать Pages только после зелёного CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,9 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -15,9 +16,15 @@ concurrency:
 
 jobs:
   build:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -28,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
 
-      - name: Build
+      - name: Build exact green main SHA
         run: npm run build
 
       - name: Setup Pages

--- a/tests/unit/deployWorkflow.test.ts
+++ b/tests/unit/deployWorkflow.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const workflow = readFileSync(
+  resolve(process.cwd(), '.github/workflows/deploy.yml'),
+  'utf8'
+)
+
+describe('публикация GitHub Pages', () => {
+  it('ждёт успешный CI на push в main', () => {
+    expect(workflow).toContain('workflow_run:')
+    expect(workflow).toContain('workflows: ["CI"]')
+    expect(workflow).toContain("github.event.workflow_run.conclusion == 'success'")
+    expect(workflow).toContain("github.event.workflow_run.event == 'push'")
+    expect(workflow).toContain("github.event.workflow_run.head_branch == 'main'")
+    expect(workflow).not.toMatch(/\n  push:\s*\n/)
+  })
+
+  it('собирает именно SHA, который прошёл CI', () => {
+    expect(workflow).toContain('ref: ${{ github.event.workflow_run.head_sha }}')
+  })
+})


### PR DESCRIPTION
Closes #137.

После сегодняшней регрессии отделяет публикацию от простого push в `main`.

Теперь GitHub Pages:
- запускается только после завершённого workflow `CI`;
- требует `success`, событие `push` и ветку `main`;
- checkout/build делает для exact `workflow_run.head_sha`;
- не дублирует второй набор тестов внутри deploy workflow;
- имеет unit guard на эти инварианты.

Цель: публичная версия не может опережать зелёный CI.