### PR TITLE
Перевести trusted replay на accepted MTS v0.5 / proof v0.4

### DIFF
--- a/contracts/anum_docs-v0.5/mts-conformance-v0.5.json
+++ b/contracts/anum_docs-v0.5/mts-conformance-v0.5.json
@@ -1,0 +1,66 @@
+{
+  "schema": "mts-conformance/v0.5",
+  "status": "accepted",
+  "contract": "mts-contract/v0.5",
+  "composition": "all referenced accepted corpora are required; no prior vector is copied, weakened or replaced",
+  "requiredCorpora": [
+    {
+      "role": "base-v0.4",
+      "path": "contracts/mts-conformance-v0.4.json",
+      "schema": "mts-conformance/v0.4",
+      "contract": "mts-contract/v0.4"
+    },
+    {
+      "role": "opening-path-v0.4",
+      "path": "contracts/mts-opening-path-conformance-v0.4.json",
+      "schema": "mts-opening-path-conformance/v0.4",
+      "contract": "mts-opening-path/v0.4"
+    },
+    {
+      "role": "proof-v0.4",
+      "path": "contracts/mts-proof-conformance-v0.4.json",
+      "schema": "mts-proof-conformance/v0.4",
+      "contract": "mts-proof/v0.4"
+    },
+    {
+      "role": "direct-deixis-v0.5",
+      "path": "contracts/mts-direct-deixis-conformance-v0.5.json",
+      "schema": "mts-direct-deixis-conformance/v0.5",
+      "contract": "mts-direct-deixis/v0.5"
+    }
+  ],
+  "releaseAssertions": {
+    "allRequiredCorporaMustPass": true,
+    "mtsContractV04RemainsImmutable": true,
+    "mtsProofV04IsExactDependency": true,
+    "openingPathV04IsExactDependency": true,
+    "directDeixisV05IsExactDependency": true,
+    "rootProgramRemainsTenDefinitions": true,
+    "allSixProofRelationsReplay": true,
+    "definitionOpeningPathRemainsOperationalCertificate": true,
+    "proofSearchRemainsUntrusted": true,
+    "genericCompositionAccepted": false,
+    "judgmentOrderImpliesDependency": false,
+    "openingPathImpliesEquality": false,
+    "openingPathFeedsContextuallySatisfies": false,
+    "directDeixisImpliesContextSensitive": false,
+    "noDirectDeixisImpliesContextInvariant": false,
+    "interpreterIsALink": true,
+    "interpreterIdentityUsedAsHiddenInput": false,
+    "separateSubjectOntologyRequired": false,
+    "interpreterFocusBindingAccepted": false,
+    "relativeProductionRemainsRaw": true,
+    "persistentBackendAccepted": false,
+    "pmmCanonicalDependency": false
+  },
+  "downstreamAssertions": {
+    "aproverMayPinMtsContractV05": true,
+    "aproverMustPinMtsProofV04": true,
+    "aproverMustReplayAllSixRelationsIndependently": true,
+    "aproverMaySearchDefinitionOpeningPaths": true,
+    "aproverSearchRemainsUntrusted": true,
+    "aproverMustNotInventAdditionalComposition": true,
+    "aproverMustNotPromoteDirectDeixisToSensitivity": true,
+    "aproverMustNotUseHiddenInterpreterIdentity": true
+  }
+}

--- a/contracts/anum_docs-v0.5/mts-contract-v0.5.json
+++ b/contracts/anum_docs-v0.5/mts-contract-v0.5.json
@@ -1,0 +1,142 @@
+{
+  "schema": "mts-contract/v0.5",
+  "status": "accepted",
+  "accepted": true,
+  "issue": 168,
+  "dependsOn": [
+    "mts-contract/v0.4",
+    "mts-opening-path/v0.4",
+    "mts-proof/v0.4",
+    "mts-direct-deixis/v0.5"
+  ],
+  "extends": "mts-contract/v0.4",
+  "baseContract": "contracts/mts-contract-v0.4.json",
+  "conformanceCorpus": "contracts/mts-conformance-v0.5.json",
+  "releaseModel": "additive publication umbrella over immutable v0.4; publishes already accepted opening-path, proof-v0.4 and direct-deixis surfaces without semantic promotion",
+  "rootProgram": "tests/mtc_formulas.mtc",
+  "rootDefinitionCount": 10,
+  "preservedSurface": {
+    "allV04SemanticsUnchanged": true,
+    "definitionOpeningV03Unchanged": true,
+    "valueBundlesV02Unchanged": true,
+    "rootAndQuoteAnumV02Unchanged": true,
+    "relativeAnumProductionRaw": true,
+    "persistentL4Accepted": false,
+    "interpretMayRealize": false,
+    "openingPathMayRealize": false,
+    "globalRewrite": false,
+    "displayLabelIsIdentity": false
+  },
+  "l5": {
+    "proofContract": "contracts/mts-proof-v0.4.json",
+    "proofSchema": "mts-proof/v0.4",
+    "contractVersion": "mts-contract/v0.4",
+    "trustedCheckerModule": "core/proof_checker.py",
+    "trustedRelations": [
+      "ContextuallySatisfies",
+      "Opens",
+      "NoVisibleDefinition",
+      "DefinitionConflict",
+      "NonAddressableDefinitionTarget",
+      "DefinitionOpeningPath"
+    ],
+    "definitionOpeningPathContract": "contracts/mts-opening-path-v0.4.json",
+    "definitionOpeningPathClassification": "operational-composite-certificate",
+    "searchTrusted": false,
+    "checkerTrusted": true,
+    "genericCompositionAccepted": false,
+    "judgmentOrderImpliesDependency": false,
+    "openingPathImpliesEquality": false,
+    "openingPathImpliesEquivalence": false,
+    "openingPathImpliesNormalization": false,
+    "openingPathFeedsContextuallySatisfiesImplicitly": false,
+    "transitivityAccepted": false,
+    "symmetryAccepted": false,
+    "congruenceAccepted": false,
+    "modusPonensAccepted": false,
+    "globalSubstitutionAccepted": false,
+    "proofDagDependencyAccepted": false
+  },
+  "contextAnalysis": {
+    "directDeixisContract": "contracts/mts-direct-deixis-v0.5.json",
+    "operation": "analyze_direct_deixis",
+    "meaning": "reports explicit ContextPronoun occurrences in one typed L2 Expression",
+    "positiveImpliesContextSensitive": false,
+    "emptyImpliesContextInvariant": false,
+    "opensDefinitions": false,
+    "readsMemory": false,
+    "readsContextFrame": false,
+    "readsInterpreterIdentity": false,
+    "readsSecurityPolicy": false,
+    "trustedProofRelationAdded": false
+  },
+  "interpreterBoundary": {
+    "interpreterIsALink": true,
+    "separateSubjectOntologyRequired": false,
+    "acceptedEvaluationContext": "explicit ContextFrame(start,end,parent?)",
+    "interpreterLinkIdentityIsHiddenEvalInput": false,
+    "currentFocusBindingSemanticsAccepted": false,
+    "currentFocusLinkRefObservable": false,
+    "contextMayBeVirtual": true,
+    "securityPolicyChangesPronounMeaning": false,
+    "researchIssue": 148
+  },
+  "versionBoundaries": {
+    "v02ModifiedInPlace": false,
+    "v03ModifiedInPlace": false,
+    "v04ModifiedInPlace": false,
+    "proofV03ModifiedInPlace": false,
+    "proofV04ModifiedToFitUmbrella": false,
+    "openingPathV04ModifiedToFitUmbrella": false,
+    "directDeixisV05ModifiedToFitUmbrella": false,
+    "compatibilitySemanticLayerAllowed": false
+  },
+  "excludedFromThisRelease": [
+    "generic proof DAG or top-level judgment dependency semantics",
+    "opening-path to equality/equivalence/normalization/contextual-satisfaction bridge",
+    "unrestricted equality transitivity, symmetry or congruence",
+    "modus ponens or global substitution",
+    "universal ContextInvariant theorem",
+    "indirect definition dependency as current interpret semantics",
+    "interpreter-focus identity/lifecycle semantics",
+    "observable current-focus LinkRef primitive",
+    "relative Anum candidate semantics",
+    "persistent L4 backend acceptance",
+    "PMM as canonical dependency",
+    "implicit realization"
+  ],
+  "downstream": {
+    "genericConsumerMayPinV05": true,
+    "aproverProofRepinAllowed": true,
+    "requiredProofSchema": "mts-proof/v0.4",
+    "requiredProofContractVersion": "mts-contract/v0.4",
+    "consumerMustReplayIndependently": true,
+    "consumerMaySearchDefinitionOpeningPaths": true,
+    "consumerSearchTrusted": false,
+    "consumerMayInventAdditionalCompositionRules": false,
+    "consumerMayInferContextSensitivityFromDirectDeixis": false,
+    "consumerMayUseHiddenInterpreterIdentity": false
+  },
+  "nextGates": {
+    "proofComposition": {
+      "issue": 122,
+      "status": "DefinitionOpeningPath accepted; broader calculus remains open"
+    },
+    "interpreterFocus": {
+      "issue": 148,
+      "status": "research; explicit ContextFrame remains accepted boundary"
+    },
+    "contextInvariance": {
+      "issue": 156,
+      "status": "direct deixis accepted; universal/indirect claims remain deferred"
+    },
+    "relativeAnum": {
+      "issue": 123,
+      "status": "candidate research only"
+    },
+    "persistentL4": {
+      "issue": 124,
+      "status": "persistent backend conformance required"
+    }
+  }
+}

--- a/contracts/anum_docs-v0.5/mts-direct-deixis-conformance-v0.5.json
+++ b/contracts/anum_docs-v0.5/mts-direct-deixis-conformance-v0.5.json
@@ -4,11 +4,39 @@
   "accepted": true,
   "contract": "mts-direct-deixis/v0.5",
   "vectors": [
-    {"id": "none", "source": "[] = []", "expected": []},
-    {"id": "current-start", "source": "◁ = a", "expected": [{"path": [0], "up": 0, "pole": "◁"}]},
-    {"id": "current-end", "source": "a = ▷", "expected": [{"path": [1], "up": 0, "pole": "▷"}]},
-    {"id": "parent-end", "source": "a = ↑▷", "expected": [{"path": [1], "up": 1, "pole": "▷"}]},
-    {"id": "grandparent-grouped-start", "source": "((↑↑◁)) = a", "expected": [{"path": [0, 0, 0], "up": 2, "pole": "◁"}]},
+    {
+      "id": "none",
+      "source": "[] = []",
+      "expected": []
+    },
+    {
+      "id": "current-start",
+      "source": "◁ = a",
+      "expected": [
+        {"path": [0], "up": 0, "pole": "◁"}
+      ]
+    },
+    {
+      "id": "current-end",
+      "source": "a = ▷",
+      "expected": [
+        {"path": [1], "up": 0, "pole": "▷"}
+      ]
+    },
+    {
+      "id": "parent-end",
+      "source": "a = ↑▷",
+      "expected": [
+        {"path": [1], "up": 1, "pole": "▷"}
+      ]
+    },
+    {
+      "id": "grandparent-grouped-start",
+      "source": "((↑↑◁)) = a",
+      "expected": [
+        {"path": [0, 0, 0], "up": 2, "pole": "◁"}
+      ]
+    },
     {
       "id": "bundle-order",
       "source": "{◁ = a, ↑▷ = b, ▷ = c}",
@@ -56,17 +84,29 @@
     {
       "id": "whitespace-current-start",
       "sources": ["◁=a", "  ◁   =   a  "],
-      "expected": [{"path": [0], "up": 0, "pole": "◁"}]
+      "expected": [
+        {"path": [0], "up": 0, "pole": "◁"}
+      ]
     },
     {
       "id": "whitespace-parent",
       "sources": ["a=↑▷", "a = ↑ ▷"],
-      "expected": [{"path": [1], "up": 1, "pole": "▷"}]
+      "expected": [
+        {"path": [1], "up": 1, "pole": "▷"}
+      ]
     }
   ],
   "negativeClaims": [
-    {"id": "empty-does-not-mean-invariant", "source": "[] = []", "forbiddenConclusion": "ContextInvariant"},
-    {"id": "present-does-not-mean-sensitive", "source": "◁ = ◁", "forbiddenConclusion": "ContextSensitive"}
+    {
+      "id": "empty-does-not-mean-invariant",
+      "source": "[] = []",
+      "forbiddenConclusion": "ContextInvariant"
+    },
+    {
+      "id": "present-does-not-mean-sensitive",
+      "source": "◁ = ◁",
+      "forbiddenConclusion": "ContextSensitive"
+    }
   ],
   "releaseAssertions": {
     "allPortableVectorsReplayInProductionCore": true,

--- a/contracts/anum_docs-v0.5/mts-direct-deixis-conformance-v0.5.json
+++ b/contracts/anum_docs-v0.5/mts-direct-deixis-conformance-v0.5.json
@@ -1,0 +1,83 @@
+{
+  "schema": "mts-direct-deixis-conformance/v0.5",
+  "status": "accepted",
+  "accepted": true,
+  "contract": "mts-direct-deixis/v0.5",
+  "vectors": [
+    {"id": "none", "source": "[] = []", "expected": []},
+    {"id": "current-start", "source": "◁ = a", "expected": [{"path": [0], "up": 0, "pole": "◁"}]},
+    {"id": "current-end", "source": "a = ▷", "expected": [{"path": [1], "up": 0, "pole": "▷"}]},
+    {"id": "parent-end", "source": "a = ↑▷", "expected": [{"path": [1], "up": 1, "pole": "▷"}]},
+    {"id": "grandparent-grouped-start", "source": "((↑↑◁)) = a", "expected": [{"path": [0, 0, 0], "up": 2, "pole": "◁"}]},
+    {
+      "id": "bundle-order",
+      "source": "{◁ = a, ↑▷ = b, ▷ = c}",
+      "expected": [
+        {"path": [0, 0], "up": 0, "pole": "◁"},
+        {"path": [1, 0], "up": 1, "pole": "▷"},
+        {"path": [2, 0], "up": 0, "pole": "▷"}
+      ]
+    },
+    {
+      "id": "projections",
+      "source": "♀◁ = ▷♂",
+      "expected": [
+        {"path": [0, 0], "up": 0, "pole": "◁"},
+        {"path": [1, 0], "up": 0, "pole": "▷"}
+      ]
+    },
+    {
+      "id": "definition-target-and-body",
+      "source": "◁ : {▷ = a, ↑◁ = b}",
+      "expected": [
+        {"path": [0], "up": 0, "pole": "◁"},
+        {"path": [1, 0, 0], "up": 0, "pole": "▷"},
+        {"path": [1, 1, 0], "up": 1, "pole": "◁"}
+      ]
+    },
+    {
+      "id": "sequence",
+      "source": "◁▷ = ab",
+      "expected": [
+        {"path": [0, 0], "up": 0, "pole": "◁"},
+        {"path": [0, 1], "up": 0, "pole": "▷"}
+      ]
+    },
+    {
+      "id": "nested-link",
+      "source": "(◁ ⟼ ↑▷) = x",
+      "expected": [
+        {"path": [0, 0, 0], "up": 0, "pole": "◁"},
+        {"path": [0, 0, 1], "up": 1, "pole": "▷"}
+      ]
+    }
+  ],
+  "equivalentSpellings": [
+    {
+      "id": "whitespace-current-start",
+      "sources": ["◁=a", "  ◁   =   a  "],
+      "expected": [{"path": [0], "up": 0, "pole": "◁"}]
+    },
+    {
+      "id": "whitespace-parent",
+      "sources": ["a=↑▷", "a = ↑ ▷"],
+      "expected": [{"path": [1], "up": 1, "pole": "▷"}]
+    }
+  ],
+  "negativeClaims": [
+    {"id": "empty-does-not-mean-invariant", "source": "[] = []", "forbiddenConclusion": "ContextInvariant"},
+    {"id": "present-does-not-mean-sensitive", "source": "◁ = ◁", "forbiddenConclusion": "ContextSensitive"}
+  ],
+  "releaseAssertions": {
+    "allPortableVectorsReplayInProductionCore": true,
+    "allEquivalentSpellingsMatch": true,
+    "directPresenceDoesNotMeanContextSensitive": true,
+    "emptyResultDoesNotMeanContextInvariant": true,
+    "noMemoryDependency": true,
+    "noDefinitionEnvironmentDependency": true,
+    "noContextFrameDependency": true,
+    "noInterpreterIdentityDependency": true,
+    "noProofSemanticChange": true,
+    "tenRootDefinitionsUnchanged": true
+  }
+}

--- a/contracts/anum_docs-v0.5/mts-direct-deixis-v0.5.json
+++ b/contracts/anum_docs-v0.5/mts-direct-deixis-v0.5.json
@@ -1,0 +1,87 @@
+{
+  "schema": "mts-direct-deixis/v0.5",
+  "status": "accepted",
+  "accepted": true,
+  "issue": 156,
+  "dependsOn": [
+    "mts-contract/v0.4"
+  ],
+  "conformanceCorpus": "contracts/mts-direct-deixis-conformance-v0.5.json",
+  "scope": "normative read-only structural detection of explicit ContextPronoun occurrences in one typed L2 Expression; no evaluation, dependency closure, sensitivity or invariance theorem",
+  "operation": {
+    "name": "analyze_direct_deixis",
+    "input": "typed L2 Expression",
+    "result": "ordered DeicticOccurrence[]",
+    "occurrence": {
+      "path": "structural typed-AST path of non-negative integers",
+      "up": "exact ContextPronoun.up",
+      "pole": "exact ContextPronoun.pole (◁ or ▷)"
+    },
+    "ordering": "deterministic preorder, equivalent to lexicographic structural path order for this tree traversal",
+    "readsMemory": false,
+    "readsDefinitionEnvironment": false,
+    "readsContextFrame": false,
+    "readsInterpreterIdentity": false,
+    "readsSecurityPolicy": false,
+    "writesAnything": false
+  },
+  "pathSemantics": {
+    "roundOrSquareContent": [0],
+    "unaryOperand": [0],
+    "binaryLeft": [0],
+    "binaryRight": [1],
+    "bundleOrSequenceItem": "append zero-based item index",
+    "definitionTarget": [0],
+    "definitionBody": [1],
+    "groupingTransparent": false,
+    "sourceSpanIncluded": false,
+    "displayTextIncluded": false
+  },
+  "meaningBoundary": {
+    "positiveResultMeans": "the typed AST directly contains the reported explicit context-pronoun occurrences",
+    "positiveResultImpliesContextSensitivity": false,
+    "emptyResultMeans": "the typed AST contains no direct ContextPronoun occurrence",
+    "emptyResultImpliesContextInvariance": false,
+    "opensDefinitions": false,
+    "followsTransitiveDependencies": false,
+    "evaluatesExpression": false,
+    "changesInterpretSemantics": false
+  },
+  "interpreterBoundary": {
+    "interpreterIsALink": true,
+    "interpreterIdentityIsInputToThisOperation": false,
+    "focusOrContextFrameIsInputToThisOperation": false,
+    "reason": "direct deixis is a property of the typed expression structure, not of one interpreter instance or one runtime context"
+  },
+  "proofBoundary": {
+    "trustedProofRelationAdded": false,
+    "ContextInvariantAccepted": false,
+    "ContextSensitiveAccepted": false,
+    "mtsProofV03Modified": false,
+    "futureProofUseRequiresExplicitAcceptedLift": true
+  },
+  "productionIntegration": {
+    "referenceCore": "core/mtc_context_analysis.py",
+    "operation": "analyze_direct_deixis",
+    "productionConformance": "tests/test_mts_direct_deixis_reference.py",
+    "singleCanonicalImplementation": true,
+    "candidateWalkerRetainedInProduction": false
+  },
+  "rootProgram": {
+    "path": "tests/mtc_formulas.mtc",
+    "definitionCount": 10,
+    "mustRemainUnchanged": true,
+    "analysisMayInspectWithoutMutation": true
+  },
+  "versioning": {
+    "mtsContractV04Modified": false,
+    "publishedThroughUmbrella": false,
+    "futureUmbrellaMustBeAdditive": true
+  },
+  "nextBoundary": {
+    "indirectDefinitionDependencyAccepted": false,
+    "universalContextInvarianceAccepted": false,
+    "coordinationIssueForComposition": 122,
+    "interpreterFocusResearchIssue": 148
+  }
+}

--- a/contracts/anum_docs-v0.5/mts-opening-path-conformance-v0.4.json
+++ b/contracts/anum_docs-v0.5/mts-opening-path-conformance-v0.4.json
@@ -1,0 +1,262 @@
+{
+  "schema": "mts-opening-path-conformance/v0.4",
+  "status": "accepted",
+  "accepted": true,
+  "contract": "mts-opening-path/v0.4",
+  "validPaths": [
+    {
+      "id": "one-edge",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"}
+      ],
+      "finalBody": "b"
+    },
+    {
+      "id": "ends-in-non-form-judgment",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b = c"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b = c"}
+      ],
+      "finalBody": "b = c"
+    },
+    {
+      "id": "two-edge",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "b : c"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"},
+        {"target": "b", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "c"}
+      ],
+      "finalBody": "c"
+    },
+    {
+      "id": "ends-in-constraint-bundle",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "b : {◁ = x, ▷ = y}"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"},
+        {"target": "b", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "{◁ = x, ▷ = y}"}
+      ],
+      "finalBody": "{◁ = x, ▷ = y}"
+    },
+    {
+      "id": "child-shadowing",
+      "scopes": [
+        {"path": [], "parent": null, "definitions": ["a : root", "b : rootEnd"]},
+        {"path": [0], "parent": [], "definitions": ["a : b", "b : childEnd"]}
+      ],
+      "lookupScope": [0],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [0], "ordinal": 0}, "body": "b"},
+        {"target": "b", "definitionId": {"scopePath": [0], "ordinal": 1}, "body": "childEnd"}
+      ],
+      "finalBody": "childEnd"
+    },
+    {
+      "id": "self-cycle-one-edge",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : a"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "a"}
+      ],
+      "finalBody": "a"
+    },
+    {
+      "id": "mutual-cycle-two-edges",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "b : a"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"},
+        {"target": "b", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "a"}
+      ],
+      "finalBody": "a"
+    },
+    {
+      "id": "structural-adjacency-whitespace",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : (b)", "(b) : c"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "(b)"},
+        {"target": "( b )", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "c"}
+      ],
+      "finalBody": "c"
+    }
+  ],
+  "invalidPaths": [
+    {
+      "id": "zero-edge",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [],
+      "finalBody": "a"
+    },
+    {
+      "id": "repeated-definition-id",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "b : a"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"},
+        {"target": "b", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "a"},
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"}
+      ],
+      "finalBody": "b"
+    },
+    {
+      "id": "forged-body",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "c"}
+      ],
+      "finalBody": "c"
+    },
+    {
+      "id": "forged-definition-id",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 9}, "body": "b"}
+      ],
+      "finalBody": "b"
+    },
+    {
+      "id": "next-target-mismatch",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "c : d"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"},
+        {"target": "c", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "d"}
+      ],
+      "finalBody": "d"
+    },
+    {
+      "id": "start-target-mismatch",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "x : y"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "x", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "y"}
+      ],
+      "finalBody": "y"
+    },
+    {
+      "id": "continue-after-non-form",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b = c", "x : y"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b = c"},
+        {"target": "x", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "y"}
+      ],
+      "finalBody": "y"
+    },
+    {
+      "id": "continue-after-non-addressable-form",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : {◁ = x}"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "{◁ = x}"},
+        {"target": "{ ◁ = x }", "definitionId": {"scopePath": [], "ordinal": 1}, "body": "z"}
+      ],
+      "finalBody": "z"
+    },
+    {
+      "id": "no-match-edge",
+      "scopes": [{"path": [], "parent": null, "definitions": []}],
+      "lookupScope": [],
+      "startTarget": "missing",
+      "edges": [
+        {"target": "missing", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "x"}
+      ],
+      "finalBody": "x"
+    },
+    {
+      "id": "conflict-edge",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b", "a : c"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"}
+      ],
+      "finalBody": "b"
+    },
+    {
+      "id": "non-addressable-edge",
+      "scopes": [{"path": [], "parent": null, "definitions": []}],
+      "lookupScope": [],
+      "startTarget": "[]",
+      "edges": [
+        {"target": "[]", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "x"}
+      ],
+      "finalBody": "x"
+    },
+    {
+      "id": "forged-final-body",
+      "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+      "lookupScope": [],
+      "startTarget": "a",
+      "edges": [
+        {"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"}
+      ],
+      "finalBody": "c"
+    }
+  ],
+  "transportAssertions": {
+    "targetSourcesParsedBeforeStructuralComparison": true,
+    "equivalentTargetWhitespaceAllowed": true,
+    "edgeBodyMustBeCanonicalFormatExpression": true,
+    "finalBodyMustBeCanonicalFormatExpression": true,
+    "definitionIdMustReplayExactly": true,
+    "sharedEnvironmentAndLookupScope": true
+  },
+  "coreAssertions": {
+    "allValidPathsAcceptedByCanonicalVerifier": true,
+    "allInvalidPathsRejectedByCanonicalVerifierOrStrictTransportAdapter": true,
+    "emptyPathRejected": true,
+    "startAndAdjacencyCheckedStructurally": true,
+    "everyEdgeIndependentlyOpened": true,
+    "repeatedDefinitionIdRejected": true,
+    "nonFormAndNonAddressableTerminalBodiesAllowed": true,
+    "continuationAcrossNonFormOrNonAddressableBodyRejected": true,
+    "noAutoContinuation": true
+  },
+  "meaningAssertions": {
+    "impliesEquality": false,
+    "impliesEquivalence": false,
+    "impliesNormalization": false,
+    "impliesContextualSatisfaction": false,
+    "genericCompositionAccepted": false
+  },
+  "effectsAssertions": {
+    "readsMemory": false,
+    "readsContextFrame": false,
+    "readsInterpreterIdentity": false,
+    "materializes": false,
+    "deletes": false,
+    "mutatesDefinitionEnvironment": false
+  },
+  "releaseAssertions": {
+    "mtsProofV03Unchanged": true,
+    "mtsContractV04Unchanged": true,
+    "tenRootDefinitionsUnchanged": true,
+    "standaloneRelationOnly": true,
+    "proofV04StillRequiresSeparateAcceptance": true
+  }
+}

--- a/contracts/anum_docs-v0.5/mts-opening-path-v0.4.json
+++ b/contracts/anum_docs-v0.5/mts-opening-path-v0.4.json
@@ -1,0 +1,138 @@
+{
+  "schema": "mts-opening-path/v0.4",
+  "status": "accepted",
+  "accepted": true,
+  "issue": 161,
+  "dependsOn": [
+    "mts-definition-opening/v0.3",
+    "mts-derivation-base/v0.3",
+    "mts-proof/v0.3"
+  ],
+  "conformanceCorpus": "contracts/mts-opening-path-conformance-v0.4.json",
+  "scope": "normative read-only verification of one finite self-contained DefinitionOpeningPath operational composite certificate; no equality, normalization, evaluation, generic composition, memory or context effects",
+  "relation": {
+    "name": "DefinitionOpeningPath",
+    "classification": "operational-composite-certificate",
+    "minimumEdges": 1,
+    "sharedDefinitionEnvironment": true,
+    "sharedLookupScope": true,
+    "replaysExactlyWitnessEdges": true,
+    "autoContinues": false
+  },
+  "typedCore": {
+    "module": "core/mtc_opening_path.py",
+    "verifier": "verify_opening_path",
+    "environmentArgument": "DefinitionEnvironment already representing the explicit lookup scope",
+    "witness": {
+      "startTarget": "Form",
+      "edges": "ordered non-empty tuple[OpeningPathEdge,...]",
+      "finalBody": "Expression"
+    },
+    "edge": {
+      "target": "Form",
+      "definitionId": "DefinitionId(scopePath,ordinal)",
+      "body": "Expression"
+    },
+    "comparison": "typed structural_key equality; SourceSpan/display text are not semantic identity",
+    "singleCanonicalImplementation": true
+  },
+  "portableCertificate": {
+    "sharedFields": ["scopes", "lookupScope", "startTarget", "edges", "finalBody"],
+    "scopes": "same explicit lexical snapshot semantics as mts-proof/v0.3 definition relations",
+    "lookupScope": "one exact serialized scope path used for every edge",
+    "startTarget": "parseable Form source; structural identity after parsing",
+    "edges": {
+      "target": "parseable Form source; structural identity after parsing; equivalent whitespace allowed",
+      "definitionId": "exact replay-local DefinitionId",
+      "body": "canonical format_expression transport of the expected replay body"
+    },
+    "finalBody": "canonical format_expression transport of the final expected replay body",
+    "transportDecoderOwnedByCoreVerifier": false,
+    "reason": "transport/version validation belongs to the consuming artifact layer; every consumer must construct the same typed witness and invoke the one canonical verifier"
+  },
+  "verificationOrder": [
+    "reject empty path",
+    "check first edge target structurally matches startTarget",
+    "for each later edge require previous replay body is Form and structurally equals next target",
+    "replay open_definition(target, environment)",
+    "require kind=match",
+    "require exact replay-local DefinitionId",
+    "reject repeated replayed DefinitionId",
+    "require replay body structurally equals expected typed edge body",
+    "after exact serialized edge count require last replay body structurally equals finalBody"
+  ],
+  "failureCodes": [
+    "empty-path",
+    "start-target-mismatch",
+    "previous-body-not-form",
+    "adjacency-mismatch",
+    "opening-not-match",
+    "definition-id-mismatch",
+    "repeated-definition-id",
+    "body-mismatch",
+    "final-body-mismatch"
+  ],
+  "cycleCanonicality": {
+    "definitionIdMayAppearAtMostOnce": true,
+    "selfCycleCanonicalWitness": "one edge",
+    "mutualCycleCanonicalWitness": "one edge per distinct DefinitionId until repetition",
+    "repeatedDefinitionIdMeansSemanticFalse": false,
+    "repeatedDefinitionIdMeansInvalidCertificate": true
+  },
+  "terminalBoundary": {
+    "finalBodyMayBeAnyExpression": true,
+    "nonFormFinalBodyAllowed": true,
+    "nonAddressableFormFinalBodyAllowed": true,
+    "continuationRequiresPreviousBodyIsForm": true,
+    "continuationRequiresNextOpenDefinitionMatch": true,
+    "finalBodyEvaluated": false
+  },
+  "meaningBoundary": {
+    "impliesEquality": false,
+    "impliesEquivalence": false,
+    "impliesNormalization": false,
+    "impliesContextualSatisfaction": false,
+    "impliesGenericTransitivity": false,
+    "opensOnlySerializedEdges": true,
+    "evaluatesBodies": false,
+    "readsMemory": false,
+    "readsContextFrame": false,
+    "readsInterpreterIdentity": false,
+    "materializes": false,
+    "deletes": false
+  },
+  "searchCheckerBoundary": {
+    "searchTrusted": false,
+    "searchMayExploreDefinitionGraph": true,
+    "searchMayUseVisitedDefinitionIds": true,
+    "certificateTrustedWithoutReplay": false,
+    "checkerMustInvokeCanonicalVerifier": true,
+    "searchTracePartOfTrustedMeaning": false
+  },
+  "proofBoundary": {
+    "trustedProofRelationAddedByThisContract": false,
+    "eligibleForFutureProofRelation": true,
+    "futureRelationName": "DefinitionOpeningPath",
+    "futureTrustedMeaningMustEqualThisVerifier": true,
+    "mtsProofV03Modified": false,
+    "genericCompositionAccepted": false,
+    "openingPathPlusContextuallySatisfiesAccepted": false
+  },
+  "productionIntegration": {
+    "referenceCore": "core/mtc_opening_path.py",
+    "productionConformance": "tests/test_mts_opening_path_reference.py",
+    "acceptedConformance": "contracts/mts-opening-path-conformance-v0.4.json"
+  },
+  "versioning": {
+    "mtsContractV04Modified": false,
+    "mtsProofV03Modified": false,
+    "publishedThroughUmbrella": false,
+    "futureUmbrellaMustBeAdditive": true
+  },
+  "nextBoundary": {
+    "proofV04MayConsumeThisRelationAfterSeparateAcceptance": true,
+    "otherCompositionRulesAccepted": false,
+    "compositionIssue": 122,
+    "aproverMayInventAdditionalRules": false
+  }
+}

--- a/contracts/anum_docs-v0.5/mts-proof-conformance-v0.4.json
+++ b/contracts/anum_docs-v0.5/mts-proof-conformance-v0.4.json
@@ -1,0 +1,150 @@
+{
+  "schema": "mts-proof-conformance/v0.4",
+  "status": "accepted",
+  "accepted": true,
+  "contract": "mts-proof/v0.4",
+  "baseCorpus": "contracts/mts-proof-conformance-v0.3.json",
+  "openingPathCorpus": "contracts/mts-opening-path-conformance-v0.4.json",
+  "selection": {
+    "baseValidJudgments": "all",
+    "baseForgeries": "all",
+    "baseInvalidArtifactsForV03Regression": "all",
+    "openingPathValidPaths": "all",
+    "openingPathInvalidPaths": "all",
+    "v04InvalidArtifacts": "all",
+    "mixedArtifact": "required"
+  },
+  "invalidArtifacts": [
+    {
+      "id": "wrong-proof-version",
+      "artifact": {"proofVersion": "mts-proof/v0.3", "contractVersion": "mts-contract/v0.4", "judgments": []}
+    },
+    {
+      "id": "wrong-contract-version",
+      "artifact": {"proofVersion": "mts-proof/v0.4", "contractVersion": "mts-contract/v0.3", "judgments": []}
+    },
+    {
+      "id": "unexpected-proof-field",
+      "artifact": {"proofVersion": "mts-proof/v0.4", "contractVersion": "mts-contract/v0.4", "judgments": [], "searchTrace": []}
+    },
+    {
+      "id": "unknown-relation",
+      "artifact": {
+        "proofVersion": "mts-proof/v0.4",
+        "contractVersion": "mts-contract/v0.4",
+        "judgments": [{"relation": "Equality", "left": "a", "right": "b"}]
+      }
+    },
+    {
+      "id": "opening-unexpected-field",
+      "artifact": {
+        "proofVersion": "mts-proof/v0.4",
+        "contractVersion": "mts-contract/v0.4",
+        "judgments": [{
+          "relation": "DefinitionOpeningPath",
+          "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+          "lookupScope": [],
+          "startTarget": "a",
+          "edges": [{"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"}],
+          "finalBody": "b",
+          "searchTrace": []
+        }]
+      }
+    },
+    {
+      "id": "edge-unexpected-field",
+      "artifact": {
+        "proofVersion": "mts-proof/v0.4",
+        "contractVersion": "mts-contract/v0.4",
+        "judgments": [{
+          "relation": "DefinitionOpeningPath",
+          "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+          "lookupScope": [],
+          "startTarget": "a",
+          "edges": [{"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b", "trusted": true}],
+          "finalBody": "b"
+        }]
+      }
+    },
+    {
+      "id": "noncanonical-edge-body",
+      "artifact": {
+        "proofVersion": "mts-proof/v0.4",
+        "contractVersion": "mts-contract/v0.4",
+        "judgments": [{
+          "relation": "DefinitionOpeningPath",
+          "scopes": [{"path": [], "parent": null, "definitions": ["a : (b)"]}],
+          "lookupScope": [],
+          "startTarget": "a",
+          "edges": [{"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "( b )"}],
+          "finalBody": "(b)"
+        }]
+      }
+    },
+    {
+      "id": "noncanonical-final-body",
+      "artifact": {
+        "proofVersion": "mts-proof/v0.4",
+        "contractVersion": "mts-contract/v0.4",
+        "judgments": [{
+          "relation": "DefinitionOpeningPath",
+          "scopes": [{"path": [], "parent": null, "definitions": ["a : {◁ = x}"]}],
+          "lookupScope": [],
+          "startTarget": "a",
+          "edges": [{"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "{◁ = x}"}],
+          "finalBody": "{ ◁ = x }"
+        }]
+      }
+    },
+    {
+      "id": "lookup-scope-not-serialized",
+      "artifact": {
+        "proofVersion": "mts-proof/v0.4",
+        "contractVersion": "mts-contract/v0.4",
+        "judgments": [{
+          "relation": "DefinitionOpeningPath",
+          "scopes": [{"path": [], "parent": null, "definitions": ["a : b"]}],
+          "lookupScope": [0],
+          "startTarget": "a",
+          "edges": [{"target": "a", "definitionId": {"scopePath": [], "ordinal": 0}, "body": "b"}],
+          "finalBody": "b"
+        }]
+      }
+    }
+  ],
+  "mixedArtifact": {
+    "baseJudgmentId": "opens-direct",
+    "openingPathId": "two-edge",
+    "requiredBothOrdersAccepted": true,
+    "orderImpliesDependency": false
+  },
+  "releaseAssertions": {
+    "trustedRelationsExactlySix": true,
+    "fiveBaseRelationsReuseV03TrustedMeaning": true,
+    "allV03ValidBaseJudgmentsLift": true,
+    "allV03BaseForgeriesRemainRejected": true,
+    "allV03InvalidArtifactsRemainRejectedByV03Api": true,
+    "allOpeningPathValidVectorsLift": true,
+    "allOpeningPathInvalidVectorsReject": true,
+    "allV04TransportForgeriesReject": true,
+    "openingPathUsesCanonicalVerifier": true,
+    "mixedJudgmentOrderDoesNotCreateDependency": true,
+    "canonicalRoundTripRequired": true,
+    "mtsProofV03Unchanged": true,
+    "genericCompositionAccepted": false,
+    "tenRootDefinitionsUnchanged": true
+  },
+  "effectsAssertions": {
+    "openingPathReadsMemory": false,
+    "openingPathReadsContextFrame": false,
+    "openingPathReadsInterpreterIdentity": false,
+    "materializes": false,
+    "deletes": false
+  },
+  "versioningAssertions": {
+    "proofVersion": "mts-proof/v0.4",
+    "contractVersion": "mts-contract/v0.4",
+    "publishedThroughUmbrella": false,
+    "futureUmbrella": "mts-contract/v0.5"
+  }
+}

--- a/contracts/anum_docs-v0.5/mts-proof-v0.4.json
+++ b/contracts/anum_docs-v0.5/mts-proof-v0.4.json
@@ -1,0 +1,135 @@
+{
+  "schema": "mts-proof/v0.4",
+  "status": "accepted",
+  "accepted": true,
+  "issue": 165,
+  "dependsOn": [
+    "mts-contract/v0.4",
+    "mts-proof/v0.3",
+    "mts-opening-path/v0.4"
+  ],
+  "conformanceCorpus": "contracts/mts-proof-conformance-v0.4.json",
+  "purpose": "Trusted independent replay of the five accepted v0.3 base relations plus the accepted finite DefinitionOpeningPath operational composite certificate; no other composition or inference rule is accepted.",
+  "proofObject": {
+    "required": ["proofVersion", "contractVersion", "judgments"],
+    "proofVersion": "mts-proof/v0.4",
+    "contractVersion": "mts-contract/v0.4",
+    "judgments": "ordered V04Judgment[]; array order is artifact order only and has no generic premise/dependency meaning"
+  },
+  "trustedRelations": [
+    "ContextuallySatisfies",
+    "Opens",
+    "NoVisibleDefinition",
+    "DefinitionConflict",
+    "NonAddressableDefinitionTarget",
+    "DefinitionOpeningPath"
+  ],
+  "baseRelations": {
+    "shapesIdenticalToV03": true,
+    "trustedMeaningIdenticalToV03": true,
+    "checkerPath": "core/proof_checker.py::check_v03_judgment",
+    "reimplementedForV04": false,
+    "proofV03ArtifactsReinterpretedAsV04": false
+  },
+  "definitionOpeningPath": {
+    "required": ["relation", "scopes", "lookupScope", "startTarget", "edges", "finalBody"],
+    "relation": "DefinitionOpeningPath",
+    "scopes": "same explicit canonical lexical snapshot semantics as v0.3 definition judgments",
+    "lookupScope": "one exact serialized scope path used for every opening edge",
+    "startTarget": "parseable Form source; structural identity after parsing; equivalent whitespace permitted",
+    "edges": {
+      "minimum": 1,
+      "required": ["target", "definitionId", "body"],
+      "target": "parseable Form source; structural identity after parsing; equivalent whitespace permitted",
+      "definitionId": "exact non-negative replay-local DefinitionId(scopePath,ordinal)",
+      "body": "exact canonical format_expression transport parsed into typed Expression"
+    },
+    "finalBody": "exact canonical format_expression transport parsed into typed Expression",
+    "typedWitness": "OpeningPathWitness",
+    "trustedReplay": "core/mtc_opening_path.py::verify_opening_path",
+    "autoContinues": false,
+    "searchTraceTrusted": false
+  },
+  "transportBoundary": {
+    "wrongOrMissingVersionsRejected": true,
+    "unexpectedProofFieldsRejected": true,
+    "unexpectedJudgmentFieldsRejected": true,
+    "unexpectedOpeningEdgeFieldsRejected": true,
+    "unknownRelationsRejected": true,
+    "noncanonicalExpectedBodyTransportRejected": true,
+    "noncanonicalFinalBodyTransportRejected": true,
+    "targetWhitespaceCanonicalizationRequired": false,
+    "sourceSpanIdentity": false
+  },
+  "checker": {
+    "module": "core/proof_checker.py",
+    "singleTrustedModuleForV02V03V04": true,
+    "baseRelationsDelegateExistingV03Replay": true,
+    "openingPathDelegatesCanonicalVerifier": true,
+    "trustsSerializedOpeningBodyWithoutReplay": false,
+    "trustsSerializedDefinitionIdWithoutReplay": false,
+    "trustsSearchTrace": false,
+    "mayAutoExtendOpeningPath": false,
+    "mayReadAmbientInterpreterState": false,
+    "mayInjectCanonicalRootDefinitions": false,
+    "mayMaterialize": false,
+    "mayDelete": false
+  },
+  "compositionBoundary": {
+    "DefinitionOpeningPathInternallyComposesOpeningEdges": true,
+    "judgmentOrderImpliesDependency": false,
+    "genericCompositionAccepted": false,
+    "openingPathFeedsContextuallySatisfiesImplicitly": false,
+    "openingPathImpliesEquality": false,
+    "openingPathImpliesEquivalence": false,
+    "openingPathImpliesNormalization": false,
+    "transitivityAccepted": false,
+    "symmetryAccepted": false,
+    "congruenceAccepted": false,
+    "modusPonensAccepted": false,
+    "globalSubstitutionAccepted": false,
+    "proofDagDependencyAccepted": false
+  },
+  "effectsBoundary": {
+    "openingPathReadsMemory": false,
+    "openingPathReadsContextFrame": false,
+    "openingPathReadsInterpreterIdentity": false,
+    "openingPathMaterializes": false,
+    "openingPathDeletes": false
+  },
+  "v03Compatibility": {
+    "mtsProofV03Modified": false,
+    "mtsProofV03Schema": "mts-proof/v0.3",
+    "mtsProofV03ContractVersion": "mts-contract/v0.3",
+    "trustedRelationsRemainExactlyFive": true,
+    "existingV03ArtifactsReplayByExistingApi": true,
+    "retroactiveReinterpretation": false
+  },
+  "serialization": {
+    "typedApi": [
+      "proof_v04_from_data",
+      "check_proof_v04",
+      "check_proof_v04_data",
+      "proof_v04_to_data",
+      "canonical_proof_v04_json"
+    ],
+    "canonicalTargetSerialization": "format_expression; decoder additionally accepts structurally equivalent target whitespace",
+    "canonicalBodySerialization": "format_expression",
+    "roundTripRequired": true
+  },
+  "rootProgram": {
+    "definitionCount": 10,
+    "mustRemainUnchanged": true
+  },
+  "versioning": {
+    "mtsContractV04Modified": false,
+    "publishedThroughUmbrella": false,
+    "futureUmbrella": "mts-contract/v0.5",
+    "futureUmbrellaMustBeAdditive": true
+  },
+  "downstream": {
+    "directAproverRepinAllowedBeforeUmbrella": false,
+    "reason": "publish the full new context/proof surface through additive mts-contract/v0.5 before downstream exact pin",
+    "aproverMayInventAdditionalRules": false
+  }
+}

--- a/contracts/anum_docs-v0.5/provenance.json
+++ b/contracts/anum_docs-v0.5/provenance.json
@@ -1,0 +1,14 @@
+{
+  "sourceRepository": "netkeep80/anum_docs",
+  "sourceCommit": "5f985b2abc273efaa6c369781c5ad1e08c282d34",
+  "artifacts": {
+    "contract": {"path": "contracts/mts-contract-v0.5.json", "gitBlobSha": "637a717e8ed988cac58571ab5f3ac76c065d445c"},
+    "conformance": {"path": "contracts/mts-conformance-v0.5.json", "gitBlobSha": "f54296a23b649223d79fccd5664cd97556312a59"},
+    "proof": {"path": "contracts/mts-proof-v0.4.json", "gitBlobSha": "5402be3294d17cd386300ea1984d70337d2b3a4f"},
+    "proofConformance": {"path": "contracts/mts-proof-conformance-v0.4.json", "gitBlobSha": "306dd536ec817ff29371dd4e322a2eaa789af5ba"},
+    "openingPath": {"path": "contracts/mts-opening-path-v0.4.json", "gitBlobSha": "3a51955f6dd97d6af7a97aa96b864c4918735c87"},
+    "openingPathConformance": {"path": "contracts/mts-opening-path-conformance-v0.4.json", "gitBlobSha": "ca1dcc23d208e8f318ac6fb259d56d025ca2a34f"},
+    "directDeixis": {"path": "contracts/mts-direct-deixis-v0.5.json", "gitBlobSha": "64198b6a8a9261a2e0fe42b1a9fc6d1eba557a66"},
+    "directDeixisConformance": {"path": "contracts/mts-direct-deixis-conformance-v0.5.json", "gitBlobSha": "981e31ee6a0c090a02e04464c1a5df69a492c25a"}
+  }
+}

--- a/src/core/definitionOpeningPath.ts
+++ b/src/core/definitionOpeningPath.ts
@@ -1,0 +1,194 @@
+import type { ASTNode } from './ast'
+import {
+  DefinitionEnvironment,
+  canonicalExpression,
+  openDefinition,
+  parseDefinition,
+  parseDefinitionTarget,
+  type DefinitionId,
+  type ScopePath,
+} from './definitionEnvironment'
+import { parseExpr } from './parser'
+
+export interface DefinitionScopeSnapshot {
+  readonly path: ScopePath
+  readonly parent: ScopePath | null
+  readonly definitions: readonly string[]
+}
+
+export interface OpeningPathEdge {
+  readonly target: ASTNode
+  readonly definitionId: DefinitionId
+  readonly body: ASTNode
+}
+
+export interface OpeningPathWitness {
+  readonly startTarget: ASTNode
+  readonly edges: readonly OpeningPathEdge[]
+  readonly finalBody: ASTNode
+}
+
+export type OpeningPathFailureCode =
+  | 'empty-path'
+  | 'start-target-mismatch'
+  | 'previous-body-not-form'
+  | 'adjacency-mismatch'
+  | 'opening-not-match'
+  | 'definition-id-mismatch'
+  | 'repeated-definition-id'
+  | 'body-mismatch'
+  | 'final-body-mismatch'
+
+export type OpeningPathVerification =
+  | { readonly accepted: true }
+  | { readonly accepted: false; readonly failure: OpeningPathFailureCode }
+
+function samePath(left: ScopePath, right: ScopePath): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index])
+}
+
+function comparePath(left: ScopePath, right: ScopePath): number {
+  const length = Math.min(left.length, right.length)
+  for (let index = 0; index < length; index++) {
+    if (left[index] !== right[index]) return left[index] - right[index]
+  }
+  return left.length - right.length
+}
+
+function assertPath(path: ScopePath, label: string): void {
+  for (const value of path) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error(`${label} must contain only non-negative integers`)
+    }
+  }
+}
+
+/** Build exactly the explicit lexical snapshot used by portable proof artifacts. */
+export function buildDefinitionEnvironments(
+  scopes: readonly DefinitionScopeSnapshot[]
+): Map<string, DefinitionEnvironment> {
+  if (scopes.length === 0) throw new Error('explicit root scope is required')
+
+  const sorted = [...scopes].sort(
+    (left, right) => left.path.length - right.path.length || comparePath(left.path, right.path)
+  )
+  if (JSON.stringify(sorted) !== JSON.stringify(scopes)) {
+    throw new Error('definition scopes must use canonical order')
+  }
+
+  const result = new Map<string, DefinitionEnvironment>()
+  for (const [index, scope] of scopes.entries()) {
+    assertPath(scope.path, 'scope.path')
+    if (scope.parent !== null) assertPath(scope.parent, 'scope.parent')
+    const key = JSON.stringify(scope.path)
+    if (result.has(key)) throw new Error('duplicate definition scope path')
+
+    let environment: DefinitionEnvironment
+    if (scope.parent === null) {
+      if (index !== 0 || scope.path.length !== 0) throw new Error('root scope must be first')
+      environment = new DefinitionEnvironment()
+    } else {
+      if (scope.path.length === 0 || !samePath(scope.path.slice(0, -1), scope.parent)) {
+        throw new Error('scope path must extend parent by one index')
+      }
+      const parent = result.get(JSON.stringify(scope.parent))
+      if (parent === undefined) throw new Error('parent scope must precede child')
+      environment = parent.child(scope.path[scope.path.length - 1])
+    }
+
+    result.set(key, environment)
+    for (const source of scope.definitions) environment.register(parseDefinition(source))
+  }
+
+  if (!result.has('[]')) throw new Error('explicit root scope is required')
+  return result
+}
+
+export function environmentAt(
+  scopes: readonly DefinitionScopeSnapshot[],
+  lookupScope: ScopePath
+): DefinitionEnvironment {
+  assertPath(lookupScope, 'lookupScope')
+  const environment = buildDefinitionEnvironments(scopes).get(JSON.stringify(lookupScope))
+  if (environment === undefined) throw new Error('lookupScope is not serialized')
+  return environment
+}
+
+function isForm(node: ASTNode): boolean {
+  return node.type !== 'Definition' && node.type !== 'Equality' && node.type !== 'Inequality'
+}
+
+function structurallySame(left: ASTNode, right: ASTNode): boolean {
+  return canonicalExpression(left) === canonicalExpression(right)
+}
+
+function sameDefinitionId(left: DefinitionId, right: DefinitionId): boolean {
+  return samePath(left.scopePath, right.scopePath) && left.ordinal === right.ordinal
+}
+
+function definitionIdKey(value: DefinitionId): string {
+  return `${JSON.stringify(value.scopePath)}:${value.ordinal}`
+}
+
+/** Replay exactly the serialized finite operational certificate; never auto-continue. */
+export function verifyDefinitionOpeningPath(
+  witness: OpeningPathWitness,
+  environment: DefinitionEnvironment
+): OpeningPathVerification {
+  if (witness.edges.length === 0) return { accepted: false, failure: 'empty-path' }
+  if (!structurallySame(witness.startTarget, witness.edges[0].target)) {
+    return { accepted: false, failure: 'start-target-mismatch' }
+  }
+
+  const seen = new Set<string>()
+  let replayBody: ASTNode | null = null
+
+  for (const [index, edge] of witness.edges.entries()) {
+    if (index > 0) {
+      if (replayBody === null || !isForm(replayBody)) {
+        return { accepted: false, failure: 'previous-body-not-form' }
+      }
+      if (!structurallySame(replayBody, edge.target)) {
+        return { accepted: false, failure: 'adjacency-mismatch' }
+      }
+    }
+
+    const opening = openDefinition(edge.target, environment)
+    if (opening.kind !== 'match' || opening.definitionId === undefined || opening.body === undefined) {
+      return { accepted: false, failure: 'opening-not-match' }
+    }
+    if (!sameDefinitionId(opening.definitionId, edge.definitionId)) {
+      return { accepted: false, failure: 'definition-id-mismatch' }
+    }
+
+    const idKey = definitionIdKey(opening.definitionId)
+    if (seen.has(idKey)) return { accepted: false, failure: 'repeated-definition-id' }
+    seen.add(idKey)
+
+    if (!structurallySame(opening.body, edge.body)) {
+      return { accepted: false, failure: 'body-mismatch' }
+    }
+    replayBody = opening.body
+  }
+
+  if (replayBody === null || !structurallySame(replayBody, witness.finalBody)) {
+    return { accepted: false, failure: 'final-body-mismatch' }
+  }
+  return { accepted: true }
+}
+
+export function parseCanonicalExpression(source: string, label: string): ASTNode {
+  const expression = parseExpr(source)
+  if (canonicalExpression(expression) !== source) {
+    throw new Error(`${label} must use canonical expression transport`)
+  }
+  return expression
+}
+
+export function parseOpeningTarget(source: string): ASTNode {
+  return parseDefinitionTarget(source)
+}
+
+export function isOpeningPathForm(node: ASTNode): boolean {
+  return isForm(node)
+}

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -176,7 +176,9 @@ export class Parser {
 
     if (this.check('DEFINE')) {
       this.advance()
-      const right = this.parseTerm()
+      // `:` is the weakest canonical infix operator and is right-associative:
+      // `a : b = c` => Definition(a, Equality(b,c)); `a : b : c` => a : (b : c).
+      const right = this.parseExpr()
       return {
         type: 'Definition',
         name: left,

--- a/src/core/proofReplayV04.ts
+++ b/src/core/proofReplayV04.ts
@@ -1,0 +1,333 @@
+import type { ASTNode } from './ast'
+import {
+  canonicalExpression,
+  type DefinitionId,
+  type ScopePath,
+} from './definitionEnvironment'
+import {
+  environmentAt,
+  parseCanonicalExpression,
+  parseOpeningTarget,
+  verifyDefinitionOpeningPath,
+  type DefinitionScopeSnapshot,
+  type OpeningPathEdge,
+} from './definitionOpeningPath'
+import {
+  MTS_PROOF_CONTRACT_VERSION_V03,
+  MTS_PROOF_SCHEMA_V03,
+  checkJudgmentV03,
+  parseProofObjectV03,
+  type MtsProofJudgmentV03,
+} from './proofReplayV03'
+
+export const MTS_PROOF_SCHEMA_V04 = 'mts-proof/v0.4' as const
+export const MTS_PROOF_CONTRACT_VERSION_V04 = 'mts-contract/v0.4' as const
+
+export interface DefinitionOpeningPathJudgmentV04 {
+  readonly relation: 'DefinitionOpeningPath'
+  readonly scopes: readonly DefinitionScopeSnapshot[]
+  readonly lookupScope: ScopePath
+  readonly startTarget: ASTNode
+  readonly edges: readonly OpeningPathEdge[]
+  readonly finalBody: ASTNode
+}
+
+export type MtsProofJudgmentV04 = MtsProofJudgmentV03 | DefinitionOpeningPathJudgmentV04
+
+export interface MtsProofObjectV04 {
+  readonly proofVersion: typeof MTS_PROOF_SCHEMA_V04
+  readonly contractVersion: typeof MTS_PROOF_CONTRACT_VERSION_V04
+  readonly judgments: readonly MtsProofJudgmentV04[]
+}
+
+export class ProofObjectV04ValidationError extends Error {
+  readonly path: string
+
+  constructor(path: string, message: string) {
+    super(`${path}: ${message}`)
+    this.name = 'ProofObjectV04ValidationError'
+    this.path = path
+  }
+}
+
+type UnknownRecord = Record<string, unknown>
+
+function fail(path: string, message: string): never {
+  throw new ProofObjectV04ValidationError(path, message)
+}
+
+function record(value: unknown, path: string): UnknownRecord {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    fail(path, 'expected object')
+  }
+  return value as UnknownRecord
+}
+
+function exactKeys(source: UnknownRecord, expected: readonly string[], path: string): void {
+  const actual = Object.keys(source).sort()
+  const wanted = [...expected].sort()
+  if (JSON.stringify(actual) !== JSON.stringify(wanted)) {
+    fail(path, `expected exactly fields ${wanted.join(', ')}`)
+  }
+}
+
+function stringValue(value: unknown, path: string): string {
+  if (typeof value !== 'string') fail(path, 'expected string')
+  return value
+}
+
+function nonNegativeInt(value: unknown, path: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    fail(path, 'expected non-negative integer')
+  }
+  return value
+}
+
+function scopePath(value: unknown, path: string): ScopePath {
+  if (!Array.isArray(value)) fail(path, 'expected integer path array')
+  return value.map((part, index) => nonNegativeInt(part, `${path}[${index}]`))
+}
+
+function definitionId(value: unknown, path: string): DefinitionId {
+  const source = record(value, path)
+  exactKeys(source, ['scopePath', 'ordinal'], path)
+  return {
+    scopePath: scopePath(source.scopePath, `${path}.scopePath`),
+    ordinal: nonNegativeInt(source.ordinal, `${path}.ordinal`),
+  }
+}
+
+function scopes(value: unknown, path: string): readonly DefinitionScopeSnapshot[] {
+  if (!Array.isArray(value)) fail(path, 'expected lexical scopes array')
+  const result = value.map((entry, index) => {
+    const itemPath = `${path}[${index}]`
+    const source = record(entry, itemPath)
+    exactKeys(source, ['path', 'parent', 'definitions'], itemPath)
+    if (!Array.isArray(source.definitions)) fail(`${itemPath}.definitions`, 'expected string array')
+    const definitions = source.definitions.map((item, definitionIndex) =>
+      stringValue(item, `${itemPath}.definitions[${definitionIndex}]`)
+    )
+    return {
+      path: scopePath(source.path, `${itemPath}.path`),
+      parent: source.parent === null ? null : scopePath(source.parent, `${itemPath}.parent`),
+      definitions,
+    }
+  })
+  // environmentAt performs canonical ordering, parent and duplicate validation.
+  environmentAt(result, result[0]?.path ?? [])
+  return result
+}
+
+function openingPathJudgment(value: unknown, path: string): DefinitionOpeningPathJudgmentV04 {
+  const source = record(value, path)
+  exactKeys(source, ['relation', 'scopes', 'lookupScope', 'startTarget', 'edges', 'finalBody'], path)
+  if (source.relation !== 'DefinitionOpeningPath') fail(`${path}.relation`, 'invalid relation')
+
+  const parsedScopes = scopes(source.scopes, `${path}.scopes`)
+  const lookupScope = scopePath(source.lookupScope, `${path}.lookupScope`)
+  environmentAt(parsedScopes, lookupScope)
+
+  if (!Array.isArray(source.edges) || source.edges.length === 0) {
+    fail(`${path}.edges`, 'expected non-empty edge array')
+  }
+  const edges = source.edges.map((entry, index): OpeningPathEdge => {
+    const itemPath = `${path}.edges[${index}]`
+    const edge = record(entry, itemPath)
+    exactKeys(edge, ['target', 'definitionId', 'body'], itemPath)
+    return {
+      target: parseOpeningTarget(stringValue(edge.target, `${itemPath}.target`)),
+      definitionId: definitionId(edge.definitionId, `${itemPath}.definitionId`),
+      body: parseCanonicalExpression(
+        stringValue(edge.body, `${itemPath}.body`),
+        `${itemPath}.body`
+      ),
+    }
+  })
+
+  return {
+    relation: 'DefinitionOpeningPath',
+    scopes: parsedScopes,
+    lookupScope,
+    startTarget: parseOpeningTarget(stringValue(source.startTarget, `${path}.startTarget`)),
+    edges,
+    finalBody: parseCanonicalExpression(
+      stringValue(source.finalBody, `${path}.finalBody`),
+      `${path}.finalBody`
+    ),
+  }
+}
+
+function baseJudgment(value: unknown, path: string): MtsProofJudgmentV03 {
+  try {
+    const proof = parseProofObjectV03({
+      proofVersion: MTS_PROOF_SCHEMA_V03,
+      contractVersion: MTS_PROOF_CONTRACT_VERSION_V03,
+      judgments: [value],
+    })
+    return proof.judgments[0]
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : 'invalid base judgment'
+    fail(path, message)
+  }
+}
+
+function judgment(value: unknown, path: string): MtsProofJudgmentV04 {
+  const source = record(value, path)
+  return source.relation === 'DefinitionOpeningPath'
+    ? openingPathJudgment(value, path)
+    : baseJudgment(value, path)
+}
+
+export function parseProofObjectV04(value: unknown): MtsProofObjectV04 {
+  const source = record(value, '$')
+  exactKeys(source, ['proofVersion', 'contractVersion', 'judgments'], '$')
+  if (source.proofVersion !== MTS_PROOF_SCHEMA_V04) {
+    fail('$.proofVersion', `expected ${MTS_PROOF_SCHEMA_V04}`)
+  }
+  if (source.contractVersion !== MTS_PROOF_CONTRACT_VERSION_V04) {
+    fail('$.contractVersion', `expected ${MTS_PROOF_CONTRACT_VERSION_V04}`)
+  }
+  if (!Array.isArray(source.judgments)) fail('$.judgments', 'expected array')
+  return {
+    proofVersion: MTS_PROOF_SCHEMA_V04,
+    contractVersion: MTS_PROOF_CONTRACT_VERSION_V04,
+    judgments: source.judgments.map((item, index) => judgment(item, `$.judgments[${index}]`)),
+  }
+}
+
+export function parseProofJsonV04(source: string): MtsProofObjectV04 {
+  try {
+    return parseProofObjectV04(JSON.parse(source) as unknown)
+  } catch (cause) {
+    if (cause instanceof ProofObjectV04ValidationError) throw cause
+    const message = cause instanceof Error ? cause.message : 'invalid JSON'
+    fail('$', `invalid JSON: ${message}`)
+  }
+}
+
+export function checkJudgmentV04(value: MtsProofJudgmentV04): boolean {
+  if (value.relation !== 'DefinitionOpeningPath') return checkJudgmentV03(value)
+  try {
+    const environment = environmentAt(value.scopes, value.lookupScope)
+    return verifyDefinitionOpeningPath(
+      {
+        startTarget: value.startTarget,
+        edges: value.edges,
+        finalBody: value.finalBody,
+      },
+      environment
+    ).accepted
+  } catch {
+    return false
+  }
+}
+
+export function checkProofV04(proof: MtsProofObjectV04): boolean {
+  if (
+    proof.proofVersion !== MTS_PROOF_SCHEMA_V04 ||
+    proof.contractVersion !== MTS_PROOF_CONTRACT_VERSION_V04
+  ) {
+    return false
+  }
+  return proof.judgments.every(checkJudgmentV04)
+}
+
+export function checkProofV04Data(value: unknown): boolean {
+  try {
+    return checkProofV04(parseProofObjectV04(value))
+  } catch {
+    return false
+  }
+}
+
+function contextToData(value: { readonly start: number; readonly end: number; readonly parent?: unknown }): unknown {
+  return {
+    start: value.start,
+    end: value.end,
+    parent:
+      value.parent === undefined
+        ? null
+        : contextToData(value.parent as { readonly start: number; readonly end: number; readonly parent?: unknown }),
+  }
+}
+
+function scopeToData(value: { readonly path: ScopePath; readonly parent: ScopePath | null; readonly definitions: readonly string[] }): unknown {
+  return {
+    path: [...value.path],
+    parent: value.parent === null ? null : [...value.parent],
+    definitions: [...value.definitions],
+  }
+}
+
+function baseJudgmentToData(value: MtsProofJudgmentV03): unknown {
+  if (value.relation === 'ContextuallySatisfies') {
+    return {
+      relation: value.relation,
+      expression: value.expression,
+      context: contextToData(value.context),
+      symbols: value.symbols.map(([name, link]) => [name, link]),
+      memory: value.memory.map(item => ({ ...item })),
+      expected: {
+        substitutions: value.expected.substitutions.map(item => ({ path: [...item.path], link: item.link })),
+        aliases: value.expected.aliases.map(item => ({ path: [...item.path], targetPath: [...item.targetPath] })),
+      },
+    }
+  }
+  if (value.relation === 'Opens') {
+    return {
+      relation: value.relation,
+      scopes: value.scopes.map(scopeToData),
+      lookupScope: [...value.lookupScope],
+      target: value.target,
+      expected: {
+        definitionId: {
+          scopePath: [...value.expected.definitionId.scopePath],
+          ordinal: value.expected.definitionId.ordinal,
+        },
+        body: value.expected.body,
+      },
+    }
+  }
+  if (value.relation === 'NoVisibleDefinition' || value.relation === 'DefinitionConflict') {
+    return {
+      relation: value.relation,
+      scopes: value.scopes.map(scopeToData),
+      lookupScope: [...value.lookupScope],
+      target: value.target,
+    }
+  }
+  return { relation: value.relation, target: value.target }
+}
+
+function openingPathToData(value: DefinitionOpeningPathJudgmentV04): unknown {
+  return {
+    relation: value.relation,
+    scopes: value.scopes.map(scopeToData),
+    lookupScope: [...value.lookupScope],
+    startTarget: canonicalExpression(value.startTarget),
+    edges: value.edges.map(edge => ({
+      target: canonicalExpression(edge.target),
+      definitionId: {
+        scopePath: [...edge.definitionId.scopePath],
+        ordinal: edge.definitionId.ordinal,
+      },
+      body: canonicalExpression(edge.body),
+    })),
+    finalBody: canonicalExpression(value.finalBody),
+  }
+}
+
+export function proofObjectV04ToData(proof: MtsProofObjectV04): unknown {
+  if (!checkProofV04(proof)) throw new Error('cannot serialize invalid mts-proof/v0.4')
+  return {
+    proofVersion: proof.proofVersion,
+    contractVersion: proof.contractVersion,
+    judgments: proof.judgments.map(item =>
+      item.relation === 'DefinitionOpeningPath' ? openingPathToData(item) : baseJudgmentToData(item)
+    ),
+  }
+}
+
+export function canonicalProofV04Json(proof: MtsProofObjectV04): string {
+  return JSON.stringify(proofObjectV04ToData(proof))
+}

--- a/src/core/proofReplayVersioned.ts
+++ b/src/core/proofReplayVersioned.ts
@@ -10,10 +10,19 @@ import {
   parseProofObjectV03,
   type MtsProofObjectV03,
 } from './proofReplayV03'
+import {
+  MTS_PROOF_SCHEMA_V04,
+  checkProofV04,
+  parseProofObjectV04,
+  type MtsProofObjectV04,
+} from './proofReplayV04'
 
-export type VersionedProofObject = MtsProofObjectV02 | MtsProofObjectV03
+export type VersionedProofObject = MtsProofObjectV02 | MtsProofObjectV03 | MtsProofObjectV04
 
-export type ProofReplayVersion = typeof MTS_PROOF_SCHEMA | typeof MTS_PROOF_SCHEMA_V03
+export type ProofReplayVersion =
+  | typeof MTS_PROOF_SCHEMA
+  | typeof MTS_PROOF_SCHEMA_V03
+  | typeof MTS_PROOF_SCHEMA_V04
 
 function objectRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -26,6 +35,7 @@ export function detectProofVersion(value: unknown): ProofReplayVersion | null {
   if (source === null) return null
   if (source.schema === MTS_PROOF_SCHEMA) return MTS_PROOF_SCHEMA
   if (source.proofVersion === MTS_PROOF_SCHEMA_V03) return MTS_PROOF_SCHEMA_V03
+  if (source.proofVersion === MTS_PROOF_SCHEMA_V04) return MTS_PROOF_SCHEMA_V04
   return null
 }
 
@@ -33,13 +43,16 @@ export function parseVersionedProofObject(value: unknown): VersionedProofObject 
   const version = detectProofVersion(value)
   if (version === MTS_PROOF_SCHEMA) return parseProofObject(value)
   if (version === MTS_PROOF_SCHEMA_V03) return parseProofObjectV03(value)
+  if (version === MTS_PROOF_SCHEMA_V04) return parseProofObjectV04(value)
   throw new Error('unsupported MTS proof artifact version')
 }
 
 export function checkVersionedProof(value: unknown): boolean {
   try {
     const proof = parseVersionedProofObject(value)
-    return 'schema' in proof ? checkProof(proof) : proof.judgments.every(checkJudgmentV03)
+    if ('schema' in proof) return checkProof(proof)
+    if (proof.proofVersion === MTS_PROOF_SCHEMA_V04) return checkProofV04(proof)
+    return proof.judgments.every(checkJudgmentV03)
   } catch {
     return false
   }

--- a/tests/unit/definitionOpeningPath.test.ts
+++ b/tests/unit/definitionOpeningPath.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  environmentAt,
+  parseCanonicalExpression,
+  parseOpeningTarget,
+  verifyDefinitionOpeningPath,
+  type DefinitionScopeSnapshot,
+  type OpeningPathEdge,
+} from '../../src/core/definitionOpeningPath'
+
+function scopes(definitions: readonly string[]): DefinitionScopeSnapshot[] {
+  return [{ path: [], parent: null, definitions }]
+}
+
+function edge(target: string, ordinal: number, body: string): OpeningPathEdge {
+  return {
+    target: parseOpeningTarget(target),
+    definitionId: { scopePath: [], ordinal },
+    body: parseCanonicalExpression(body, 'edge.body'),
+  }
+}
+
+function verify(
+  definitions: readonly string[],
+  startTarget: string,
+  edges: readonly OpeningPathEdge[],
+  finalBody: string
+) {
+  const snapshot = scopes(definitions)
+  return verifyDefinitionOpeningPath(
+    {
+      startTarget: parseOpeningTarget(startTarget),
+      edges,
+      finalBody: parseCanonicalExpression(finalBody, 'finalBody'),
+    },
+    environmentAt(snapshot, [])
+  )
+}
+
+describe('DefinitionOpeningPath canonical verifier', () => {
+  it('accepts one and two exact opening edges', () => {
+    expect(verify(['a : b'], 'a', [edge('a', 0, 'b')], 'b')).toEqual({ accepted: true })
+    expect(
+      verify(['a : b', 'b : c'], 'a', [edge('a', 0, 'b'), edge('b', 1, 'c')], 'c')
+    ).toEqual({ accepted: true })
+  })
+
+  it('accepts the finite canonical self-cycle witness', () => {
+    expect(verify(['a : a'], 'a', [edge('a', 0, 'a')], 'a')).toEqual({ accepted: true })
+  })
+
+  it('accepts the finite canonical mutual-cycle witness', () => {
+    expect(
+      verify(['a : b', 'b : a'], 'a', [edge('a', 0, 'b'), edge('b', 1, 'a')], 'a')
+    ).toEqual({ accepted: true })
+  })
+
+  it('rejects a repeated DefinitionId instead of looping', () => {
+    const result = verify(
+      ['a : b', 'b : a'],
+      'a',
+      [edge('a', 0, 'b'), edge('b', 1, 'a'), edge('a', 0, 'b')],
+      'b'
+    )
+    expect(result).toEqual({ accepted: false, failure: 'repeated-definition-id' })
+  })
+
+  it('allows a non-Form final body but cannot continue through it', () => {
+    expect(verify(['a : b = c'], 'a', [edge('a', 0, 'b = c')], 'b = c')).toEqual({
+      accepted: true,
+    })
+
+    const result = verify(
+      ['a : b = c', 'x : y'],
+      'a',
+      [edge('a', 0, 'b = c'), edge('x', 1, 'y')],
+      'y'
+    )
+    expect(result).toEqual({ accepted: false, failure: 'previous-body-not-form' })
+  })
+
+  it('does not confuse non-addressable Form with non-Form', () => {
+    const result = verify(
+      ['a : {◁ = x}'],
+      'a',
+      [
+        edge('a', 0, '{◁ = x}'),
+        {
+          target: parseOpeningTarget('{ ◁ = x }'),
+          definitionId: { scopePath: [], ordinal: 1 },
+          body: parseCanonicalExpression('z', 'edge.body'),
+        },
+      ],
+      'z'
+    )
+    expect(result).toEqual({ accepted: false, failure: 'opening-not-match' })
+  })
+
+  it('rejects forged DefinitionId, body and final body', () => {
+    expect(verify(['a : b'], 'a', [edge('a', 9, 'b')], 'b')).toEqual({
+      accepted: false,
+      failure: 'definition-id-mismatch',
+    })
+    expect(verify(['a : b'], 'a', [edge('a', 0, 'c')], 'c')).toEqual({
+      accepted: false,
+      failure: 'body-mismatch',
+    })
+    expect(verify(['a : b'], 'a', [edge('a', 0, 'b')], 'c')).toEqual({
+      accepted: false,
+      failure: 'final-body-mismatch',
+    })
+  })
+})

--- a/tests/unit/parser.test.ts
+++ b/tests/unit/parser.test.ts
@@ -1,4 +1,4 @@
-/** Unit tests for the single canonical МТС v0.2 parser. */
+/** Unit tests for the single canonical МТС parser. */
 
 import { describe, expect, it } from 'vitest'
 import { LexerError } from '../../src/core/lexer'
@@ -31,6 +31,18 @@ describe('Parser', () => {
     expect(toMtsSource(parseExpr('a = b'))).toBe('a = b')
     expect(toMtsSource(parseExpr('a != b'))).toBe('a != b')
     expect(toMtsSource(parseExpr('a : b'))).toBe('a : b')
+  })
+
+  it('keeps definition weaker than judgments and right-associative', () => {
+    const judgmentBody = parseExpr('a : b = c')
+    expect(judgmentBody.type).toBe('Definition')
+    expect((judgmentBody as { form: { type: string } }).form.type).toBe('Equality')
+    expect(toMtsSource(judgmentBody)).toBe('a : b = c')
+
+    const nested = parseExpr('a : b : c')
+    expect(nested.type).toBe('Definition')
+    expect((nested as { form: { type: string } }).form.type).toBe('Definition')
+    expect(toMtsSource(nested)).toBe('a : b : c')
   })
 
   it('parses context pronouns and ancestor ascent', () => {

--- a/tests/unit/proofReplayV04.test.ts
+++ b/tests/unit/proofReplayV04.test.ts
@@ -1,0 +1,241 @@
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  MTS_PROOF_CONTRACT_VERSION_V04,
+  MTS_PROOF_SCHEMA_V04,
+  canonicalProofV04Json,
+  checkProofV04,
+  parseProofObjectV04,
+  proofObjectV04ToData,
+} from '../../src/core/proofReplayV04'
+import { checkVersionedProof, detectProofVersion } from '../../src/core/proofReplayVersioned'
+
+const bundleRoot = resolve(process.cwd(), 'contracts/anum_docs-v0.5')
+const oldProofRoot = resolve(process.cwd(), 'contracts/anum_docs-v0.4')
+const provenancePath = resolve(bundleRoot, 'provenance.json')
+const contractPath = resolve(bundleRoot, 'mts-contract-v0.5.json')
+const conformancePath = resolve(bundleRoot, 'mts-conformance-v0.5.json')
+const proofPath = resolve(bundleRoot, 'mts-proof-v0.4.json')
+const proofConformancePath = resolve(bundleRoot, 'mts-proof-conformance-v0.4.json')
+const openingPath = resolve(bundleRoot, 'mts-opening-path-v0.4.json')
+const openingConformancePath = resolve(bundleRoot, 'mts-opening-path-conformance-v0.4.json')
+const directDeixisPath = resolve(bundleRoot, 'mts-direct-deixis-v0.5.json')
+const directDeixisConformancePath = resolve(bundleRoot, 'mts-direct-deixis-conformance-v0.5.json')
+const baseProofConformancePath = resolve(oldProofRoot, 'mts-proof-conformance-v0.3.json')
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8')) as unknown
+}
+
+function gitBlobSha(path: string): string {
+  const content = readFileSync(path)
+  return createHash('sha1')
+    .update(`blob ${content.byteLength}\0`)
+    .update(content)
+    .digest('hex')
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function patchDotted(source: Record<string, unknown>, patch: Record<string, unknown>) {
+  const result = clone(source)
+  for (const [dotted, replacement] of Object.entries(patch)) {
+    const parts = dotted.split('.')
+    let current = result
+    for (const part of parts.slice(0, -1)) current = current[part] as Record<string, unknown>
+    current[parts[parts.length - 1]] = clone(replacement)
+  }
+  return result
+}
+
+interface BaseProofCorpus {
+  validJudgments: Array<{ id: string; judgment: Record<string, unknown> }>
+  invalidArtifacts: Array<{ id: string; artifact: unknown }>
+  forgeries: Array<{
+    id: string
+    sourceJudgment?: string
+    patch?: Record<string, unknown>
+    replaceRelation?: string
+    remove?: string[]
+    judgment?: Record<string, unknown>
+    mustReject: boolean
+  }>
+}
+
+interface OpeningPathVector {
+  id: string
+  scopes: Array<{ path: number[]; parent: number[] | null; definitions: string[] }>
+  lookupScope: number[]
+  startTarget: string
+  edges: Array<{
+    target: string
+    definitionId: { scopePath: number[]; ordinal: number }
+    body: string
+  }>
+  finalBody: string
+}
+
+interface OpeningCorpus {
+  validPaths: OpeningPathVector[]
+  invalidPaths: OpeningPathVector[]
+}
+
+interface ProofV04Corpus {
+  invalidArtifacts: Array<{ id: string; artifact: unknown }>
+  mixedArtifact: {
+    baseJudgmentId: string
+    openingPathId: string
+    requiredBothOrdersAccepted: boolean
+    orderImpliesDependency: boolean
+  }
+}
+
+function baseCorpus(): BaseProofCorpus {
+  return readJson(baseProofConformancePath) as BaseProofCorpus
+}
+
+function openingCorpus(): OpeningCorpus {
+  return readJson(openingConformancePath) as OpeningCorpus
+}
+
+function proofCorpus(): ProofV04Corpus {
+  return readJson(proofConformancePath) as ProofV04Corpus
+}
+
+function validBaseById(): Map<string, Record<string, unknown>> {
+  return new Map(baseCorpus().validJudgments.map(item => [item.id, item.judgment]))
+}
+
+function forgedBase(vector: BaseProofCorpus['forgeries'][number]): Record<string, unknown> {
+  if (vector.judgment !== undefined) return clone(vector.judgment)
+  const source = validBaseById().get(vector.sourceJudgment ?? '')
+  if (source === undefined) throw new Error(`missing source judgment ${vector.sourceJudgment}`)
+  const result = vector.patch === undefined ? clone(source) : patchDotted(source, vector.patch)
+  if (vector.replaceRelation !== undefined) result.relation = vector.replaceRelation
+  for (const key of vector.remove ?? []) delete result[key]
+  return result
+}
+
+function openingJudgment(vector: OpeningPathVector): Record<string, unknown> {
+  return {
+    relation: 'DefinitionOpeningPath',
+    scopes: clone(vector.scopes),
+    lookupScope: clone(vector.lookupScope),
+    startTarget: vector.startTarget,
+    edges: clone(vector.edges),
+    finalBody: vector.finalBody,
+  }
+}
+
+function proofArtifact(judgments: readonly unknown[]) {
+  return {
+    proofVersion: MTS_PROOF_SCHEMA_V04,
+    contractVersion: MTS_PROOF_CONTRACT_VERSION_V04,
+    judgments,
+  }
+}
+
+describe('current anum_docs v0.5 exact pin', () => {
+  it('pins the compressed upstream release byte-exactly', () => {
+    const provenance = readJson(provenancePath) as {
+      sourceRepository: string
+      sourceCommit: string
+      artifacts: Record<string, { path: string; gitBlobSha: string }>
+    }
+    expect(provenance.sourceRepository).toBe('netkeep80/anum_docs')
+    expect(provenance.sourceCommit).toBe('5f985b2abc273efaa6c369781c5ad1e08c282d34')
+
+    const pinned: Array<[string, string]> = [
+      [contractPath, provenance.artifacts.contract.gitBlobSha],
+      [conformancePath, provenance.artifacts.conformance.gitBlobSha],
+      [proofPath, provenance.artifacts.proof.gitBlobSha],
+      [proofConformancePath, provenance.artifacts.proofConformance.gitBlobSha],
+      [openingPath, provenance.artifacts.openingPath.gitBlobSha],
+      [openingConformancePath, provenance.artifacts.openingPathConformance.gitBlobSha],
+      [directDeixisPath, provenance.artifacts.directDeixis.gitBlobSha],
+      [directDeixisConformancePath, provenance.artifacts.directDeixisConformance.gitBlobSha],
+    ]
+    for (const [path, expected] of pinned) expect(gitBlobSha(path)).toBe(expected)
+  })
+
+  it('pins exactly six trusted proof relations and no generic composition', () => {
+    const contract = readJson(contractPath) as {
+      schema: string
+      l5: { proofSchema: string; trustedRelations: string[]; genericCompositionAccepted: boolean }
+      downstream: { aproverProofRepinAllowed: boolean; consumerMayInventAdditionalCompositionRules: boolean }
+    }
+    expect(contract.schema).toBe('mts-contract/v0.5')
+    expect(contract.l5.proofSchema).toBe(MTS_PROOF_SCHEMA_V04)
+    expect(contract.l5.trustedRelations).toEqual([
+      'ContextuallySatisfies',
+      'Opens',
+      'NoVisibleDefinition',
+      'DefinitionConflict',
+      'NonAddressableDefinitionTarget',
+      'DefinitionOpeningPath',
+    ])
+    expect(contract.l5.genericCompositionAccepted).toBe(false)
+    expect(contract.downstream.aproverProofRepinAllowed).toBe(true)
+    expect(contract.downstream.consumerMayInventAdditionalCompositionRules).toBe(false)
+  })
+})
+
+describe('trusted mts-proof/v0.4 replay', () => {
+  it('lifts every accepted v0.3 base judgment through the same trusted replay', () => {
+    for (const vector of baseCorpus().validJudgments) {
+      expect(checkVersionedProof(proofArtifact([vector.judgment])), vector.id).toBe(true)
+    }
+  })
+
+  it('rejects every accepted v0.3 base forgery after lifting', () => {
+    for (const vector of baseCorpus().forgeries) {
+      expect(vector.mustReject).toBe(true)
+      expect(checkVersionedProof(proofArtifact([forgedBase(vector)])), vector.id).toBe(false)
+    }
+  })
+
+  it('accepts every upstream DefinitionOpeningPath vector', () => {
+    for (const vector of openingCorpus().validPaths) {
+      expect(checkVersionedProof(proofArtifact([openingJudgment(vector)])), vector.id).toBe(true)
+    }
+  })
+
+  it('rejects every upstream invalid DefinitionOpeningPath vector', () => {
+    for (const vector of openingCorpus().invalidPaths) {
+      expect(checkVersionedProof(proofArtifact([openingJudgment(vector)])), vector.id).toBe(false)
+    }
+  })
+
+  it('rejects every v0.4 transport forgery', () => {
+    for (const vector of proofCorpus().invalidArtifacts) {
+      expect(checkVersionedProof(vector.artifact), vector.id).toBe(false)
+    }
+  })
+
+  it('does not give judgment order dependency semantics', () => {
+    const mixed = proofCorpus().mixedArtifact
+    const base = validBaseById().get(mixed.baseJudgmentId)
+    const opening = openingCorpus().validPaths.find(item => item.id === mixed.openingPathId)
+    if (base === undefined || opening === undefined) throw new Error('missing mixed corpus vector')
+    expect(checkVersionedProof(proofArtifact([base, openingJudgment(opening)]))).toBe(true)
+    expect(checkVersionedProof(proofArtifact([openingJudgment(opening), base]))).toBe(true)
+    expect(mixed.requiredBothOrdersAccepted).toBe(true)
+    expect(mixed.orderImpliesDependency).toBe(false)
+  })
+
+  it('round-trips canonical portable v0.4 data through fresh replay', () => {
+    const opening = openingCorpus().validPaths.find(item => item.id === 'two-edge')
+    if (opening === undefined) throw new Error('missing two-edge vector')
+    const proof = parseProofObjectV04(proofArtifact([openingJudgment(opening)]))
+    expect(checkProofV04(proof)).toBe(true)
+    const data = proofObjectV04ToData(proof)
+    expect(checkVersionedProof(data)).toBe(true)
+    expect(JSON.parse(canonicalProofV04Json(proof))).toEqual(data)
+    expect(detectProofVersion(data)).toBe(MTS_PROOF_SCHEMA_V04)
+  })
+})


### PR DESCRIPTION
Первый чистый migration slice по #144/#139, заменяющий устаревший draft #145.

Upstream pin: `netkeep80/anum_docs@5f985b2abc273efaa6c369781c5ad1e08c282d34` — текущий compressed accepted surface после semantic reset #343.

Что сделано:
- byte-exact pin `mts-contract/v0.5`, `mts-conformance/v0.5`, `mts-proof/v0.4`, proof conformance, opening-path contract/conformance и direct-deixis contract/conformance;
- provenance фиксирует upstream commit и Git blob SHA каждого артефакта;
- canonical `DefinitionOpeningPath` verifier: exact lexical snapshot, exact DefinitionId, finite cycle canonicality, no auto-continue, no memory/context/interpreter effects;
- strict `mts-proof/v0.4` transport/replay: первые пять relations делегируются существующему trusted v0.3 replay, шестая — canonical opening-path verifier;
- versioned replay распознаёт v0.4;
- parser исправлен для upstream grammar: `:` слабее judgment и правоассоциативен (`a : b = c`, `a : b : c`);
- тесты напрямую исполняют current upstream valid/invalid opening-path corpus, v0.4 transport forgeries, lifted base judgments/forgeries и mixed-order invariant.

Новых inference rules нет: generic composition, equality/equivalence/normalization bridge, hidden interpreter identity и search trust остаются запрещены.

Следующий migration slice сразу после merge удалит старые v0.2/v0.3 proof modes/vendor bundles и переведёт search/UI на current v0.4, чтобы старые версии не сохранялись ради compatibility.

Supersedes #145.