### PR TITLE
Добавить exact-pin и trusted replay mts-proof/v0.3

### DIFF
--- a/contracts/anum_docs-v0.4/mts-conformance-v0.4.json
+++ b/contracts/anum_docs-v0.4/mts-conformance-v0.4.json
@@ -1,0 +1,42 @@
+{
+  "schema": "mts-conformance/v0.4",
+  "status": "accepted",
+  "contract": "mts-contract/v0.4",
+  "composition": "all referenced accepted corpora are required; no prior vector is copied, weakened or replaced",
+  "requiredCorpora": [
+    {
+      "role": "base-v0.3",
+      "path": "contracts/mts-conformance-v0.3.json",
+      "schema": "mts-conformance/v0.3",
+      "contract": "mts-contract/v0.3"
+    },
+    {
+      "role": "proof-v0.3",
+      "path": "contracts/mts-proof-conformance-v0.3.json",
+      "schema": "mts-proof-conformance/v0.3",
+      "contract": "mts-proof/v0.3"
+    }
+  ],
+  "releaseAssertions": {
+    "allRequiredCorporaMustPass": true,
+    "mtsContractV03RemainsImmutable": true,
+    "mtsProofV03IsExactDependency": true,
+    "rootProgramRemainsTenDefinitions": true,
+    "allFiveBaseProofRelationsReplay": true,
+    "proofSearchRemainsUntrusted": true,
+    "genericCompositionAccepted": false,
+    "openingImpliesEquality": false,
+    "ambientInterpreterIdentityUsed": false,
+    "subjectFocusExtensionAccepted": false,
+    "relativeProductionRemainsRaw": true,
+    "persistentBackendAccepted": false,
+    "pmmCanonicalDependency": false
+  },
+  "downstreamAssertions": {
+    "aproverMayPinMtsContractV04": true,
+    "aproverMustPinMtsProofV03": true,
+    "aproverMustReplayBaseRelationsIndependently": true,
+    "aproverMustNotInventComposition": true,
+    "aproverMustNotAddSubjectFocusSemantics": true
+  }
+}

--- a/contracts/anum_docs-v0.4/mts-contract-v0.4.json
+++ b/contracts/anum_docs-v0.4/mts-contract-v0.4.json
@@ -1,0 +1,108 @@
+{
+  "schema": "mts-contract/v0.4",
+  "status": "accepted",
+  "accepted": true,
+  "issue": 153,
+  "dependsOn": [
+    "mts-contract/v0.3",
+    "mts-proof/v0.3"
+  ],
+  "extends": "mts-contract/v0.3",
+  "baseContract": "contracts/mts-contract-v0.3.json",
+  "conformanceCorpus": "contracts/mts-conformance-v0.4.json",
+  "releaseModel": "additive proof-publication umbrella; v0.3 remains immutable and independently replayable",
+  "rootProgram": "tests/mtc_formulas.mtc",
+  "rootDefinitionCount": 10,
+  "preservedSurface": {
+    "l0ToL4": "all accepted mts-contract/v0.3 semantics remain unchanged",
+    "definitionOpening": "mts-definition-opening/v0.3 unchanged",
+    "valueBundles": "accepted v0.2 flat ValueBundle semantics unchanged",
+    "rootAndQuoteAnum": "accepted v0.2 semantics unchanged",
+    "relativeAnum": "RAW in production",
+    "inMemoryL4": "accepted v0.2 semantics unchanged",
+    "persistentL4Accepted": false,
+    "interpretMayRealize": false,
+    "openDefinitionMayRealize": false,
+    "globalRewrite": false,
+    "displayLabelIsIdentity": false
+  },
+  "l5": {
+    "proofContract": "contracts/mts-proof-v0.3.json",
+    "proofSchema": "mts-proof/v0.3",
+    "contractVersion": "mts-contract/v0.3",
+    "trustedCheckerModule": "core/proof_checker.py",
+    "trustedRelations": [
+      "ContextuallySatisfies",
+      "Opens",
+      "NoVisibleDefinition",
+      "DefinitionConflict",
+      "NonAddressableDefinitionTarget"
+    ],
+    "searchTrusted": false,
+    "checkerTrusted": true,
+    "genericCompositionAccepted": false,
+    "judgmentOrderImpliesDependency": false,
+    "openingImpliesEquality": false,
+    "globalSubstitutionAccepted": false,
+    "transitivityAccepted": false,
+    "symmetryAccepted": false,
+    "congruenceAccepted": false,
+    "modusPonensAccepted": false
+  },
+  "contextBoundary": {
+    "acceptedContextInput": "explicit ContextFrame(start,end,parent?)",
+    "ambientInterpreterIdentity": false,
+    "subjectIdentity": false,
+    "currentFocusLinkRefIdentity": false,
+    "deicticSubjectFocusExtensionAccepted": false,
+    "futureResearchIssue": 148,
+    "futureResearchVersion": "v0.5+"
+  },
+  "versionBoundaries": {
+    "v02ModifiedInPlace": false,
+    "v03ModifiedInPlace": false,
+    "v03ConformanceReplaced": false,
+    "proofV03ModifiedToFitUmbrella": false,
+    "v04ConformanceComposesPriorCorpora": true,
+    "compatibilitySemanticLayerAllowed": false
+  },
+  "excludedFromThisRelease": [
+    "multi-step proof composition or DAG dependency semantics",
+    "new inference rules beyond accepted base relation replay",
+    "subject/focus/deictic context extension from issue #148",
+    "current-focus LinkRef identity",
+    "relative Anum candidate semantics",
+    "persistent/high-performance L4 backend acceptance",
+    "PMM as canonical dependency",
+    "global textual substitution",
+    "unrestricted equality rewrite",
+    "implicit realization"
+  ],
+  "downstream": {
+    "genericConsumerMayPinV04": true,
+    "aproverProofRepinAllowed": true,
+    "requiredProofSchema": "mts-proof/v0.3",
+    "requiredProofContractVersion": "mts-contract/v0.3",
+    "consumerMustReplayIndependently": true,
+    "consumerMayInventCompositionRules": false,
+    "consumerMayUseSubjectFocusSemantics": false
+  },
+  "nextGates": {
+    "proofComposition": {
+      "issue": 122,
+      "status": "research/challenge required"
+    },
+    "deicticSubjectFocus": {
+      "issue": 148,
+      "status": "v0.5+ research"
+    },
+    "relativeAnum": {
+      "issue": 123,
+      "status": "candidate research only"
+    },
+    "persistentL4": {
+      "issue": 124,
+      "status": "persistent backend conformance required"
+    }
+  }
+}

--- a/contracts/anum_docs-v0.4/mts-proof-conformance-v0.3.json
+++ b/contracts/anum_docs-v0.4/mts-proof-conformance-v0.3.json
@@ -1,0 +1,227 @@
+{
+  "schema": "mts-proof-conformance/v0.3",
+  "status": "accepted",
+  "accepted": true,
+  "contract": "mts-proof/v0.3",
+  "proofVersion": "mts-proof/v0.3",
+  "contractVersion": "mts-contract/v0.3",
+  "validJudgments": [
+    {
+      "id": "contextually-satisfies-aroot",
+      "judgment": {
+        "relation": "ContextuallySatisfies",
+        "expression": "{◁ = ∞, ▷ = ∞}",
+        "context": {"start": 1, "end": 1, "parent": null},
+        "symbols": [["∞", 1]],
+        "memory": [],
+        "expected": {"substitutions": [], "aliases": []}
+      }
+    },
+    {
+      "id": "contextually-satisfies-link-decomposition",
+      "judgment": {
+        "relation": "ContextuallySatisfies",
+        "expression": "10 = [] ⟼ []",
+        "context": {"start": 2, "end": 3, "parent": null},
+        "symbols": [["10", 10]],
+        "memory": [{"id": 10, "start": 2, "end": 3}],
+        "expected": {
+          "substitutions": [
+            {"path": [1, 0], "link": 2},
+            {"path": [1, 1], "link": 3}
+          ],
+          "aliases": []
+        }
+      }
+    },
+    {
+      "id": "opens-direct",
+      "judgment": {
+        "relation": "Opens",
+        "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+        "lookupScope": [],
+        "target": "a",
+        "expected": {
+          "definitionId": {"scopePath": [], "ordinal": 0},
+          "body": "b"
+        }
+      }
+    },
+    {
+      "id": "opens-child-shadowing",
+      "judgment": {
+        "relation": "Opens",
+        "scopes": [
+          {"path": [], "parent": null, "definitions": ["a : root"]},
+          {"path": [0], "parent": [], "definitions": ["a : child"]}
+        ],
+        "lookupScope": [0],
+        "target": "a",
+        "expected": {
+          "definitionId": {"scopePath": [0], "ordinal": 0},
+          "body": "child"
+        }
+      }
+    },
+    {
+      "id": "opens-self-one-step",
+      "judgment": {
+        "relation": "Opens",
+        "scopes": [{"path": [], "parent": null, "definitions": ["a : a"]}],
+        "lookupScope": [],
+        "target": "a",
+        "expected": {
+          "definitionId": {"scopePath": [], "ordinal": 0},
+          "body": "a"
+        }
+      }
+    },
+    {
+      "id": "no-visible-definition",
+      "judgment": {
+        "relation": "NoVisibleDefinition",
+        "scopes": [{"path": [], "parent": null, "definitions": []}],
+        "lookupScope": [],
+        "target": "a"
+      }
+    },
+    {
+      "id": "definition-conflict",
+      "judgment": {
+        "relation": "DefinitionConflict",
+        "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "a : c"]}],
+        "lookupScope": [],
+        "target": "a"
+      }
+    },
+    {
+      "id": "non-addressable-target",
+      "judgment": {
+        "relation": "NonAddressableDefinitionTarget",
+        "target": "[]"
+      }
+    }
+  ],
+  "invalidArtifacts": [
+    {
+      "id": "wrong-proof-version",
+      "artifact": {"proofVersion": "mts-proof/v0.2", "contractVersion": "mts-contract/v0.3", "judgments": []}
+    },
+    {
+      "id": "wrong-contract-version",
+      "artifact": {"proofVersion": "mts-proof/v0.3", "contractVersion": "mts-contract/v0.2", "judgments": []}
+    },
+    {
+      "id": "unknown-relation",
+      "artifact": {
+        "proofVersion": "mts-proof/v0.3",
+        "contractVersion": "mts-contract/v0.3",
+        "judgments": [{"relation": "Equality", "left": "a", "right": "b"}]
+      }
+    },
+    {
+      "id": "unexpected-proof-field",
+      "artifact": {"proofVersion": "mts-proof/v0.3", "contractVersion": "mts-contract/v0.3", "judgments": [], "searchTrace": []}
+    }
+  ],
+  "forgeries": [
+    {
+      "id": "context-counterexample-not-satisfied",
+      "sourceJudgment": "contextually-satisfies-aroot",
+      "patch": {"context.end": 2},
+      "mustReject": true
+    },
+    {
+      "id": "forged-substitution",
+      "sourceJudgment": "contextually-satisfies-link-decomposition",
+      "patch": {"expected.substitutions": [{"path": [1, 0], "link": 999}]},
+      "mustReject": true
+    },
+    {
+      "id": "forged-opening-body",
+      "sourceJudgment": "opens-direct",
+      "patch": {"expected.body": "c"},
+      "mustReject": true
+    },
+    {
+      "id": "forged-opening-id",
+      "sourceJudgment": "opens-direct",
+      "patch": {"expected.definitionId.ordinal": 9},
+      "mustReject": true
+    },
+    {
+      "id": "no-match-when-visible",
+      "sourceJudgment": "opens-direct",
+      "replaceRelation": "NoVisibleDefinition",
+      "remove": ["expected"],
+      "mustReject": true
+    },
+    {
+      "id": "conflict-with-single-definition",
+      "sourceJudgment": "opens-direct",
+      "replaceRelation": "DefinitionConflict",
+      "remove": ["expected"],
+      "mustReject": true
+    },
+    {
+      "id": "addressable-target-claimed-non-addressable",
+      "sourceJudgment": "non-addressable-target",
+      "patch": {"target": "a"},
+      "mustReject": true
+    },
+    {
+      "id": "hidden-root-injection",
+      "judgment": {
+        "relation": "Opens",
+        "scopes": [{"path": [], "parent": null, "definitions": []}],
+        "lookupScope": [],
+        "target": "∞",
+        "expected": {
+          "definitionId": {"scopePath": [], "ordinal": 0},
+          "body": "{◁ = ∞, ▷ = ∞}"
+        }
+      },
+      "mustReject": true
+    },
+    {
+      "id": "duplicate-scope",
+      "judgment": {
+        "relation": "NoVisibleDefinition",
+        "scopes": [
+          {"path": [], "parent": null, "definitions": []},
+          {"path": [], "parent": null, "definitions": []}
+        ],
+        "lookupScope": [],
+        "target": "a"
+      },
+      "mustReject": true
+    },
+    {
+      "id": "noncanonical-scope-order",
+      "judgment": {
+        "relation": "NoVisibleDefinition",
+        "scopes": [
+          {"path": [], "parent": null, "definitions": []},
+          {"path": [1], "parent": [], "definitions": []},
+          {"path": [0], "parent": [], "definitions": []}
+        ],
+        "lookupScope": [0],
+        "target": "a"
+      },
+      "mustReject": true
+    }
+  ],
+  "releaseAssertions": {
+    "allFiveAcceptedRelationsCovered": true,
+    "contextualSatisfactionRequiresSuccess": true,
+    "exactSubstitutionsAndAliasesChecked": true,
+    "openingBodyAndDefinitionIdChecked": true,
+    "negativeRelationsAreScopeBound": true,
+    "hiddenRootInjectionRejected": true,
+    "malformedScopeSnapshotsRejected": true,
+    "unknownRelationsRejected": true,
+    "v02RegressionRequired": true,
+    "genericCompositionAccepted": false,
+    "ambientSubjectOrInterpreterStateUsed": false
+  }
+}

--- a/contracts/anum_docs-v0.4/mts-proof-v0.3.json
+++ b/contracts/anum_docs-v0.4/mts-proof-v0.3.json
@@ -1,0 +1,129 @@
+{
+  "schema": "mts-proof/v0.3",
+  "status": "accepted",
+  "accepted": true,
+  "issue": 147,
+  "dependsOn": [
+    "mts-contract/v0.3",
+    "mts-derivation-base/v0.3",
+    "mts-proof/v0.2"
+  ],
+  "conformanceCorpus": "contracts/mts-proof-conformance-v0.3.json",
+  "purpose": "Trusted independent replay of the five accepted base derivation relations; no multi-step composition or proof-search semantics.",
+  "proofObject": {
+    "required": ["proofVersion", "contractVersion", "judgments"],
+    "proofVersion": "mts-proof/v0.3",
+    "contractVersion": "mts-contract/v0.3",
+    "judgments": "ordered BaseJudgment[]; ordering is artifact order only and has no inference/composition meaning"
+  },
+  "trustedRelations": [
+    "ContextuallySatisfies",
+    "Opens",
+    "NoVisibleDefinition",
+    "DefinitionConflict",
+    "NonAddressableDefinitionTarget"
+  ],
+  "contextuallySatisfies": {
+    "required": ["relation", "expression", "context", "symbols", "memory", "expected"],
+    "context": {
+      "start": "LinkRef",
+      "end": "LinkRef",
+      "parent": "optional recursive explicit ContextFrame"
+    },
+    "expected": {
+      "substitutions": "exact sorted array of {path:int[],link:LinkRef}",
+      "aliases": "exact sorted array of {path:int[],targetPath:int[]}"
+    },
+    "replay": "canonical interpret_constraints with success required to be true",
+    "globalTruth": false,
+    "hiddenInterpreterIdentity": false,
+    "subjectOrFocusIdentity": false,
+    "materializes": false
+  },
+  "definitionEnvironment": {
+    "scope": {
+      "required": ["path", "parent", "definitions"],
+      "path": "non-negative int[]",
+      "parent": "null for root or exact parent path",
+      "definitions": "ordered canonical L2 Definition source strings"
+    },
+    "scopeOrder": "canonical order by (path length, lexicographic path)",
+    "rootScopeRequired": true,
+    "duplicateScopeRejected": true,
+    "hiddenRootInjection": false,
+    "definitionId": "replay-local DefinitionId(scopePath, successful registration ordinal)",
+    "sourceSpanIdentity": false,
+    "persistentIdentity": false
+  },
+  "opens": {
+    "required": ["relation", "scopes", "lookupScope", "target", "expected"],
+    "expected": {
+      "definitionId": {"scopePath": "int[]", "ordinal": "non-negative int"},
+      "body": "exact canonical format_expression output"
+    },
+    "replay": "open_definition exactly once and require kind=match",
+    "impliesEquality": false,
+    "evaluatesRhs": false,
+    "materializes": false
+  },
+  "noVisibleDefinition": {
+    "required": ["relation", "scopes", "lookupScope", "target"],
+    "replay": "open_definition exactly once and require kind=no-match",
+    "globalAbsence": false,
+    "closedWorldBeyondSnapshot": false
+  },
+  "definitionConflict": {
+    "required": ["relation", "scopes", "lookupScope", "target"],
+    "replay": "open_definition exactly once and require kind=conflict",
+    "impliesBodyEquality": false
+  },
+  "nonAddressableDefinitionTarget": {
+    "required": ["relation", "target"],
+    "replay": "open_definition against a fresh empty DefinitionEnvironment and require kind=non-addressable",
+    "globalSemanticInvalidity": false
+  },
+  "checker": {
+    "module": "core/proof_checker.py",
+    "singleTrustedModuleForV02AndV03": true,
+    "replaysCanonicalInterpreter": true,
+    "replaysCanonicalDefinitionOpening": true,
+    "trustsSerializedExpectedResultWithoutReplay": false,
+    "mayReadAmbientInterpreterState": false,
+    "mayInjectCanonicalRootDefinitions": false,
+    "mayMaterialize": false,
+    "mayDelete": false,
+    "unknownRelationRejected": true,
+    "wrongOrMissingVersionRejected": true,
+    "unexpectedFieldsRejected": true
+  },
+  "compositionBoundary": {
+    "judgmentOrderImpliesDependency": false,
+    "genericCompositionAccepted": false,
+    "transitivityAccepted": false,
+    "symmetryAccepted": false,
+    "congruenceAccepted": false,
+    "modusPonensAccepted": false,
+    "globalSubstitutionAccepted": false,
+    "openingToEqualityAccepted": false,
+    "recursiveNormalizationAccepted": false
+  },
+  "v02Compatibility": {
+    "mtsProofV02Modified": false,
+    "mtsProofV02Schema": "mts-proof/v0.2",
+    "mtsProofV02ContractVersion": "mts-contract/v0.2",
+    "mtsProofV02TrustedRuleSet": ["interpret"],
+    "existingV02ArtifactsReplayedByExistingApi": true,
+    "retroactiveReinterpretation": false
+  },
+  "contextVersionBoundary": {
+    "explicitContextFrameOnly": true,
+    "subjectFocusResearchIssue": 148,
+    "subjectOrFocusAddedToV03Artifact": false,
+    "futureContextSemanticsMustUseAdditiveContract": true
+  },
+  "downstream": {
+    "proofSemanticsAccepted": true,
+    "aproverRepinAllowedDirectlyFromMtsContractV03": false,
+    "reason": "mts-contract/v0.3 is immutable and predates mts-proof/v0.3 publication; downstream repin requires a later additive umbrella contract"
+  }
+}

--- a/contracts/anum_docs-v0.4/provenance.json
+++ b/contracts/anum_docs-v0.4/provenance.json
@@ -1,0 +1,24 @@
+{
+  "sourceRepository": "netkeep80/anum_docs",
+  "sourceCommit": "ec8161ceeecbecfd95481688821785fd32757873",
+  "contract": {
+    "path": "contracts/mts-contract-v0.4.json",
+    "sourceCommit": "ec8161ceeecbecfd95481688821785fd32757873",
+    "gitBlobSha": "52ff42a3f1b4112b1a1707f4cec8a8bee07281f3"
+  },
+  "conformance": {
+    "path": "contracts/mts-conformance-v0.4.json",
+    "sourceCommit": "ec8161ceeecbecfd95481688821785fd32757873",
+    "gitBlobSha": "4fbf336833dca0b6f3d9fe6143a2f40a8bd62474"
+  },
+  "proof": {
+    "path": "contracts/mts-proof-v0.3.json",
+    "sourceCommit": "ec8161ceeecbecfd95481688821785fd32757873",
+    "gitBlobSha": "9cbc83e51ca83d391eb8d2018dcc5b2d25e8e65f"
+  },
+  "proofConformance": {
+    "path": "contracts/mts-proof-conformance-v0.3.json",
+    "sourceCommit": "ec8161ceeecbecfd95481688821785fd32757873",
+    "gitBlobSha": "c7f0223eee0564138e783a27f00b13bf8b48bcf9"
+  }
+}

--- a/src/components/ProofReplayPanel.vue
+++ b/src/components/ProofReplayPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { presentProofArtifactJson } from '../core/proofArtifactPresentation'
+import { presentVersionedProofArtifactJson } from '../core/proofArtifactPresentationVersioned'
 import ProofSearchPanel from './ProofSearchPanel.vue'
 
 const props = defineProps<{
@@ -14,7 +14,7 @@ const emit = defineEmits<{
 
 const fileInput = ref<HTMLInputElement | null>(null)
 const mode = ref<'replay' | 'search'>('replay')
-const view = computed(() => presentProofArtifactJson(props.modelValue))
+const view = computed(() => presentVersionedProofArtifactJson(props.modelValue))
 
 const updateSource = (event: Event) => {
   emit('update:modelValue', (event.target as HTMLTextAreaElement).value)
@@ -49,7 +49,7 @@ const openGeneratedProof = (source: string) => {
     <header class="proof-replay-header">
       <div>
         <strong>Trusted proof replay</strong>
-        <span class="proof-replay-subtitle">mts-proof/v0.2 · replay-only</span>
+        <span class="proof-replay-subtitle">mts-proof/v0.2 + v0.3 · replay-only</span>
       </div>
       <div class="proof-replay-actions">
         <input
@@ -75,7 +75,7 @@ const openGeneratedProof = (source: string) => {
         class="proof-source"
         :value="modelValue"
         spellcheck="false"
-        placeholder="Paste an mts-proof/v0.2 JSON artifact here"
+        placeholder="Paste an mts-proof/v0.2 or mts-proof/v0.3 JSON artifact here"
         @input="updateSource"
       />
 
@@ -99,7 +99,7 @@ const openGeneratedProof = (source: string) => {
             <code>{{ view.contractVersion }}</code>
           </div>
 
-          <div class="proof-steps">
+          <div v-if="view.version === 'v0.2'" class="proof-steps">
             <article v-for="step in view.steps" :key="step.index" class="proof-step">
               <div class="proof-step-header">
                 <span class="proof-step-number">#{{ step.index }}</span>
@@ -144,6 +144,62 @@ const openGeneratedProof = (source: string) => {
                   </code>
                 </div>
                 <span v-else class="proof-none">none</span>
+              </div>
+            </article>
+          </div>
+
+          <div v-else class="proof-steps proof-judgments" data-testid="proof-v03-judgments">
+            <article v-for="judgment in view.judgments" :key="judgment.index" class="proof-step">
+              <div class="proof-step-header">
+                <span class="proof-step-number">#{{ judgment.index }}</span>
+                <code>{{ judgment.relation }}</code>
+                <span
+                  class="step-verdict"
+                  :class="{ accepted: judgment.accepted, rejected: !judgment.accepted }"
+                >
+                  {{ judgment.accepted ? 'accepted' : 'rejected' }}
+                </span>
+              </div>
+
+              <code class="proof-expression">{{ judgment.primary }}</code>
+
+              <div v-if="judgment.context.length" class="proof-section">
+                <span class="proof-section-title">Context</span>
+                <div class="context-rows">
+                  <code v-for="frame in judgment.context" :key="frame.depth">
+                    {{ frame.depth === 0 ? 'current' : `parent↑${frame.depth}` }}:
+                    ◁={{ frame.start }} · ▷={{ frame.end }}
+                  </code>
+                </div>
+              </div>
+
+              <div v-if="judgment.meta.length" class="proof-meta">
+                <span v-for="item in judgment.meta" :key="item">{{ item }}</span>
+              </div>
+
+              <div v-if="judgment.details.length" class="proof-section">
+                <span class="proof-section-title">Replay claim</span>
+                <div class="proof-values">
+                  <code v-for="item in judgment.details" :key="item">{{ item }}</code>
+                </div>
+              </div>
+
+              <div v-if="judgment.substitutions.length" class="proof-section">
+                <span class="proof-section-title">Expected substitutions</span>
+                <div class="proof-values">
+                  <code v-for="item in judgment.substitutions" :key="`${item.occurrence}:${item.link}`">
+                    [] @ {{ item.occurrence }} → LinkRef {{ item.link }}
+                  </code>
+                </div>
+              </div>
+
+              <div v-if="judgment.aliases.length" class="proof-section">
+                <span class="proof-section-title">Expected aliases</span>
+                <div class="proof-values">
+                  <code v-for="item in judgment.aliases" :key="`${item.occurrence}:${item.target}`">
+                    [] @ {{ item.occurrence }} → [] @ {{ item.target }}
+                  </code>
+                </div>
               </div>
             </article>
           </div>

--- a/src/core/definitionEnvironment.ts
+++ b/src/core/definitionEnvironment.ts
@@ -1,0 +1,359 @@
+import type {
+  ASTNode,
+  DefExpr,
+  LinkExpr,
+  EqExpr,
+  NeqExpr,
+  MaleExpr,
+  FemaleExpr,
+  NotExpr,
+  SetExpr,
+  SequenceExpr,
+  IdentExpr,
+  AbitLitExpr,
+  StringLitExpr,
+  LiteralExpr,
+  RoundExpr,
+  SquareExpr,
+  ContextPronounExpr,
+  NumExpr,
+} from './ast'
+import { parseExpr } from './parser'
+
+export type ScopePath = readonly number[]
+
+export interface DefinitionId {
+  readonly scopePath: ScopePath
+  readonly ordinal: number
+}
+
+export type DefinitionRegistrationKind = 'registered' | 'conflict' | 'non-addressable'
+export type DefinitionLookupKind = 'match' | 'no-match' | 'conflict' | 'non-addressable'
+
+interface DefinitionEntry {
+  readonly id: DefinitionId
+  readonly key: string
+  readonly definition: DefExpr
+}
+
+export interface DefinitionRegistrationResult {
+  readonly kind: DefinitionRegistrationKind
+  readonly entry?: DefinitionEntry
+}
+
+export interface DefinitionOpeningResult {
+  readonly kind: DefinitionLookupKind
+  readonly definitionId?: DefinitionId
+  readonly body?: ASTNode
+}
+
+function samePath(left: ScopePath, right: ScopePath): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index])
+}
+
+function assertPath(path: ScopePath, label = 'scope path'): void {
+  for (const value of path) {
+    if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${label} must be non-negative`)
+  }
+}
+
+function precedence(node: ASTNode): number {
+  switch (node.type) {
+    case 'Definition':
+      return 10
+    case 'Equality':
+    case 'Inequality':
+      return 20
+    case 'Link':
+      return 40
+    case 'Sequence':
+      return 50
+    case 'Not':
+      return 60
+    case 'Female':
+    case 'Male':
+      return 70
+    default:
+      return 100
+  }
+}
+
+function canonicalInner(node: ASTNode, parentPrecedence: number): string {
+  const current = precedence(node)
+  let text: string
+
+  switch (node.type) {
+    case 'Identifier':
+      text = (node as IdentExpr).name
+      break
+    case 'Infinity':
+      text = '∞'
+      break
+    case 'Num':
+      text = String((node as NumExpr).value)
+      break
+    case 'AbitLit':
+      text = `'${(node as AbitLitExpr).value}'`
+      break
+    case 'StringLit':
+      text = `"${(node as StringLitExpr).value}"`
+      break
+    case 'Literal':
+      text = (node as LiteralExpr).value
+      break
+    case 'ContextPronoun': {
+      const value = node as ContextPronounExpr
+      text = `${'↑'.repeat(value.up)}${value.pole === 'start' ? '◁' : '▷'}`
+      break
+    }
+    case 'Round': {
+      const value = node as RoundExpr
+      text = `(${value.content === null ? '' : canonicalInner(value.content, 0)})`
+      break
+    }
+    case 'Square': {
+      const value = node as SquareExpr
+      text = `[${value.content === null ? '' : canonicalInner(value.content, 0)}]`
+      break
+    }
+    case 'Set':
+      text = `{${(node as SetExpr).elements.map(item => canonicalInner(item, 0)).join(', ')}}`
+      break
+    case 'Sequence':
+      text = (node as SequenceExpr).items.map(item => canonicalInner(item, 51)).join('')
+      break
+    case 'Female':
+      text = `♀${canonicalInner((node as FemaleExpr).operand, 70)}`
+      break
+    case 'Male':
+      text = `${canonicalInner((node as MaleExpr).operand, 70)}♂`
+      break
+    case 'Not':
+      text = `¬${canonicalInner((node as NotExpr).operand, 60)}`
+      break
+    case 'Link': {
+      const value = node as LinkExpr
+      text = `${canonicalInner(value.left, 40)} ⟼ ${canonicalInner(value.right, 41)}`
+      break
+    }
+    case 'Equality': {
+      const value = node as EqExpr
+      text = `${canonicalInner(value.left, 20)} = ${canonicalInner(value.right, 21)}`
+      break
+    }
+    case 'Inequality': {
+      const value = node as NeqExpr
+      text = `${canonicalInner(value.left, 20)} != ${canonicalInner(value.right, 21)}`
+      break
+    }
+    case 'Definition': {
+      const value = node as DefExpr
+      text = `${canonicalInner(value.name, 10)} : ${canonicalInner(value.form, 10)}`
+      break
+    }
+    default:
+      throw new Error(`unsupported AST node ${node.type}`)
+  }
+
+  return current < parentPrecedence ? `(${text})` : text
+}
+
+/** Canonical formatter matching anum_docs `format_expression` observable output. */
+export function canonicalExpression(node: ASTNode): string {
+  return canonicalInner(node, 0)
+}
+
+type StructuralValue = string | number | null | StructuralValue[]
+
+function structuralValue(node: ASTNode | null): StructuralValue {
+  if (node === null) return null
+
+  switch (node.type) {
+    // anum_docs represents all of these unquoted atoms as Symbol(name).
+    case 'Identifier':
+      return ['symbol', (node as IdentExpr).name]
+    case 'Infinity':
+      return ['symbol', '∞']
+    case 'Num':
+      return ['symbol', String((node as NumExpr).value)]
+    case 'AbitLit':
+      return ['symbol', (node as AbitLitExpr).value]
+    case 'StringLit':
+      return ['symbol', (node as StringLitExpr).value]
+    case 'Literal':
+      return ['literal', (node as LiteralExpr).value]
+    case 'ContextPronoun': {
+      const value = node as ContextPronounExpr
+      return ['context-pronoun', value.up, value.pole === 'start' ? '◁' : '▷']
+    }
+    case 'Round':
+      return ['round', structuralValue((node as RoundExpr).content)]
+    case 'Square':
+      return ['square', structuralValue((node as SquareExpr).content)]
+    case 'Set':
+      return ['bundle', (node as SetExpr).elements.map(structuralValue)]
+    case 'Sequence':
+      return ['sequence', (node as SequenceExpr).items.map(structuralValue)]
+    case 'Female':
+      return ['start', structuralValue((node as FemaleExpr).operand)]
+    case 'Male':
+      return ['end', structuralValue((node as MaleExpr).operand)]
+    case 'Not':
+      return ['inversion', structuralValue((node as NotExpr).operand)]
+    case 'Link': {
+      const value = node as LinkExpr
+      return ['link', structuralValue(value.left), structuralValue(value.right)]
+    }
+    case 'Equality': {
+      const value = node as EqExpr
+      return ['equality', structuralValue(value.left), structuralValue(value.right)]
+    }
+    case 'Inequality': {
+      const value = node as NeqExpr
+      return ['inequality', structuralValue(value.left), structuralValue(value.right)]
+    }
+    case 'Definition': {
+      const value = node as DefExpr
+      return ['definition', structuralValue(value.name), structuralValue(value.form)]
+    }
+    default:
+      throw new Error(`unsupported AST node ${node.type}`)
+  }
+}
+
+function isAddressableTarget(node: ASTNode): boolean {
+  switch (node.type) {
+    case 'Identifier':
+    case 'Infinity':
+    case 'Num':
+    case 'AbitLit':
+    case 'StringLit':
+    case 'Literal':
+      return true
+    case 'ContextPronoun':
+    case 'Set':
+    case 'Equality':
+    case 'Inequality':
+    case 'Definition':
+      return false
+    case 'Round': {
+      const content = (node as RoundExpr).content
+      return content === null || isAddressableTarget(content)
+    }
+    case 'Square': {
+      const content = (node as SquareExpr).content
+      return content !== null && isAddressableTarget(content)
+    }
+    case 'Sequence': {
+      const items = (node as SequenceExpr).items
+      return items.length > 0 && items.every(isAddressableTarget)
+    }
+    case 'Female':
+      return isAddressableTarget((node as FemaleExpr).operand)
+    case 'Male':
+      return isAddressableTarget((node as MaleExpr).operand)
+    case 'Not':
+      return isAddressableTarget((node as NotExpr).operand)
+    case 'Link': {
+      const value = node as LinkExpr
+      return isAddressableTarget(value.left) && isAddressableTarget(value.right)
+    }
+    default:
+      return false
+  }
+}
+
+export function definitionTargetKey(node: ASTNode): string | null {
+  return isAddressableTarget(node) ? JSON.stringify(structuralValue(node)) : null
+}
+
+export function parseDefinition(source: string): DefExpr {
+  const node = parseExpr(source)
+  if (node.type !== 'Definition') throw new Error('definition source must parse as Definition')
+  return node as DefExpr
+}
+
+export function parseDefinitionTarget(source: string): ASTNode {
+  return parseDefinition(`${source} : __proof_query__`).name
+}
+
+export class DefinitionEnvironment {
+  readonly scopePath: ScopePath
+  readonly parent: DefinitionEnvironment | null
+  private readonly entries = new Map<string, DefinitionEntry>()
+  private readonly conflicts = new Set<string>()
+  private readonly children = new Map<number, DefinitionEnvironment>()
+  private nextOrdinal = 0
+
+  constructor(scopePath: ScopePath = [], parent: DefinitionEnvironment | null = null) {
+    assertPath(scopePath)
+    if (parent === null) {
+      if (scopePath.length !== 0) throw new Error('root definition scope path must be empty')
+    } else {
+      if (scopePath.length === 0 || !samePath(scopePath.slice(0, -1), parent.scopePath)) {
+        throw new Error('child definition scope path must extend parent by one index')
+      }
+      const index = scopePath[scopePath.length - 1]
+      if (parent.children.has(index)) throw new Error('definition child scope already exists')
+      parent.children.set(index, this)
+    }
+    this.scopePath = [...scopePath]
+    this.parent = parent
+  }
+
+  child(index: number): DefinitionEnvironment {
+    if (!Number.isSafeInteger(index) || index < 0) {
+      throw new Error('definition child index must be a non-negative integer')
+    }
+    const existing = this.children.get(index)
+    if (existing !== undefined) return existing
+    return new DefinitionEnvironment([...this.scopePath, index], this)
+  }
+
+  register(definition: DefExpr): DefinitionRegistrationResult {
+    const key = definitionTargetKey(definition.name)
+    if (key === null) return { kind: 'non-addressable' }
+    if (this.conflicts.has(key)) return { kind: 'conflict' }
+
+    const existing = this.entries.get(key)
+    if (existing !== undefined) {
+      this.conflicts.add(key)
+      return { kind: 'conflict' }
+    }
+
+    const entry: DefinitionEntry = {
+      id: { scopePath: [...this.scopePath], ordinal: this.nextOrdinal++ },
+      key,
+      definition,
+    }
+    this.entries.set(key, entry)
+    return { kind: 'registered', entry }
+  }
+
+  lookup(target: ASTNode): DefinitionOpeningResult {
+    const key = definitionTargetKey(target)
+    if (key === null) return { kind: 'non-addressable' }
+
+    let current: DefinitionEnvironment | null = this
+    while (current !== null) {
+      if (current.conflicts.has(key)) return { kind: 'conflict' }
+      const entry = current.entries.get(key)
+      if (entry !== undefined) {
+        return {
+          kind: 'match',
+          definitionId: entry.id,
+          body: entry.definition.form,
+        }
+      }
+      current = current.parent
+    }
+    return { kind: 'no-match' }
+  }
+}
+
+export function openDefinition(
+  target: ASTNode,
+  environment: DefinitionEnvironment
+): DefinitionOpeningResult {
+  return environment.lookup(target)
+}

--- a/src/core/definitionEnvironment.ts
+++ b/src/core/definitionEnvironment.ts
@@ -330,24 +330,23 @@ export class DefinitionEnvironment {
     return { kind: 'registered', entry }
   }
 
+  private lookupKey(key: string): DefinitionOpeningResult {
+    if (this.conflicts.has(key)) return { kind: 'conflict' }
+    const entry = this.entries.get(key)
+    if (entry !== undefined) {
+      return {
+        kind: 'match',
+        definitionId: entry.id,
+        body: entry.definition.form,
+      }
+    }
+    return this.parent?.lookupKey(key) ?? { kind: 'no-match' }
+  }
+
   lookup(target: ASTNode): DefinitionOpeningResult {
     const key = definitionTargetKey(target)
     if (key === null) return { kind: 'non-addressable' }
-
-    let current: DefinitionEnvironment | null = this
-    while (current !== null) {
-      if (current.conflicts.has(key)) return { kind: 'conflict' }
-      const entry = current.entries.get(key)
-      if (entry !== undefined) {
-        return {
-          kind: 'match',
-          definitionId: entry.id,
-          body: entry.definition.form,
-        }
-      }
-      current = current.parent
-    }
-    return { kind: 'no-match' }
+    return this.lookupKey(key)
   }
 }
 

--- a/src/core/definitionEnvironment.ts
+++ b/src/core/definitionEnvironment.ts
@@ -169,7 +169,9 @@ function structuralValue(node: ASTNode | null): StructuralValue {
   if (node === null) return null
 
   switch (node.type) {
-    // anum_docs represents all of these unquoted atoms as Symbol(name).
+    // anum_docs represents all unquoted atoms as Symbol(name). aprover's
+    // quoted literal AST variants must preserve their quote delimiters because
+    // upstream treats the spelling itself as the Symbol name.
     case 'Identifier':
       return ['symbol', (node as IdentExpr).name]
     case 'Infinity':
@@ -177,9 +179,9 @@ function structuralValue(node: ASTNode | null): StructuralValue {
     case 'Num':
       return ['symbol', String((node as NumExpr).value)]
     case 'AbitLit':
-      return ['symbol', (node as AbitLitExpr).value]
+      return ['symbol', `'${(node as AbitLitExpr).value}'`]
     case 'StringLit':
-      return ['symbol', (node as StringLitExpr).value]
+      return ['symbol', `"${(node as StringLitExpr).value}"`]
     case 'Literal':
       return ['literal', (node as LiteralExpr).value]
     case 'ContextPronoun': {

--- a/src/core/proofArtifactPresentationVersioned.ts
+++ b/src/core/proofArtifactPresentationVersioned.ts
@@ -1,0 +1,199 @@
+import {
+  presentProofArtifactJson,
+  type ProofAliasView,
+  type ProofContextView,
+  type ProofStepReplayView,
+  type ProofSubstitutionView,
+} from './proofArtifactPresentation'
+import { formatOccurrencePath } from './interpretationPresentation'
+import type { ContextFrame } from './interpreter'
+import { MTS_PROOF_SCHEMA } from './proofReplay'
+import {
+  MTS_PROOF_SCHEMA_V03,
+  ProofObjectV03ValidationError,
+  checkJudgmentV03,
+  parseProofObjectV03,
+  type MtsProofJudgmentV03,
+} from './proofReplayV03'
+
+export interface VersionedEmptyProofArtifactView {
+  readonly status: 'empty'
+}
+
+export interface VersionedInvalidProofArtifactView {
+  readonly status: 'invalid'
+  readonly error: string
+  readonly errorPath?: string
+}
+
+export interface ProofJudgmentReplayView {
+  readonly index: number
+  readonly relation: string
+  readonly accepted: boolean
+  readonly primary: string
+  readonly context: readonly ProofContextView[]
+  readonly substitutions: readonly ProofSubstitutionView[]
+  readonly aliases: readonly ProofAliasView[]
+  readonly meta: readonly string[]
+  readonly details: readonly string[]
+}
+
+export interface ReplayedVersionedProofArtifactView {
+  readonly status: 'accepted' | 'rejected'
+  readonly version: 'v0.2' | 'v0.3'
+  readonly schema: string
+  readonly contractVersion: string
+  readonly accepted: boolean
+  readonly steps: readonly ProofStepReplayView[]
+  readonly judgments: readonly ProofJudgmentReplayView[]
+}
+
+export type VersionedProofArtifactView =
+  | VersionedEmptyProofArtifactView
+  | VersionedInvalidProofArtifactView
+  | ReplayedVersionedProofArtifactView
+
+function contextView(frame: ContextFrame): ProofContextView[] {
+  const result: ProofContextView[] = []
+  let current: ContextFrame | undefined = frame
+  let depth = 0
+  while (current !== undefined) {
+    result.push({ depth, start: current.start, end: current.end })
+    current = current.parent
+    depth += 1
+  }
+  return result
+}
+
+function pathText(path: readonly number[]): string {
+  return path.length === 0 ? 'root' : `[${path.join(',')}]`
+}
+
+function judgmentView(value: MtsProofJudgmentV03, index: number): ProofJudgmentReplayView {
+  const accepted = checkJudgmentV03(value)
+
+  if (value.relation === 'ContextuallySatisfies') {
+    return {
+      index: index + 1,
+      relation: value.relation,
+      accepted,
+      primary: value.expression,
+      context: contextView(value.context),
+      substitutions: value.expected.substitutions.map(item => ({
+        occurrence: formatOccurrencePath(item.path),
+        link: item.link,
+      })),
+      aliases: value.expected.aliases.map(item => ({
+        occurrence: formatOccurrencePath(item.path),
+        target: formatOccurrencePath(item.targetPath),
+      })),
+      meta: [`symbols: ${value.symbols.length}`, `distinguished links: ${value.memory.length}`],
+      details: [],
+    }
+  }
+
+  if (value.relation === 'Opens') {
+    return {
+      index: index + 1,
+      relation: value.relation,
+      accepted,
+      primary: value.target,
+      context: [],
+      substitutions: [],
+      aliases: [],
+      meta: [`lookup scope: ${pathText(value.lookupScope)}`, `scopes: ${value.scopes.length}`],
+      details: [
+        `DefinitionId: ${pathText(value.expected.definitionId.scopePath)} / ${value.expected.definitionId.ordinal}`,
+        `RHS: ${value.expected.body}`,
+      ],
+    }
+  }
+
+  if (value.relation === 'NoVisibleDefinition' || value.relation === 'DefinitionConflict') {
+    return {
+      index: index + 1,
+      relation: value.relation,
+      accepted,
+      primary: value.target,
+      context: [],
+      substitutions: [],
+      aliases: [],
+      meta: [`lookup scope: ${pathText(value.lookupScope)}`, `scopes: ${value.scopes.length}`],
+      details: [value.relation === 'NoVisibleDefinition' ? 'expected: no-match' : 'expected: conflict'],
+    }
+  }
+
+  return {
+    index: index + 1,
+    relation: value.relation,
+    accepted,
+    primary: value.target,
+    context: [],
+    substitutions: [],
+    aliases: [],
+    meta: [],
+    details: ['expected: non-addressable'],
+  }
+}
+
+function invalid(cause: unknown): VersionedInvalidProofArtifactView {
+  if (cause instanceof ProofObjectV03ValidationError) {
+    return { status: 'invalid', error: cause.message, errorPath: cause.path }
+  }
+  return {
+    status: 'invalid',
+    error: cause instanceof Error ? cause.message : 'Unknown proof artifact error',
+  }
+}
+
+/** Presentation-only version dispatch. Trusted replay remains in the versioned core modules. */
+export function presentVersionedProofArtifactJson(source: string): VersionedProofArtifactView {
+  if (!source.trim()) return { status: 'empty' }
+
+  let raw: unknown
+  try {
+    raw = JSON.parse(source) as unknown
+  } catch (cause) {
+    return invalid(cause)
+  }
+
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return { status: 'invalid', error: 'Proof artifact must be a JSON object' }
+  }
+  const record = raw as Record<string, unknown>
+
+  if (record.schema === MTS_PROOF_SCHEMA) {
+    const view = presentProofArtifactJson(source)
+    if (view.status === 'empty' || view.status === 'invalid') return view
+    return {
+      ...view,
+      version: 'v0.2',
+      judgments: [],
+    }
+  }
+
+  if (record.proofVersion !== MTS_PROOF_SCHEMA_V03) {
+    return {
+      status: 'invalid',
+      error: `Unsupported proof artifact version; expected ${MTS_PROOF_SCHEMA} or ${MTS_PROOF_SCHEMA_V03}`,
+      errorPath: record.proofVersion === undefined ? '$.schema/$.proofVersion' : '$.proofVersion',
+    }
+  }
+
+  try {
+    const proof = parseProofObjectV03(raw)
+    const judgments = proof.judgments.map(judgmentView)
+    const accepted = judgments.every(item => item.accepted)
+    return {
+      status: accepted ? 'accepted' : 'rejected',
+      version: 'v0.3',
+      schema: proof.proofVersion,
+      contractVersion: proof.contractVersion,
+      accepted,
+      steps: [],
+      judgments,
+    }
+  } catch (cause) {
+    return invalid(cause)
+  }
+}

--- a/src/core/proofReplayV03.ts
+++ b/src/core/proofReplayV03.ts
@@ -1,0 +1,490 @@
+import { parseExpr } from './parser'
+import { InterpretationSession } from './interpretationSession'
+import type {
+  ContextFrame,
+  InterpretationAlias,
+  InterpretationSubstitution,
+  OccurrencePath,
+} from './interpreter'
+import type { DistinguishedLink } from './memoryView'
+import {
+  DefinitionEnvironment,
+  canonicalExpression,
+  openDefinition,
+  parseDefinition,
+  parseDefinitionTarget,
+  type ScopePath,
+} from './definitionEnvironment'
+
+export const MTS_PROOF_SCHEMA_V03 = 'mts-proof/v0.3' as const
+export const MTS_PROOF_CONTRACT_VERSION_V03 = 'mts-contract/v0.3' as const
+
+export type MtsProofRelationV03 =
+  | 'ContextuallySatisfies'
+  | 'Opens'
+  | 'NoVisibleDefinition'
+  | 'DefinitionConflict'
+  | 'NonAddressableDefinitionTarget'
+
+export interface DefinitionScopeSnapshotV03 {
+  readonly path: ScopePath
+  readonly parent: ScopePath | null
+  readonly definitions: readonly string[]
+}
+
+export interface ExpectedDefinitionIdV03 {
+  readonly scopePath: ScopePath
+  readonly ordinal: number
+}
+
+export interface ContextuallySatisfiesJudgmentV03 {
+  readonly relation: 'ContextuallySatisfies'
+  readonly expression: string
+  readonly context: ContextFrame
+  readonly symbols: readonly (readonly [string, number])[]
+  readonly memory: readonly DistinguishedLink[]
+  readonly expected: {
+    readonly substitutions: readonly InterpretationSubstitution[]
+    readonly aliases: readonly InterpretationAlias[]
+  }
+}
+
+export interface OpensJudgmentV03 {
+  readonly relation: 'Opens'
+  readonly scopes: readonly DefinitionScopeSnapshotV03[]
+  readonly lookupScope: ScopePath
+  readonly target: string
+  readonly expected: {
+    readonly definitionId: ExpectedDefinitionIdV03
+    readonly body: string
+  }
+}
+
+export interface NoVisibleDefinitionJudgmentV03 {
+  readonly relation: 'NoVisibleDefinition'
+  readonly scopes: readonly DefinitionScopeSnapshotV03[]
+  readonly lookupScope: ScopePath
+  readonly target: string
+}
+
+export interface DefinitionConflictJudgmentV03 {
+  readonly relation: 'DefinitionConflict'
+  readonly scopes: readonly DefinitionScopeSnapshotV03[]
+  readonly lookupScope: ScopePath
+  readonly target: string
+}
+
+export interface NonAddressableDefinitionTargetJudgmentV03 {
+  readonly relation: 'NonAddressableDefinitionTarget'
+  readonly target: string
+}
+
+export type MtsProofJudgmentV03 =
+  | ContextuallySatisfiesJudgmentV03
+  | OpensJudgmentV03
+  | NoVisibleDefinitionJudgmentV03
+  | DefinitionConflictJudgmentV03
+  | NonAddressableDefinitionTargetJudgmentV03
+
+export interface MtsProofObjectV03 {
+  readonly proofVersion: typeof MTS_PROOF_SCHEMA_V03
+  readonly contractVersion: typeof MTS_PROOF_CONTRACT_VERSION_V03
+  readonly judgments: readonly MtsProofJudgmentV03[]
+}
+
+export class ProofObjectV03ValidationError extends Error {
+  readonly path: string
+
+  constructor(path: string, message: string) {
+    super(`${path}: ${message}`)
+    this.name = 'ProofObjectV03ValidationError'
+    this.path = path
+  }
+}
+
+type UnknownRecord = Record<string, unknown>
+
+function fail(path: string, message: string): never {
+  throw new ProofObjectV03ValidationError(path, message)
+}
+
+function record(value: unknown, path: string): UnknownRecord {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    fail(path, 'expected object')
+  }
+  return value as UnknownRecord
+}
+
+function exactKeys(source: UnknownRecord, expected: readonly string[], path: string): void {
+  const actual = Object.keys(source).sort()
+  const wanted = [...expected].sort()
+  if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+    fail(path, `expected exactly fields ${wanted.join(', ')}`)
+  }
+}
+
+function stringValue(value: unknown, path: string): string {
+  if (typeof value !== 'string') fail(path, 'expected string')
+  return value
+}
+
+function nonNegativeInt(value: unknown, path: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    fail(path, 'expected non-negative integer')
+  }
+  return value
+}
+
+function occurrencePath(value: unknown, path: string): OccurrencePath {
+  if (!Array.isArray(value)) fail(path, 'expected integer path array')
+  return value.map((part, index) => nonNegativeInt(part, `${path}[${index}]`))
+}
+
+function samePath(left: ScopePath, right: ScopePath): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index])
+}
+
+function comparePath(left: readonly number[], right: readonly number[]): number {
+  const length = Math.min(left.length, right.length)
+  for (let index = 0; index < length; index++) {
+    if (left[index] !== right[index]) return left[index] - right[index]
+  }
+  return left.length - right.length
+}
+
+function contextFrame(value: unknown, path: string): ContextFrame {
+  const source = record(value, path)
+  exactKeys(source, ['start', 'end', 'parent'], path)
+  return {
+    start: nonNegativeInt(source.start, `${path}.start`),
+    end: nonNegativeInt(source.end, `${path}.end`),
+    ...(source.parent === null ? {} : { parent: contextFrame(source.parent, `${path}.parent`) }),
+  }
+}
+
+function memory(value: unknown, path: string): readonly DistinguishedLink[] {
+  if (!Array.isArray(value)) fail(path, 'expected memory array')
+  const ids = new Set<number>()
+  const poles = new Set<string>()
+  return value.map((entry, index) => {
+    const itemPath = `${path}[${index}]`
+    const source = record(entry, itemPath)
+    exactKeys(source, ['id', 'start', 'end'], itemPath)
+    const result = {
+      id: nonNegativeInt(source.id, `${itemPath}.id`),
+      start: nonNegativeInt(source.start, `${itemPath}.start`),
+      end: nonNegativeInt(source.end, `${itemPath}.end`),
+    }
+    if (ids.has(result.id)) fail(`${itemPath}.id`, 'duplicate LinkRef')
+    const poleKey = `${result.start}:${result.end}`
+    if (poles.has(poleKey)) fail(itemPath, 'ambiguous duplicate poles')
+    ids.add(result.id)
+    poles.add(poleKey)
+    return result
+  })
+}
+
+function symbolBindings(value: unknown, path: string): readonly (readonly [string, number])[] {
+  if (!Array.isArray(value)) fail(path, 'expected symbol binding array')
+  const seen = new Set<string>()
+  const result = value.map((entry, index) => {
+    const itemPath = `${path}[${index}]`
+    if (!Array.isArray(entry) || entry.length !== 2) fail(itemPath, 'expected [name, LinkRef]')
+    const name = stringValue(entry[0], `${itemPath}[0]`)
+    if (name.length === 0) fail(`${itemPath}[0]`, 'symbol name must be non-empty')
+    if (seen.has(name)) fail(`${itemPath}[0]`, 'duplicate symbol binding')
+    seen.add(name)
+    return [name, nonNegativeInt(entry[1], `${itemPath}[1]`)] as const
+  })
+  const sorted = [...result].sort(([left], [right]) => left.localeCompare(right))
+  if (JSON.stringify(result) !== JSON.stringify(sorted)) fail(path, 'symbol bindings must be sorted')
+  return result
+}
+
+function substitutions(value: unknown, path: string): readonly InterpretationSubstitution[] {
+  if (!Array.isArray(value)) fail(path, 'expected substitutions array')
+  const seen = new Set<string>()
+  const result = value.map((entry, index) => {
+    const itemPath = `${path}[${index}]`
+    const source = record(entry, itemPath)
+    exactKeys(source, ['path', 'link'], itemPath)
+    const item = {
+      path: occurrencePath(source.path, `${itemPath}.path`),
+      link: nonNegativeInt(source.link, `${itemPath}.link`),
+    }
+    const key = JSON.stringify(item.path)
+    if (seen.has(key)) fail(`${itemPath}.path`, 'duplicate substitution path')
+    seen.add(key)
+    return item
+  })
+  const sorted = [...result].sort((left, right) => comparePath(left.path, right.path) || left.link - right.link)
+  if (JSON.stringify(result) !== JSON.stringify(sorted)) fail(path, 'substitutions must be sorted')
+  return result
+}
+
+function aliases(value: unknown, path: string): readonly InterpretationAlias[] {
+  if (!Array.isArray(value)) fail(path, 'expected aliases array')
+  const seen = new Set<string>()
+  const result = value.map((entry, index) => {
+    const itemPath = `${path}[${index}]`
+    const source = record(entry, itemPath)
+    exactKeys(source, ['path', 'targetPath'], itemPath)
+    const item = {
+      path: occurrencePath(source.path, `${itemPath}.path`),
+      targetPath: occurrencePath(source.targetPath, `${itemPath}.targetPath`),
+    }
+    const key = JSON.stringify(item.path)
+    if (seen.has(key)) fail(`${itemPath}.path`, 'duplicate alias path')
+    seen.add(key)
+    return item
+  })
+  const sorted = [...result].sort(
+    (left, right) => comparePath(left.path, right.path) || comparePath(left.targetPath, right.targetPath)
+  )
+  if (JSON.stringify(result) !== JSON.stringify(sorted)) fail(path, 'aliases must be sorted')
+  return result
+}
+
+function definitionScope(value: unknown, path: string): DefinitionScopeSnapshotV03 {
+  const source = record(value, path)
+  exactKeys(source, ['path', 'parent', 'definitions'], path)
+  const scopePath = occurrencePath(source.path, `${path}.path`)
+  const parent = source.parent === null ? null : occurrencePath(source.parent, `${path}.parent`)
+  if (!Array.isArray(source.definitions)) fail(`${path}.definitions`, 'expected definition string array')
+  const definitions = source.definitions.map((item, index) =>
+    stringValue(item, `${path}.definitions[${index}]`)
+  )
+  return { path: scopePath, parent, definitions }
+}
+
+function compareScope(left: DefinitionScopeSnapshotV03, right: DefinitionScopeSnapshotV03): number {
+  return left.path.length - right.path.length || comparePath(left.path, right.path)
+}
+
+function definitionScopes(value: unknown, path: string): readonly DefinitionScopeSnapshotV03[] {
+  if (!Array.isArray(value)) fail(path, 'expected lexical scopes array')
+  if (value.length === 0) fail(path, 'explicit root scope is required')
+  const result = value.map((item, index) => definitionScope(item, `${path}[${index}]`))
+  const sorted = [...result].sort(compareScope)
+  if (JSON.stringify(result) !== JSON.stringify(sorted)) fail(path, 'scopes must use canonical order')
+
+  const seen = new Set<string>()
+  for (const [index, scope] of result.entries()) {
+    const key = JSON.stringify(scope.path)
+    if (seen.has(key)) fail(`${path}[${index}].path`, 'duplicate scope path')
+    seen.add(key)
+    if (scope.parent === null) {
+      if (index !== 0 || scope.path.length !== 0) fail(`${path}[${index}]`, 'root scope must be first')
+    } else {
+      if (scope.path.length === 0 || !samePath(scope.path.slice(0, -1), scope.parent)) {
+        fail(`${path}[${index}].parent`, 'scope must extend parent by one index')
+      }
+      if (!seen.has(JSON.stringify(scope.parent))) {
+        fail(`${path}[${index}].parent`, 'parent scope must precede child')
+      }
+    }
+  }
+  if (!samePath(result[0].path, []) || result[0].parent !== null) fail(path, 'root scope is required')
+  return result
+}
+
+function expectedDefinitionId(value: unknown, path: string): ExpectedDefinitionIdV03 {
+  const source = record(value, path)
+  exactKeys(source, ['scopePath', 'ordinal'], path)
+  return {
+    scopePath: occurrencePath(source.scopePath, `${path}.scopePath`),
+    ordinal: nonNegativeInt(source.ordinal, `${path}.ordinal`),
+  }
+}
+
+function commonDefinitionJudgment(
+  source: UnknownRecord,
+  path: string
+): { scopes: readonly DefinitionScopeSnapshotV03[]; lookupScope: ScopePath; target: string } {
+  return {
+    scopes: definitionScopes(source.scopes, `${path}.scopes`),
+    lookupScope: occurrencePath(source.lookupScope, `${path}.lookupScope`),
+    target: stringValue(source.target, `${path}.target`),
+  }
+}
+
+function judgment(value: unknown, path: string): MtsProofJudgmentV03 {
+  const source = record(value, path)
+  const relation = stringValue(source.relation, `${path}.relation`)
+
+  if (relation === 'ContextuallySatisfies') {
+    exactKeys(source, ['relation', 'expression', 'context', 'symbols', 'memory', 'expected'], path)
+    const expected = record(source.expected, `${path}.expected`)
+    exactKeys(expected, ['substitutions', 'aliases'], `${path}.expected`)
+    return {
+      relation,
+      expression: stringValue(source.expression, `${path}.expression`),
+      context: contextFrame(source.context, `${path}.context`),
+      symbols: symbolBindings(source.symbols, `${path}.symbols`),
+      memory: memory(source.memory, `${path}.memory`),
+      expected: {
+        substitutions: substitutions(expected.substitutions, `${path}.expected.substitutions`),
+        aliases: aliases(expected.aliases, `${path}.expected.aliases`),
+      },
+    }
+  }
+
+  if (relation === 'Opens') {
+    exactKeys(source, ['relation', 'scopes', 'lookupScope', 'target', 'expected'], path)
+    const expected = record(source.expected, `${path}.expected`)
+    exactKeys(expected, ['definitionId', 'body'], `${path}.expected`)
+    return {
+      relation,
+      ...commonDefinitionJudgment(source, path),
+      expected: {
+        definitionId: expectedDefinitionId(expected.definitionId, `${path}.expected.definitionId`),
+        body: stringValue(expected.body, `${path}.expected.body`),
+      },
+    }
+  }
+
+  if (relation === 'NoVisibleDefinition' || relation === 'DefinitionConflict') {
+    exactKeys(source, ['relation', 'scopes', 'lookupScope', 'target'], path)
+    return { relation, ...commonDefinitionJudgment(source, path) }
+  }
+
+  if (relation === 'NonAddressableDefinitionTarget') {
+    exactKeys(source, ['relation', 'target'], path)
+    return { relation, target: stringValue(source.target, `${path}.target`) }
+  }
+
+  fail(`${path}.relation`, `unsupported relation ${JSON.stringify(relation)}`)
+}
+
+export function parseProofObjectV03(value: unknown): MtsProofObjectV03 {
+  const source = record(value, '$')
+  exactKeys(source, ['proofVersion', 'contractVersion', 'judgments'], '$')
+  const proofVersion = stringValue(source.proofVersion, '$.proofVersion')
+  if (proofVersion !== MTS_PROOF_SCHEMA_V03) {
+    fail('$.proofVersion', `expected ${MTS_PROOF_SCHEMA_V03}, got ${JSON.stringify(proofVersion)}`)
+  }
+  const contractVersion = stringValue(source.contractVersion, '$.contractVersion')
+  if (contractVersion !== MTS_PROOF_CONTRACT_VERSION_V03) {
+    fail(
+      '$.contractVersion',
+      `expected ${MTS_PROOF_CONTRACT_VERSION_V03}, got ${JSON.stringify(contractVersion)}`
+    )
+  }
+  if (!Array.isArray(source.judgments)) fail('$.judgments', 'expected judgments array')
+  return {
+    proofVersion: MTS_PROOF_SCHEMA_V03,
+    contractVersion: MTS_PROOF_CONTRACT_VERSION_V03,
+    judgments: source.judgments.map((item, index) => judgment(item, `$.judgments[${index}]`)),
+  }
+}
+
+export function parseProofJsonV03(source: string): MtsProofObjectV03 {
+  try {
+    return parseProofObjectV03(JSON.parse(source) as unknown)
+  } catch (cause) {
+    if (cause instanceof ProofObjectV03ValidationError) throw cause
+    const message = cause instanceof Error ? cause.message : 'invalid JSON'
+    fail('$', `invalid JSON: ${message}`)
+  }
+}
+
+function sameJson(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right)
+}
+
+function normalizedSubstitutions(
+  values: readonly InterpretationSubstitution[]
+): InterpretationSubstitution[] {
+  return [...values]
+    .map(item => ({ path: [...item.path], link: item.link }))
+    .sort((left, right) => comparePath(left.path, right.path) || left.link - right.link)
+}
+
+function normalizedAliases(values: readonly InterpretationAlias[]): InterpretationAlias[] {
+  return [...values]
+    .map(item => ({ path: [...item.path], targetPath: [...item.targetPath] }))
+    .sort(
+      (left, right) =>
+        comparePath(left.path, right.path) || comparePath(left.targetPath, right.targetPath)
+    )
+}
+
+function buildEnvironments(
+  scopes: readonly DefinitionScopeSnapshotV03[]
+): Map<string, DefinitionEnvironment> {
+  const environments = new Map<string, DefinitionEnvironment>()
+  for (const scope of scopes) {
+    let environment: DefinitionEnvironment
+    if (scope.parent === null) {
+      environment = new DefinitionEnvironment()
+    } else {
+      const parent = environments.get(JSON.stringify(scope.parent))
+      if (parent === undefined) throw new Error('missing parent definition scope')
+      environment = parent.child(scope.path[scope.path.length - 1])
+    }
+    environments.set(JSON.stringify(scope.path), environment)
+    for (const source of scope.definitions) environment.register(parseDefinition(source))
+  }
+  return environments
+}
+
+function replayDefinition(
+  scopes: readonly DefinitionScopeSnapshotV03[],
+  lookupScope: ScopePath,
+  target: string
+) {
+  const environments = buildEnvironments(scopes)
+  const environment = environments.get(JSON.stringify(lookupScope))
+  if (environment === undefined) throw new Error('lookupScope is not serialized')
+  return openDefinition(parseDefinitionTarget(target), environment)
+}
+
+export function checkJudgmentV03(value: MtsProofJudgmentV03): boolean {
+  try {
+    if (value.relation === 'ContextuallySatisfies') {
+      const session = new InterpretationSession({
+        context: value.context,
+        symbols: Object.fromEntries(value.symbols),
+        links: value.memory,
+      })
+      const before = session.memorySnapshot()
+      const result = session.interpret(parseExpr(value.expression))
+      const after = session.memorySnapshot()
+      return (
+        sameJson(before, after) &&
+        result.success === true &&
+        sameJson(normalizedSubstitutions(result.substitutions), value.expected.substitutions) &&
+        sameJson(normalizedAliases(result.aliases), value.expected.aliases)
+      )
+    }
+
+    if (value.relation === 'NonAddressableDefinitionTarget') {
+      const result = openDefinition(parseDefinitionTarget(value.target), new DefinitionEnvironment())
+      return result.kind === 'non-addressable'
+    }
+
+    const result = replayDefinition(value.scopes, value.lookupScope, value.target)
+    if (value.relation === 'NoVisibleDefinition') return result.kind === 'no-match'
+    if (value.relation === 'DefinitionConflict') return result.kind === 'conflict'
+    if (result.kind !== 'match' || result.definitionId === undefined || result.body === undefined) {
+      return false
+    }
+    return (
+      samePath(result.definitionId.scopePath, value.expected.definitionId.scopePath) &&
+      result.definitionId.ordinal === value.expected.definitionId.ordinal &&
+      canonicalExpression(result.body) === value.expected.body
+    )
+  } catch {
+    return false
+  }
+}
+
+/** Independently replay every base judgment; array order has no inference meaning. */
+export function checkProofV03(proof: MtsProofObjectV03): boolean {
+  try {
+    const decoded = parseProofObjectV03(proof)
+    return decoded.judgments.every(checkJudgmentV03)
+  } catch {
+    return false
+  }
+}

--- a/src/core/proofReplayV03.ts
+++ b/src/core/proofReplayV03.ts
@@ -479,12 +479,13 @@ export function checkJudgmentV03(value: MtsProofJudgmentV03): boolean {
   }
 }
 
-/** Independently replay every base judgment; array order has no inference meaning. */
+/** Independently replay every already decoded base judgment; order has no inference meaning. */
 export function checkProofV03(proof: MtsProofObjectV03): boolean {
-  try {
-    const decoded = parseProofObjectV03(proof)
-    return decoded.judgments.every(checkJudgmentV03)
-  } catch {
+  if (
+    proof.proofVersion !== MTS_PROOF_SCHEMA_V03 ||
+    proof.contractVersion !== MTS_PROOF_CONTRACT_VERSION_V03
+  ) {
     return false
   }
+  return proof.judgments.every(checkJudgmentV03)
 }

--- a/src/core/proofReplayVersioned.ts
+++ b/src/core/proofReplayVersioned.ts
@@ -1,0 +1,46 @@
+import {
+  MTS_PROOF_SCHEMA,
+  checkProof,
+  parseProofObject,
+  type MtsProofObjectV02,
+} from './proofReplay'
+import {
+  MTS_PROOF_SCHEMA_V03,
+  checkProofV03,
+  parseProofObjectV03,
+  type MtsProofObjectV03,
+} from './proofReplayV03'
+
+export type VersionedProofObject = MtsProofObjectV02 | MtsProofObjectV03
+
+export type ProofReplayVersion = typeof MTS_PROOF_SCHEMA | typeof MTS_PROOF_SCHEMA_V03
+
+function objectRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+export function detectProofVersion(value: unknown): ProofReplayVersion | null {
+  const source = objectRecord(value)
+  if (source === null) return null
+  if (source.schema === MTS_PROOF_SCHEMA) return MTS_PROOF_SCHEMA
+  if (source.proofVersion === MTS_PROOF_SCHEMA_V03) return MTS_PROOF_SCHEMA_V03
+  return null
+}
+
+export function parseVersionedProofObject(value: unknown): VersionedProofObject {
+  const version = detectProofVersion(value)
+  if (version === MTS_PROOF_SCHEMA) return parseProofObject(value)
+  if (version === MTS_PROOF_SCHEMA_V03) return parseProofObjectV03(value)
+  throw new Error('unsupported MTS proof artifact version')
+}
+
+export function checkVersionedProof(value: unknown): boolean {
+  try {
+    const proof = parseVersionedProofObject(value)
+    return 'schema' in proof ? checkProof(proof) : checkProofV03(proof)
+  } catch {
+    return false
+  }
+}

--- a/src/core/proofReplayVersioned.ts
+++ b/src/core/proofReplayVersioned.ts
@@ -6,7 +6,7 @@ import {
 } from './proofReplay'
 import {
   MTS_PROOF_SCHEMA_V03,
-  checkProofV03,
+  checkJudgmentV03,
   parseProofObjectV03,
   type MtsProofObjectV03,
 } from './proofReplayV03'
@@ -39,7 +39,7 @@ export function parseVersionedProofObject(value: unknown): VersionedProofObject 
 export function checkVersionedProof(value: unknown): boolean {
   try {
     const proof = parseVersionedProofObject(value)
-    return 'schema' in proof ? checkProof(proof) : checkProofV03(proof)
+    return 'schema' in proof ? checkProof(proof) : proof.judgments.every(checkJudgmentV03)
   } catch {
     return false
   }

--- a/tests/e2e/proof-replay-v03.spec.ts
+++ b/tests/e2e/proof-replay-v03.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test'
+
+function openingArtifact(body = 'b') {
+  return JSON.stringify({
+    proofVersion: 'mts-proof/v0.3',
+    contractVersion: 'mts-contract/v0.3',
+    judgments: [
+      {
+        relation: 'Opens',
+        scopes: [{ path: [], parent: null, definitions: ['a : b'] }],
+        lookupScope: [],
+        target: 'a',
+        expected: {
+          definitionId: { scopePath: [], ordinal: 0 },
+          body,
+        },
+      },
+    ],
+  })
+}
+
+test.describe('aprover trusted proof v0.3 replay', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.locator('.proof-replay-toggle').click()
+  })
+
+  test('loads and independently accepts an Opens base judgment', async ({ page }) => {
+    await page.locator('#proof-artifact-source').fill(openingArtifact())
+
+    await expect(page.locator('.proof-verdict')).toContainText('REPLAY ACCEPTED')
+    await expect(page.getByTestId('proof-v03-judgments')).toBeVisible()
+    await expect(page.getByTestId('proof-v03-judgments')).toContainText('Opens')
+    await expect(page.getByTestId('proof-v03-judgments')).toContainText('DefinitionId: root / 0')
+    await expect(page.getByTestId('proof-v03-judgments')).toContainText('RHS: b')
+    await expect(page.locator('.proof-summary')).toContainText('mts-proof/v0.3')
+    await expect(page.locator('.proof-summary')).toContainText('mts-contract/v0.3')
+  })
+
+  test('separates forged replay from transport validation errors', async ({ page }) => {
+    await page.locator('#proof-artifact-source').fill(openingArtifact('c'))
+    await expect(page.locator('.proof-verdict')).toContainText('REPLAY REJECTED')
+    await expect(page.getByTestId('proof-v03-judgments')).toContainText('rejected')
+
+    await page.locator('#proof-artifact-source').fill(
+      JSON.stringify({
+        proofVersion: 'mts-proof/v0.3',
+        contractVersion: 'mts-contract/v0.3',
+        judgments: [{ relation: 'Opens', target: 'a' }],
+      })
+    )
+    await expect(page.locator('.proof-invalid')).toContainText('Validation error')
+    await expect(page.locator('.proof-invalid')).toContainText('judgments[0]')
+    await expect(page.locator('.proof-verdict')).toHaveCount(0)
+  })
+
+  test('keeps Search on the existing v0.2 one-step bridge', async ({ page }) => {
+    await page.locator('.proof-search-open').click()
+    await page.locator('.proof-search-run').click()
+    await expect(page.locator('.proof-search-status')).toContainText('SEARCH PROVEN')
+
+    const artifact = await page.getByLabel('Generated proof artifact JSON').inputValue()
+    expect(artifact).toContain('mts-proof/v0.2')
+    expect(artifact).not.toContain('mts-proof/v0.3')
+  })
+})

--- a/tests/unit/definitionEnvironmentParity.test.ts
+++ b/tests/unit/definitionEnvironmentParity.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DefinitionEnvironment,
+  definitionTargetKey,
+  openDefinition,
+  parseDefinition,
+  parseDefinitionTarget,
+} from '../../src/core/definitionEnvironment'
+
+describe('DefinitionEnvironment upstream structural-key parity', () => {
+  it('keeps quote delimiters as part of Symbol spelling', () => {
+    const abit = parseDefinitionTarget("'01'")
+    const string = parseDefinitionTarget('"01"')
+
+    expect(definitionTargetKey(abit)).toBe(JSON.stringify(['symbol', "'01'"]))
+    expect(definitionTargetKey(string)).toBe(JSON.stringify(['symbol', '"01"']))
+    expect(definitionTargetKey(abit)).not.toBe(definitionTargetKey(string))
+  })
+
+  it('does not cross-match distinct quoted spellings', () => {
+    const environment = new DefinitionEnvironment()
+    expect(environment.register(parseDefinition("'01' : a")).kind).toBe('registered')
+    expect(environment.register(parseDefinition('"01" : b')).kind).toBe('registered')
+
+    const abit = openDefinition(parseDefinitionTarget("'01'"), environment)
+    const string = openDefinition(parseDefinitionTarget('"01"'), environment)
+
+    expect(abit.kind).toBe('match')
+    expect(string.kind).toBe('match')
+    expect(abit.definitionId).toEqual({ scopePath: [], ordinal: 0 })
+    expect(string.definitionId).toEqual({ scopePath: [], ordinal: 1 })
+  })
+})

--- a/tests/unit/proofArtifactPresentationVersioned.test.ts
+++ b/tests/unit/proofArtifactPresentationVersioned.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import { presentVersionedProofArtifactJson } from '../../src/core/proofArtifactPresentationVersioned'
+
+function openingArtifact(body = 'b') {
+  return JSON.stringify({
+    proofVersion: 'mts-proof/v0.3',
+    contractVersion: 'mts-contract/v0.3',
+    judgments: [
+      {
+        relation: 'Opens',
+        scopes: [{ path: [], parent: null, definitions: ['a : b'] }],
+        lookupScope: [],
+        target: 'a',
+        expected: {
+          definitionId: { scopePath: [], ordinal: 0 },
+          body,
+        },
+      },
+    ],
+  })
+}
+
+function v02Artifact() {
+  return JSON.stringify({
+    schema: 'mts-proof/v0.2',
+    contractVersion: 'mts-contract/v0.2',
+    steps: [],
+  })
+}
+
+describe('versioned proof artifact presentation', () => {
+  it('keeps existing v0.2 presentation available through version dispatch', () => {
+    const view = presentVersionedProofArtifactJson(v02Artifact())
+    expect(view.status).toBe('accepted')
+    if (view.status !== 'accepted') throw new Error('expected accepted v0.2 proof')
+    expect(view.version).toBe('v0.2')
+    expect(view.schema).toBe('mts-proof/v0.2')
+    expect(view.steps).toEqual([])
+    expect(view.judgments).toEqual([])
+  })
+
+  it('presents an independently accepted v0.3 base judgment', () => {
+    const view = presentVersionedProofArtifactJson(openingArtifact())
+    expect(view.status).toBe('accepted')
+    if (view.status !== 'accepted') throw new Error('expected accepted v0.3 proof')
+
+    expect(view.version).toBe('v0.3')
+    expect(view.schema).toBe('mts-proof/v0.3')
+    expect(view.contractVersion).toBe('mts-contract/v0.3')
+    expect(view.steps).toEqual([])
+    expect(view.judgments).toHaveLength(1)
+    expect(view.judgments[0]).toMatchObject({
+      index: 1,
+      relation: 'Opens',
+      accepted: true,
+      primary: 'a',
+      meta: ['lookup scope: root', 'scopes: 1'],
+      details: ['DefinitionId: root / 0', 'RHS: b'],
+    })
+  })
+
+  it('distinguishes a forged but structurally valid v0.3 claim from invalid JSON', () => {
+    const forged = presentVersionedProofArtifactJson(openingArtifact('c'))
+    expect(forged.status).toBe('rejected')
+    if (forged.status !== 'rejected') throw new Error('expected replay rejection')
+    expect(forged.judgments[0].accepted).toBe(false)
+
+    const invalid = presentVersionedProofArtifactJson(
+      JSON.stringify({
+        proofVersion: 'mts-proof/v0.3',
+        contractVersion: 'mts-contract/v0.3',
+        judgments: [{ relation: 'Opens', target: 'a' }],
+      })
+    )
+    expect(invalid.status).toBe('invalid')
+    if (invalid.status !== 'invalid') throw new Error('expected validation error')
+    expect(invalid.errorPath).toContain('judgments[0]')
+  })
+
+  it('rejects unknown proof versions before replay', () => {
+    const view = presentVersionedProofArtifactJson(
+      JSON.stringify({ proofVersion: 'mts-proof/v9', contractVersion: 'mts-contract/v9', judgments: [] })
+    )
+    expect(view.status).toBe('invalid')
+    if (view.status !== 'invalid') throw new Error('expected invalid version')
+    expect(view.error).toContain('mts-proof/v0.2')
+    expect(view.error).toContain('mts-proof/v0.3')
+  })
+})

--- a/tests/unit/proofReplayV03.test.ts
+++ b/tests/unit/proofReplayV03.test.ts
@@ -15,7 +15,6 @@ import {
   MTS_PROOF_CONTRACT_VERSION_V03,
   MTS_PROOF_SCHEMA_V03,
   checkJudgmentV03,
-  checkProofV03,
   parseProofObjectV03,
 } from '../../src/core/proofReplayV03'
 import { checkVersionedProof, detectProofVersion } from '../../src/core/proofReplayVersioned'
@@ -203,7 +202,7 @@ describe('trusted mts-proof/v0.3 replay', () => {
       const proof = parseProofObjectV03(proofArtifact([vector.judgment]))
       expect(proof.judgments).toHaveLength(1)
       expect(checkJudgmentV03(proof.judgments[0]), vector.id).toBe(true)
-      expect(checkProofV03(proof), vector.id).toBe(true)
+      expect(proof.judgments.every(checkJudgmentV03), vector.id).toBe(true)
       expect(checkVersionedProof(proofArtifact([vector.judgment])), vector.id).toBe(true)
     }
   })
@@ -224,8 +223,8 @@ describe('trusted mts-proof/v0.3 replay', () => {
   it('не придаёт порядку judgments никакой dependency semantics', () => {
     const values = [...validById().values()]
     const proof = parseProofObjectV03(proofArtifact([values[2], values[5]]))
-    expect(checkProofV03(proof)).toBe(true)
-    expect(checkProofV03({ ...proof, judgments: [...proof.judgments].reverse() })).toBe(true)
+    expect(proof.judgments.every(checkJudgmentV03)).toBe(true)
+    expect([...proof.judgments].reverse().every(checkJudgmentV03)).toBe(true)
   })
 
   it('определяет version явно и не преобразует v0.2/v0.3 друг в друга', () => {

--- a/tests/unit/proofReplayV03.test.ts
+++ b/tests/unit/proofReplayV03.test.ts
@@ -104,7 +104,7 @@ function forgeryJudgment(vector: ProofCorpus['forgeries'][number]): Record<strin
   if (vector.judgment !== undefined) return clone(vector.judgment)
   const source = validById().get(vector.sourceJudgment ?? '')
   if (source === undefined) throw new Error(`missing source judgment ${vector.sourceJudgment}`)
-  let result = vector.patch === undefined ? clone(source) : patchDotted(source, vector.patch)
+  const result = vector.patch === undefined ? clone(source) : patchDotted(source, vector.patch)
   if (vector.replaceRelation !== undefined) result.relation = vector.replaceRelation
   for (const key of vector.remove ?? []) delete result[key]
   return result

--- a/tests/unit/proofReplayV03.test.ts
+++ b/tests/unit/proofReplayV03.test.ts
@@ -1,0 +1,238 @@
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  DefinitionEnvironment,
+  canonicalExpression,
+  definitionTargetKey,
+  openDefinition,
+  parseDefinition,
+  parseDefinitionTarget,
+} from '../../src/core/definitionEnvironment'
+import {
+  MTS_PROOF_CONTRACT_VERSION_V03,
+  MTS_PROOF_SCHEMA_V03,
+  checkJudgmentV03,
+  checkProofV03,
+  parseProofObjectV03,
+} from '../../src/core/proofReplayV03'
+import { checkVersionedProof, detectProofVersion } from '../../src/core/proofReplayVersioned'
+
+const bundleRoot = resolve(process.cwd(), 'contracts/anum_docs-v0.4')
+const contractPath = resolve(bundleRoot, 'mts-contract-v0.4.json')
+const conformancePath = resolve(bundleRoot, 'mts-conformance-v0.4.json')
+const proofPath = resolve(bundleRoot, 'mts-proof-v0.3.json')
+const proofConformancePath = resolve(bundleRoot, 'mts-proof-conformance-v0.3.json')
+const provenancePath = resolve(bundleRoot, 'provenance.json')
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8')) as unknown
+}
+
+function gitBlobSha(path: string): string {
+  const content = readFileSync(path)
+  return createHash('sha1')
+    .update(`blob ${content.byteLength}\0`)
+    .update(content)
+    .digest('hex')
+}
+
+interface ArtifactProvenance {
+  path: string
+  sourceCommit: string
+  gitBlobSha: string
+}
+
+interface Provenance {
+  sourceRepository: string
+  sourceCommit: string
+  contract: ArtifactProvenance
+  conformance: ArtifactProvenance
+  proof: ArtifactProvenance
+  proofConformance: ArtifactProvenance
+}
+
+interface ProofCorpus {
+  proofVersion: string
+  contractVersion: string
+  validJudgments: Array<{ id: string; judgment: Record<string, unknown> }>
+  invalidArtifacts: Array<{ id: string; artifact: unknown }>
+  forgeries: Array<{
+    id: string
+    sourceJudgment?: string
+    patch?: Record<string, unknown>
+    replaceRelation?: string
+    remove?: string[]
+    judgment?: Record<string, unknown>
+    mustReject: boolean
+  }>
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function patchDotted(source: Record<string, unknown>, patch: Record<string, unknown>) {
+  const result = clone(source)
+  for (const [dotted, replacement] of Object.entries(patch)) {
+    const parts = dotted.split('.')
+    let current = result
+    for (const part of parts.slice(0, -1)) current = current[part] as Record<string, unknown>
+    current[parts[parts.length - 1]] = clone(replacement)
+  }
+  return result
+}
+
+function proofArtifact(judgments: readonly unknown[]) {
+  return {
+    proofVersion: MTS_PROOF_SCHEMA_V03,
+    contractVersion: MTS_PROOF_CONTRACT_VERSION_V03,
+    judgments,
+  }
+}
+
+function proofCorpus(): ProofCorpus {
+  return readJson(proofConformancePath) as ProofCorpus
+}
+
+function validById(): Map<string, Record<string, unknown>> {
+  return new Map(proofCorpus().validJudgments.map(item => [item.id, item.judgment]))
+}
+
+function forgeryJudgment(vector: ProofCorpus['forgeries'][number]): Record<string, unknown> {
+  if (vector.judgment !== undefined) return clone(vector.judgment)
+  const source = validById().get(vector.sourceJudgment ?? '')
+  if (source === undefined) throw new Error(`missing source judgment ${vector.sourceJudgment}`)
+  let result = vector.patch === undefined ? clone(source) : patchDotted(source, vector.patch)
+  if (vector.replaceRelation !== undefined) result.relation = vector.replaceRelation
+  for (const key of vector.remove ?? []) delete result[key]
+  return result
+}
+
+describe('закреплённый MTS v0.4 / proof v0.3 bundle', () => {
+  it('проверяет byte-exact provenance upstream release', () => {
+    const provenance = readJson(provenancePath) as Provenance
+
+    expect(provenance.sourceRepository).toBe('netkeep80/anum_docs')
+    expect(provenance.sourceCommit).toBe('ec8161ceeecbecfd95481688821785fd32757873')
+    const artifacts: Array<[string, ArtifactProvenance, string]> = [
+      [contractPath, provenance.contract, '52ff42a3f1b4112b1a1707f4cec8a8bee07281f3'],
+      [conformancePath, provenance.conformance, '4fbf336833dca0b6f3d9fe6143a2f40a8bd62474'],
+      [proofPath, provenance.proof, '9cbc83e51ca83d391eb8d2018dcc5b2d25e8e65f'],
+      [
+        proofConformancePath,
+        provenance.proofConformance,
+        'c7f0223eee0564138e783a27f00b13bf8b48bcf9',
+      ],
+    ]
+    for (const [path, artifact, sha] of artifacts) {
+      expect(artifact.sourceCommit).toBe(provenance.sourceCommit)
+      expect(artifact.gitBlobSha).toBe(sha)
+      expect(gitBlobSha(path)).toBe(sha)
+    }
+  })
+
+  it('закрепляет proof-publication boundary без composition и subject/focus semantics', () => {
+    const contract = readJson(contractPath) as {
+      schema: string
+      l5: { proofSchema: string; trustedRelations: string[]; genericCompositionAccepted: boolean }
+      contextBoundary: { subjectIdentity: boolean; currentFocusLinkRefIdentity: boolean }
+      downstream: { aproverProofRepinAllowed: boolean; consumerMayInventCompositionRules: boolean }
+    }
+    expect(contract.schema).toBe('mts-contract/v0.4')
+    expect(contract.l5.proofSchema).toBe(MTS_PROOF_SCHEMA_V03)
+    expect(contract.l5.trustedRelations).toEqual([
+      'ContextuallySatisfies',
+      'Opens',
+      'NoVisibleDefinition',
+      'DefinitionConflict',
+      'NonAddressableDefinitionTarget',
+    ])
+    expect(contract.l5.genericCompositionAccepted).toBe(false)
+    expect(contract.contextBoundary.subjectIdentity).toBe(false)
+    expect(contract.contextBoundary.currentFocusLinkRefIdentity).toBe(false)
+    expect(contract.downstream.aproverProofRepinAllowed).toBe(true)
+    expect(contract.downstream.consumerMayInventCompositionRules).toBe(false)
+  })
+})
+
+describe('DefinitionEnvironment v0.3 consumer', () => {
+  it('повторяет nearest-scope shadowing и replay-local DefinitionId', () => {
+    const root = new DefinitionEnvironment()
+    expect(root.register(parseDefinition('a : root')).kind).toBe('registered')
+    const child = root.child(0)
+    expect(child.register(parseDefinition('a : child')).kind).toBe('registered')
+
+    const opened = openDefinition(parseDefinitionTarget('a'), child)
+    expect(opened.kind).toBe('match')
+    expect(opened.definitionId).toEqual({ scopePath: [0], ordinal: 0 })
+    expect(canonicalExpression(opened.body!)).toBe('child')
+  })
+
+  it('отличает conflict от equality и не раскрывает RHS рекурсивно', () => {
+    const environment = new DefinitionEnvironment()
+    expect(environment.register(parseDefinition('a : b')).kind).toBe('registered')
+    expect(environment.register(parseDefinition('a : c')).kind).toBe('conflict')
+    expect(openDefinition(parseDefinitionTarget('a'), environment)).toEqual({ kind: 'conflict' })
+  })
+
+  it('не делает дейксис и anonymous [] глобальными definition keys', () => {
+    expect(definitionTargetKey(parseDefinitionTarget('◁'))).toBeNull()
+    expect(definitionTargetKey(parseDefinitionTarget('↑▷'))).toBeNull()
+    expect(definitionTargetKey(parseDefinitionTarget('[]'))).toBeNull()
+    expect(definitionTargetKey(parseDefinitionTarget('[1]'))).not.toBeNull()
+    expect(definitionTargetKey(parseDefinitionTarget('(=)'))).not.toBeNull()
+  })
+
+  it('использует upstream-compatible canonical formatter, а не display printer identity', () => {
+    const definition = parseDefinition('x : {◁ = ∞, ▷ = ∞}')
+    expect(canonicalExpression(definition)).toBe('x : {◁ = ∞, ▷ = ∞}')
+    expect(canonicalExpression(parseDefinition('a : b ⟼ c').form)).toBe('b ⟼ c')
+  })
+})
+
+describe('trusted mts-proof/v0.3 replay', () => {
+  it('replay-ит каждый upstream valid judgment', () => {
+    const corpus = proofCorpus()
+    expect(corpus.proofVersion).toBe(MTS_PROOF_SCHEMA_V03)
+    expect(corpus.contractVersion).toBe(MTS_PROOF_CONTRACT_VERSION_V03)
+
+    for (const vector of corpus.validJudgments) {
+      const proof = parseProofObjectV03(proofArtifact([vector.judgment]))
+      expect(proof.judgments).toHaveLength(1)
+      expect(checkJudgmentV03(proof.judgments[0]), vector.id).toBe(true)
+      expect(checkProofV03(proof), vector.id).toBe(true)
+      expect(checkVersionedProof(proofArtifact([vector.judgment])), vector.id).toBe(true)
+    }
+  })
+
+  it('fail-closed для upstream invalid artifact vectors', () => {
+    for (const vector of proofCorpus().invalidArtifacts) {
+      expect(checkVersionedProof(vector.artifact), vector.id).toBe(false)
+    }
+  })
+
+  it('отвергает каждую upstream forgery независимым replay', () => {
+    for (const vector of proofCorpus().forgeries) {
+      expect(vector.mustReject).toBe(true)
+      expect(checkVersionedProof(proofArtifact([forgeryJudgment(vector)])), vector.id).toBe(false)
+    }
+  })
+
+  it('не придаёт порядку judgments никакой dependency semantics', () => {
+    const values = [...validById().values()]
+    const proof = parseProofObjectV03(proofArtifact([values[2], values[5]]))
+    expect(checkProofV03(proof)).toBe(true)
+    expect(checkProofV03({ ...proof, judgments: [...proof.judgments].reverse() })).toBe(true)
+  })
+
+  it('определяет version явно и не преобразует v0.2/v0.3 друг в друга', () => {
+    expect(detectProofVersion(proofArtifact([]))).toBe(MTS_PROOF_SCHEMA_V03)
+    expect(
+      detectProofVersion({ schema: 'mts-proof/v0.2', contractVersion: 'mts-contract/v0.2', steps: [] })
+    ).toBe('mts-proof/v0.2')
+    expect(detectProofVersion({ proofVersion: 'mts-proof/v9', judgments: [] })).toBeNull()
+  })
+})

--- a/tests/unit/proofReplayV03Typed.test.ts
+++ b/tests/unit/proofReplayV03Typed.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { checkProofV03, parseProofObjectV03 } from '../../src/core/proofReplayV03'
+
+describe('typed mts-proof/v0.3 replay boundary', () => {
+  it('replays a decoded ContextuallySatisfies proof without re-running raw JSON validation', () => {
+    const proof = parseProofObjectV03({
+      proofVersion: 'mts-proof/v0.3',
+      contractVersion: 'mts-contract/v0.3',
+      judgments: [
+        {
+          relation: 'ContextuallySatisfies',
+          expression: '[] = []',
+          context: { start: 1, end: 1, parent: null },
+          symbols: [],
+          memory: [],
+          expected: {
+            substitutions: [],
+            aliases: [{ path: [1], targetPath: [0] }],
+          },
+        },
+      ],
+    })
+
+    expect(proof.judgments[0].relation).toBe('ContextuallySatisfies')
+    expect(checkProofV03(proof)).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #142. Refs #139. Upstream release: `netkeep80/anum_docs@ec8161ceeecbecfd95481688821785fd32757873`.

Phase A/B consumer slice only. Multi-step search deliberately NOT included.

## Exact pin

Vendored byte-exact:
- `mts-contract/v0.4`;
- `mts-conformance/v0.4`;
- `mts-proof/v0.3`;
- `mts-proof-conformance/v0.3`;
- provenance with upstream commit + exact Git blob SHA.

Existing `contracts/anum_docs-v0.2` remains untouched for independently replayable old proof artifacts.

## Canonical definition consumer

`src/core/definitionEnvironment.ts` mirrors accepted upstream one-step semantics:
- source-location-independent structural target key;
- empty `[]`, ContextPronoun and bundle are non-addressable;
- nearest lexical scope;
- same-scope duplicate -> conflict;
- replay-local `DefinitionId(scopePath, ordinal)`;
- no RHS evaluation;
- `opening != equality`;
- upstream-compatible canonical formatter rather than display printer identity;
- quoted spellings preserve their delimiters in structural Symbol identity instead of collapsing `'01'` and `"01"`.

## Proof v0.3 replay

Strict decoder/replay for exactly five accepted relations:
- `ContextuallySatisfies`;
- `Opens`;
- `NoVisibleDefinition`;
- `DefinitionConflict`;
- `NonAddressableDefinitionTarget`.

Validation is fail-closed for versions, unknown relations, unexpected fields, malformed scopes, duplicate symbols, forged result data and hidden root assumptions.

Raw transport validation and typed replay are separated: raw JSON is strictly decoded once, then `checkProofV03()` replays the already typed judgments without re-running the transport decoder.

`ContextuallySatisfies` consumes only explicit `ContextFrame(start,end,parent?)`; no subject/current-focus/interpreter identity from upstream #148.

## Version boundary

`proofReplayVersioned.ts` dispatches:
- v0.2 by `schema=mts-proof/v0.2`;
- v0.3 by `proofVersion=mts-proof/v0.3`.

There is no v0.2<->v0.3 conversion/compatibility semantics.

## UI

Existing Replay panel now version-dispatches v0.2/v0.3 artifacts and renders v0.3 base-relation cards with independent replay verdicts.

Existing Search mode is intentionally unchanged and still generates only the accepted v0.2 one-step interpret artifact. It cannot generate v0.3 multi-step proofs.

## Executable evidence

Tests consume the exact vendored upstream proof corpus and require:
- every valid judgment replays;
- every invalid artifact rejects;
- every upstream forgery rejects;
- provenance hashes match;
- definition shadow/conflict/addressability matches upstream;
- quoted Symbol spellings remain distinct;
- typed proof replay does not revalidate transport shape;
- judgment ordering has no dependency semantics;
- v0.2 replay remains available;
- browser accepts/rejects v0.3 replay correctly;
- browser Search still produces `mts-proof/v0.2` only.

## Explicitly excluded

- no generic proof composition/DAG;
- no symmetry/transitivity/congruence/MP/global substitution;
- no opening -> equality;
- no proof-search semantic changes;
- no subject/focus/deixis extension;
- no removal/reinterpretation of v0.2 artifacts.

Merge only after lint/type/unit/build/e2e are green and branch is current relative to main.