### PR TITLE
Вывести interpret-proof search в UI с independent replay

### DIFF
--- a/src/components/ProofReplayPanel.vue
+++ b/src/components/ProofReplayPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { presentProofArtifactJson } from '../core/proofArtifactPresentation'
+import ProofSearchPanel from './ProofSearchPanel.vue'
 
 const props = defineProps<{
   modelValue: string
@@ -12,6 +13,7 @@ const emit = defineEmits<{
 }>()
 
 const fileInput = ref<HTMLInputElement | null>(null)
+const mode = ref<'replay' | 'search'>('replay')
 const view = computed(() => presentProofArtifactJson(props.modelValue))
 
 const updateSource = (event: Event) => {
@@ -29,10 +31,21 @@ const loadFile = async (event: Event) => {
 }
 
 const clear = () => emit('update:modelValue', '')
+const openSearch = () => (mode.value = 'search')
+const openGeneratedProof = (source: string) => {
+  emit('update:modelValue', source)
+  mode.value = 'replay'
+}
 </script>
 
 <template>
-  <section class="proof-replay-panel" data-testid="proof-replay-panel">
+  <ProofSearchPanel
+    v-if="mode === 'search'"
+    @close="emit('close')"
+    @open-replay="openGeneratedProof"
+  />
+
+  <section v-else class="proof-replay-panel" data-testid="proof-replay-panel">
     <header class="proof-replay-header">
       <div>
         <strong>Trusted proof replay</strong>
@@ -46,6 +59,7 @@ const clear = () => emit('update:modelValue', '')
           accept=".json,application/json"
           @change="loadFile"
         />
+        <button type="button" class="proof-action proof-search-open" @click="openSearch">Search</button>
         <button type="button" class="proof-action" @click="openFile">Load JSON</button>
         <button type="button" class="proof-action" @click="clear">Clear</button>
         <button type="button" class="proof-action close" aria-label="Close proof replay" @click="emit('close')">

--- a/src/components/ProofSearchPanel.vue
+++ b/src/components/ProofSearchPanel.vue
@@ -1,0 +1,383 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { ContextFrame, LinkRef } from '../core/interpreter'
+import type { DistinguishedLink } from '../core/memoryView'
+import { searchInterpretProof } from '../core/proofSearch'
+import { checkProof } from '../core/proofReplay'
+
+const emit = defineEmits<{
+  close: []
+  'open-replay': [source: string]
+}>()
+
+const expression = ref('[] = ◁')
+const contextSource = ref(JSON.stringify({ start: 10, end: 12 }, null, 2))
+const symbolsSource = ref('{}')
+const memorySource = ref('[]')
+const searchStatus = ref<'idle' | 'proven' | 'not-proven' | 'error'>('idle')
+const searchMessage = ref('')
+const proofSource = ref('')
+const replayAccepted = ref<boolean | null>(null)
+
+type UnknownRecord = Record<string, unknown>
+
+function record(value: unknown, label: string): UnknownRecord {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label}: expected object`)
+  }
+  return value as UnknownRecord
+}
+
+function linkRef(value: unknown, label: string): LinkRef {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value)) {
+    throw new Error(`${label}: expected integer LinkRef`)
+  }
+  return value
+}
+
+function parseJson(source: string, label: string): unknown {
+  try {
+    return JSON.parse(source) as unknown
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : 'invalid JSON'
+    throw new Error(`${label}: ${message}`)
+  }
+}
+
+function contextFrame(value: unknown, label: string): ContextFrame {
+  const source = record(value, label)
+  const frame: ContextFrame = {
+    start: linkRef(source.start, `${label}.start`),
+    end: linkRef(source.end, `${label}.end`),
+  }
+  if (source.parent === undefined) return frame
+  return { ...frame, parent: contextFrame(source.parent, `${label}.parent`) }
+}
+
+function symbols(value: unknown, label: string): Readonly<Record<string, LinkRef>> | undefined {
+  const source = record(value, label)
+  const result: Record<string, LinkRef> = {}
+  for (const [name, reference] of Object.entries(source)) {
+    result[name] = linkRef(reference, `${label}.${JSON.stringify(name)}`)
+  }
+  return Object.keys(result).length === 0 ? undefined : result
+}
+
+function distinguishedMemory(value: unknown, label: string): readonly DistinguishedLink[] | undefined {
+  if (!Array.isArray(value)) throw new Error(`${label}: expected array`)
+  const links = value.map((entry, index) => {
+    const source = record(entry, `${label}[${index}]`)
+    return {
+      id: linkRef(source.id, `${label}[${index}].id`),
+      start: linkRef(source.start, `${label}[${index}].start`),
+      end: linkRef(source.end, `${label}[${index}].end`),
+    }
+  })
+  return links.length === 0 ? undefined : links
+}
+
+const runSearch = () => {
+  searchStatus.value = 'idle'
+  searchMessage.value = ''
+  proofSource.value = ''
+  replayAccepted.value = null
+
+  let context: ContextFrame
+  let parsedSymbols: Readonly<Record<string, LinkRef>> | undefined
+  let parsedMemory: readonly DistinguishedLink[] | undefined
+
+  try {
+    context = contextFrame(parseJson(contextSource.value, 'context'), 'context')
+    parsedSymbols = symbols(parseJson(symbolsSource.value, 'symbols'), 'symbols')
+    parsedMemory = distinguishedMemory(parseJson(memorySource.value, 'memory'), 'memory')
+  } catch (cause) {
+    searchStatus.value = 'error'
+    searchMessage.value = cause instanceof Error ? cause.message : 'Invalid proof search input'
+    return
+  }
+
+  const result = searchInterpretProof({
+    expression: expression.value,
+    context,
+    ...(parsedSymbols === undefined ? {} : { symbols: parsedSymbols }),
+    ...(parsedMemory === undefined ? {} : { distinguishedMemory: parsedMemory }),
+  })
+
+  if (result.status === 'error') {
+    searchStatus.value = 'error'
+    searchMessage.value = `${result.stage}: ${result.message}`
+    return
+  }
+
+  if (result.status === 'not-proven') {
+    searchStatus.value = 'not-proven'
+    searchMessage.value = result.reason
+    return
+  }
+
+  searchStatus.value = 'proven'
+  proofSource.value = JSON.stringify(result.proof, null, 2)
+  replayAccepted.value = checkProof(result.proof)
+}
+
+const openReplay = () => {
+  if (proofSource.value) emit('open-replay', proofSource.value)
+}
+</script>
+
+<template>
+  <section class="proof-search-panel" data-testid="proof-search-panel">
+    <header class="proof-search-header">
+      <div>
+        <strong>Untrusted proof search</strong>
+        <span class="proof-search-subtitle">mts-proof/v0.2 · interpret only</span>
+      </div>
+      <button type="button" class="proof-search-action close" aria-label="Close proof search" @click="emit('close')">
+        ×
+      </button>
+    </header>
+
+    <div class="proof-search-body">
+      <div class="proof-search-inputs">
+        <label for="proof-search-expression">Expression</label>
+        <textarea
+          id="proof-search-expression"
+          v-model="expression"
+          class="proof-search-source"
+          spellcheck="false"
+        />
+
+        <label for="proof-search-context">ContextFrame JSON</label>
+        <textarea
+          id="proof-search-context"
+          v-model="contextSource"
+          class="proof-search-json"
+          spellcheck="false"
+        />
+
+        <label for="proof-search-symbols">Symbols JSON</label>
+        <textarea
+          id="proof-search-symbols"
+          v-model="symbolsSource"
+          class="proof-search-json compact"
+          spellcheck="false"
+        />
+
+        <label for="proof-search-memory">Distinguished memory JSON</label>
+        <textarea
+          id="proof-search-memory"
+          v-model="memorySource"
+          class="proof-search-json"
+          spellcheck="false"
+        />
+
+        <button type="button" class="proof-search-action primary proof-search-run" @click="runSearch">
+          Run search
+        </button>
+      </div>
+
+      <div class="proof-search-result">
+        <div v-if="searchStatus === 'idle'" class="proof-search-empty">
+          Search is untrusted. Any generated artifact is independently replayed before it is shown as accepted.
+        </div>
+
+        <div v-else class="proof-search-summary">
+          <span class="proof-search-status" :class="`status-${searchStatus}`">
+            {{ searchStatus === 'proven' ? 'SEARCH PROVEN' : searchStatus === 'not-proven' ? 'NOT PROVEN' : 'SEARCH ERROR' }}
+          </span>
+          <span v-if="searchMessage" class="proof-search-message">{{ searchMessage }}</span>
+        </div>
+
+        <template v-if="searchStatus === 'proven'">
+          <div class="proof-search-replay">
+            <span>Independent replay</span>
+            <strong
+              class="proof-search-replay-verdict"
+              :class="{ accepted: replayAccepted === true, rejected: replayAccepted === false }"
+            >
+              {{ replayAccepted ? 'REPLAY ACCEPTED' : 'REPLAY REJECTED' }}
+            </strong>
+          </div>
+
+          <textarea
+            class="proof-search-artifact"
+            :value="proofSource"
+            readonly
+            spellcheck="false"
+            aria-label="Generated proof artifact JSON"
+          />
+
+          <button type="button" class="proof-search-action" @click="openReplay">
+            Open in trusted replay
+          </button>
+        </template>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.proof-search-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 280px;
+  max-height: 58vh;
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.proof-search-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.55rem 0.75rem;
+  background: var(--accent-color);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.proof-search-header > div {
+  display: flex;
+  align-items: baseline;
+  gap: 0.65rem;
+}
+
+.proof-search-subtitle,
+.proof-search-inputs label,
+.proof-search-empty,
+.proof-search-message,
+.proof-search-replay > span {
+  color: #94a3b8;
+  font-size: 0.72rem;
+}
+
+.proof-search-body {
+  display: grid;
+  grid-template-columns: minmax(320px, 0.9fr) minmax(360px, 1.1fr);
+  gap: 0.7rem;
+  min-height: 0;
+  padding: 0.65rem;
+  overflow: hidden;
+}
+
+.proof-search-inputs,
+.proof-search-result {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-height: 0;
+}
+
+.proof-search-result {
+  overflow: auto;
+  padding: 0.55rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.proof-search-source,
+.proof-search-json,
+.proof-search-artifact {
+  width: 100%;
+  resize: vertical;
+  padding: 0.5rem;
+  color: #e2e8f0;
+  background: #0f172a;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.75rem;
+}
+
+.proof-search-source {
+  min-height: 54px;
+}
+
+.proof-search-json {
+  min-height: 76px;
+}
+
+.proof-search-json.compact {
+  min-height: 48px;
+}
+
+.proof-search-artifact {
+  min-height: 150px;
+}
+
+.proof-search-action {
+  align-self: flex-start;
+  padding: 0.28rem 0.55rem;
+  color: #cbd5e1;
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.proof-search-action:hover {
+  color: white;
+}
+
+.proof-search-action.primary {
+  margin-top: 0.25rem;
+  font-weight: 700;
+}
+
+.proof-search-action.close {
+  align-self: auto;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.proof-search-summary,
+.proof-search-replay {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.proof-search-status,
+.proof-search-replay-verdict {
+  padding: 0.12rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.status-proven,
+.accepted {
+  color: var(--success-color);
+  background: rgba(74, 222, 128, 0.1);
+}
+
+.status-not-proven {
+  color: #facc15;
+  background: rgba(250, 204, 21, 0.1);
+}
+
+.status-error,
+.rejected {
+  color: var(--error-color);
+  background: rgba(248, 113, 113, 0.1);
+}
+
+.proof-search-replay {
+  margin-top: 0.45rem;
+}
+
+@media (max-width: 900px) {
+  .proof-search-panel {
+    max-height: 70vh;
+  }
+
+  .proof-search-body {
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+  }
+}
+</style>

--- a/tests/e2e/proof-search.spec.ts
+++ b/tests/e2e/proof-search.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('aprover proof search bridge', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.locator('.proof-replay-toggle').click()
+    await page.locator('.proof-search-open').click()
+  })
+
+  test('searches, independently replays and opens the generated artifact', async ({ page }) => {
+    await expect(page.getByTestId('proof-search-panel')).toBeVisible()
+    await page.locator('.proof-search-run').click()
+
+    await expect(page.locator('.proof-search-status')).toContainText('SEARCH PROVEN')
+    await expect(page.locator('.proof-search-replay-verdict')).toContainText('REPLAY ACCEPTED')
+
+    const artifact = await page.getByLabel('Generated proof artifact JSON').inputValue()
+    expect(artifact).toContain('mts-proof/v0.2')
+    expect(artifact).toContain('[] = ◁')
+
+    await page.getByRole('button', { name: 'Open in trusted replay' }).click()
+    await expect(page.getByTestId('proof-replay-panel')).toBeVisible()
+    await expect(page.locator('.proof-verdict')).toContainText('REPLAY ACCEPTED')
+    await expect(page.locator('#proof-artifact-source')).toHaveValue(artifact)
+  })
+
+  test('shows failed matches and invalid explicit input separately', async ({ page }) => {
+    await page.locator('#proof-search-expression').fill('◁ = ▷')
+    await page.locator('.proof-search-run').click()
+    await expect(page.locator('.proof-search-status')).toContainText('NOT PROVEN')
+    await expect(page.locator('.proof-search-message')).toContainText('not-matched')
+
+    await page.locator('#proof-search-context').fill('{"start":"bad","end":12}')
+    await page.locator('.proof-search-run').click()
+    await expect(page.locator('.proof-search-status')).toContainText('SEARCH ERROR')
+    await expect(page.locator('.proof-search-message')).toContainText('context.start')
+    await expect(page.locator('.proof-search-replay-verdict')).toHaveCount(0)
+  })
+})

--- a/tests/unit/ProofSearchPanel.test.ts
+++ b/tests/unit/ProofSearchPanel.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import ProofSearchPanel from '../../src/components/ProofSearchPanel.vue'
+import { parseProofJson } from '../../src/core/proofReplay'
+
+describe('ProofSearchPanel', () => {
+  it('runs untrusted search and independently replays the generated artifact', async () => {
+    const wrapper = mount(ProofSearchPanel)
+
+    await wrapper.get('.proof-search-run').trigger('click')
+
+    expect(wrapper.text()).toContain('SEARCH PROVEN')
+    expect(wrapper.text()).toContain('REPLAY ACCEPTED')
+
+    const source = (wrapper.get('.proof-search-artifact').element as HTMLTextAreaElement).value
+    const proof = parseProofJson(source)
+    expect(proof.steps).toHaveLength(1)
+    expect(proof.steps[0].expression).toBe('[] = ◁')
+    expect(proof.steps[0].expected.substitutions).toEqual([{ path: [0], link: 10 }])
+  })
+
+  it('shows not-proven separately from errors', async () => {
+    const wrapper = mount(ProofSearchPanel)
+    await wrapper.get('#proof-search-expression').setValue('◁ = ▷')
+    await wrapper.get('.proof-search-run').trigger('click')
+
+    expect(wrapper.text()).toContain('NOT PROVEN')
+    expect(wrapper.text()).toContain('not-matched')
+    expect(wrapper.find('.proof-search-artifact').exists()).toBe(false)
+  })
+
+  it('validates explicit context input before search', async () => {
+    const wrapper = mount(ProofSearchPanel)
+    await wrapper.get('#proof-search-context').setValue('{"start":"bad","end":12}')
+    await wrapper.get('.proof-search-run').trigger('click')
+
+    expect(wrapper.text()).toContain('SEARCH ERROR')
+    expect(wrapper.text()).toContain('context.start: expected integer LinkRef')
+    expect(wrapper.find('.proof-search-artifact').exists()).toBe(false)
+  })
+
+  it('accepts explicit symbols, memory and recursive parent context', async () => {
+    const wrapper = mount(ProofSearchPanel)
+    await wrapper.get('#proof-search-expression').setValue('30 = [] ⟼ []')
+    await wrapper
+      .get('#proof-search-context')
+      .setValue('{"start":10,"end":12,"parent":{"start":20,"end":22}}')
+    await wrapper.get('#proof-search-symbols').setValue('{"30":30}')
+    await wrapper
+      .get('#proof-search-memory')
+      .setValue('[{"id":30,"start":2,"end":3}]')
+    await wrapper.get('.proof-search-run').trigger('click')
+
+    expect(wrapper.text()).toContain('SEARCH PROVEN')
+    expect(wrapper.text()).toContain('REPLAY ACCEPTED')
+
+    const source = (wrapper.get('.proof-search-artifact').element as HTMLTextAreaElement).value
+    const proof = parseProofJson(source)
+    expect(proof.steps[0].context.parent).toEqual({ start: 20, end: 22 })
+    expect(proof.steps[0].distinguishedMemory).toEqual([{ id: 30, start: 2, end: 3 }])
+  })
+
+  it('hands the portable generated artifact to the replay workflow', async () => {
+    const wrapper = mount(ProofSearchPanel)
+    await wrapper.get('.proof-search-run').trigger('click')
+    await wrapper.get('button').filter?.(() => true)
+    await wrapper.get('.proof-search-result button').trigger('click')
+
+    const emitted = wrapper.emitted('open-replay')
+    expect(emitted).toHaveLength(1)
+    expect(parseProofJson(emitted?.[0]?.[0] as string).steps).toHaveLength(1)
+  })
+})

--- a/tests/unit/ProofSearchPanel.test.ts
+++ b/tests/unit/ProofSearchPanel.test.ts
@@ -66,7 +66,6 @@ describe('ProofSearchPanel', () => {
   it('hands the portable generated artifact to the replay workflow', async () => {
     const wrapper = mount(ProofSearchPanel)
     await wrapper.get('.proof-search-run').trigger('click')
-    await wrapper.get('button').filter?.(() => true)
     await wrapper.get('.proof-search-result button').trigger('click')
 
     const emitted = wrapper.emitted('open-replay')


### PR DESCRIPTION
Closes #140. Refs #139 and netkeep80/anum_docs#120.

## Что меняется

Завершает уже существующий `mts-proof/v0.2` search/replay workflow на уровне приложения, **без новых inference rules**.

- добавлен отдельный `ProofSearchPanel.vue`;
- пользователь явно задаёт expression, recursive `ContextFrame`, symbol bindings и distinguished memory JSON;
- вход runtime-валидируется до search;
- panel вызывает существующий untrusted `searchInterpretProof()`;
- `proven`, `not-proven`, parse/interpret/input errors показываются раздельно;
- при `proven` generated `mts-proof/v0.2` artifact сразу независимо проверяется существующим `checkProof()`;
- generated JSON можно передать в существующий trusted `ProofReplayPanel`, после чего он проходит обычный external-artifact validation/replay path;
- search core не начинает доверять или проверять собственный output.

## Trust boundary

Остаётся:

```text
searchInterpretProof  — untrusted construction
        ↓
mts-proof/v0.2 JSON   — portable artifact
        ↓
checkProof            — independent trusted replay
```

Никаких A0–A11, symmetry/transitivity/congruence/MP, global substitution или локальной MTS semantics не добавлено.

## Tests

Добавлены:

- component/unit coverage: accepted search+replay, not-proven, invalid explicit context, recursive context + symbols + memory, handoff в replay;
- Playwright: browser search → independent replay → generated artifact → trusted Replay panel; отдельный failed/invalid path.

Локальный runner в текущей agent-среде недоступен (`github.com` не резолвится, `gh` отсутствует), поэтому PR намеренно остаётся draft до GitHub CI. После полностью зелёных lint/type-check/unit/build/Playwright и проверки актуальности относительно `main` можно переводить в ready/merge.